### PR TITLE
Prevent endless loop if request extracting takes more than 30 seconds

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/DataExtractorService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/DataExtractorService.java
@@ -1064,8 +1064,8 @@ public class DataExtractorService extends AbstractService implements IDataExtrac
      * in the background.
      */
     public void execute(NodeCommunication nodeCommunication, RemoteNodeStatus status) {
-        long ts = System.currentTimeMillis();
         List<ExtractRequest> requests = getExtractRequestsForNode(nodeCommunication.getNodeId());
+        long ts = System.currentTimeMillis();
         /*
          * Process extract requests until it has taken longer than 30 seconds, and then
          * allow the process to return so progress status can be seen.


### PR DESCRIPTION
If `getExtractRequestsForNode` is taking longer than 30 seconds (if you have a lot of reloads queued up) you will get an endless loop here, because you will never get into the `for` loop

happens if `initial.load.use.extract.job.enabled=true`

leads to a lot of the following log outputs: (which never process)
```
Batch 1-2820 is not ready for delivery. It is currently scheduled for extraction
```