### PR TITLE
NVARCHAR limit on SQL Server is a size of 4000

### DIFF
--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/mssql/MsSqlDdlReader.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/mssql/MsSqlDdlReader.java
@@ -153,7 +153,7 @@ public class MsSqlDdlReader extends AbstractJdbcDdlReader {
             return Types.VARCHAR;
         } else if (typeName != null && typeName.toUpperCase().contains("VARCHAR") && size > 8000) {
             return Types.LONGVARCHAR;
-        } else if (typeName != null && typeName.toUpperCase().contains("NVARCHAR") && size > 8000) {
+        } else if (typeName != null && typeName.toUpperCase().contains("NVARCHAR") && size > 4000) {
             return Types.LONGNVARCHAR;
         } else if (typeName != null && typeName.toUpperCase().equals("SQL_VARIANT")) {
             return Types.BINARY;


### PR DESCRIPTION
According to MSDN the `NVARCHAR` size limit is 4000 (because of double byte storage compared to "simple" `VARCHAR`) 

If its bigger you need to specify `(MAX)`

see: https://msdn.microsoft.com/library/ms186939(v=sql.120).aspx