### PR TITLE
Provide functionality to not require context table on sqlite for threadsafe data capture

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/common/ParameterConstants.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/common/ParameterConstants.java
@@ -290,8 +290,11 @@ final public class ParameterConstants {
     public final static String MSSQL_ROW_LEVEL_LOCKS_ONLY = "mssql.allow.only.row.level.locks.on.runtime.tables";
     
     public final static String MSSQL_USE_NTYPES_FOR_SYNC = "mssql.use.ntypes.for.sync";
+
     
     public final static String MSSQL_TRIGGER_EXECUTE_AS = "mssql.trigger.execute.as";
+    
+    public final static String SQLITE_TRIGGER_FUNCTION_TO_USE = "sqlite.trigger.function.to.use";
 
     public final static String EXTENSIONS_XML = "extensions.xml";
 

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/sql/JdbcSqlTransaction.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/sql/JdbcSqlTransaction.java
@@ -331,7 +331,7 @@ public class JdbcSqlTransaction implements ISqlTransaction {
         });
     }
 
-    protected <T> T executeCallback(IConnectionCallback<T> callback) {
+    public <T> T executeCallback(IConnectionCallback<T> callback) {
         try {
             return callback.execute(this.connection);
         } catch (SQLException ex) {


### PR DESCRIPTION
Uses the documented SQlite feature that you are able to override already defined functions with different output/behaviour (which is only visible to the current connection)

Recommended/tested settings:

```
sqlite.trigger.function.to.use=sqlite_version

db.init.sql=PRAGMA busy_timeout = 5000;
```

it's not required to use `jobs.synchronized.enable=true` anymore (if you don't care about `BUSY_TIMEOUT`)

uses the context table if no function name provided (so, no breaking change and opt-in) 

I think this is not working on android, because you need a `JdbcSqlTransaction`

You need to override an existing function, so you aren't required to provide a custom function implementation in the external applications. (which would fail the trigger if you wouldn't do that)

