### PR TITLE
0002468: Set push.thread.per.server.count to 1. It should not have been

### DIFF
--- a/symmetric-core/src/main/resources/symmetric-default.properties
+++ b/symmetric-core/src/main/resources/symmetric-default.properties
@@ -807,7 +807,7 @@ pull.lock.timeout.ms=7200000
 #
 # DatabaseOverridable: true
 # Tags: jobs
-push.thread.per.server.count=100
+push.thread.per.server.count=1
 
 # The amount of time a single push worker node_communication lock will timeout after.
 #


### PR DESCRIPTION
bumped up to 100 in 3.7.22
