### PR TITLE
Propagate varchar size on sqlite

### DIFF
--- a/symmetric-db/src/main/java/org/jumpmind/db/platform/sqlite/SqliteDdlBuilder.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/platform/sqlite/SqliteDdlBuilder.java
@@ -73,8 +73,8 @@ public class SqliteDdlBuilder extends AbstractDdlBuilder {
         databaseInfo.setDefaultSize(Types.BINARY, Integer.MAX_VALUE);
         databaseInfo.setDefaultSize(Types.VARBINARY, Integer.MAX_VALUE);
 
-        databaseInfo.setHasSize(Types.CHAR, false);
-        databaseInfo.setHasSize(Types.VARCHAR, false);
+        databaseInfo.setHasSize(Types.CHAR, true);
+        databaseInfo.setHasSize(Types.VARCHAR, true);
         databaseInfo.setHasSize(Types.BINARY, false);
         databaseInfo.setHasSize(Types.VARBINARY, false);
 


### PR DESCRIPTION
Some drivers (e.g. https://www.devart.com/dbx/sqlite/) require to have a size on the column type declaration to properly recognize the type.

Because a sqlite database doesn't care about the size, I think that it doesn't hurt to store this information to fix some compatibility issues with some drivers.

I know that this should propably be fixed in the drivers, but I think this could be also useful for other purposes. (e.g. validation of schema changes or truncation of values bases on that size to fix issues with insertions into central db)
