### PR TITLE
Allow rest sql querying via POST to fix parameter size limitations for GET

### DIFF
--- a/symmetric-server/src/main/java/org/jumpmind/symmetric/web/rest/RestService.java
+++ b/symmetric-server/src/main/java/org/jumpmind/symmetric/web/rest/RestService.java
@@ -305,7 +305,7 @@ public class RestService {
      * and can be used to diagnose state of the node
      */
     @ApiOperation(value = "Take a diagnostic snapshot for the single engine")
-    @RequestMapping(value = "engine/snapshot", method = RequestMethod.GET)
+    @RequestMapping(value = "engine/snapshot", method = {RequestMethod.GET, RequestMethod.POST})
     @ResponseStatus(HttpStatus.OK)
     @ResponseBody
     public final void getSnapshot(HttpServletResponse resp) {
@@ -321,7 +321,7 @@ public class RestService {
      * 
      */
     @ApiOperation(value = "Execute the specified SQL statement on the single engine")
-    @RequestMapping(value = "engine/querynode", method = RequestMethod.GET)
+    @RequestMapping(value = "engine/querynode", method = {RequestMethod.GET, RequestMethod.POST})
     @ResponseStatus(HttpStatus.OK)
     @ResponseBody
     public final QueryResults getQueryNode(@RequestParam(value = "query") String sql) {

--- a/symmetric-server/src/main/java/org/jumpmind/symmetric/web/rest/RestService.java
+++ b/symmetric-server/src/main/java/org/jumpmind/symmetric/web/rest/RestService.java
@@ -305,7 +305,7 @@ public class RestService {
      * and can be used to diagnose state of the node
      */
     @ApiOperation(value = "Take a diagnostic snapshot for the single engine")
-    @RequestMapping(value = "engine/snapshot", method = {RequestMethod.GET, RequestMethod.POST})
+    @RequestMapping(value = "engine/snapshot", method = RequestMethod.GET)
     @ResponseStatus(HttpStatus.OK)
     @ResponseBody
     public final void getSnapshot(HttpServletResponse resp) {
@@ -332,7 +332,7 @@ public class RestService {
      * Executes a select statement on the node and returns results.
      */
     @ApiOperation(value = "Execute the specified SQL statement for the specified engine")
-    @RequestMapping(value = "engine/{engine}/querynode", method = RequestMethod.GET)
+    @RequestMapping(value = "engine/{engine}/querynode", method = {RequestMethod.GET, RequestMethod.POST})
     @ResponseStatus(HttpStatus.OK)
     @ResponseBody
     public final QueryResults getQueryNode(@PathVariable("engine") String engineName,


### PR DESCRIPTION
The parameter size for GET is restricted to 8192 bytes. So I changed the rest api to additionally allow POST-Method for execution of bigger queries.
