### PR TITLE
mssql trigger: changed from cursor to dml

### DIFF
--- a/symmetric-client/src/main/java/org/jumpmind/symmetric/db/mssql/MsSqlSymmetricDialect.java
+++ b/symmetric-client/src/main/java/org/jumpmind/symmetric/db/mssql/MsSqlSymmetricDialect.java
@@ -369,7 +369,8 @@ public class MsSqlSymmetricDialect extends AbstractSymmetricDialect implements I
     
     @Override
     protected String getDbSpecificDataHasChangedCondition(Trigger trigger) {
-        return "@OldDataRow is null or @DataRow != @OldDataRow";
+    	/* gets filled/replaced by trigger template as it will compare by each column */
+        return "$(anyNonBlobColumnChanged)";
     }
 
 }

--- a/symmetric-client/src/main/java/org/jumpmind/symmetric/db/mssql/MsSqlTriggerTemplate.java
+++ b/symmetric-client/src/main/java/org/jumpmind/symmetric/db/mssql/MsSqlTriggerTemplate.java
@@ -182,7 +182,7 @@ public class MsSqlTriggerTemplate extends AbstractTriggerTemplate {
                 buildKeyVariablesDeclare(columns, "new"), ddl);
         
         ddl = FormatUtils.replace("anyNonBlobColumnChanged",
-        		buildNonLobColumnsAreNotEqualString(table, "inserted", "deleted"), ddl);
+        		buildNonLobColumnsAreNotEqualString(table, newTriggerValue, oldTriggerValue), ddl);
         
         ddl = FormatUtils.replace("nonBlobColumns", buildNonLobColumnsString(table), ddl);
         return ddl;
@@ -198,15 +198,15 @@ public class MsSqlTriggerTemplate extends AbstractTriggerTemplate {
     			continue;
     		}
     		if(builder.length() > 0){
-    			builder.append(" and ");
+    			builder.append(" or ");
     		}
     	
-    		builder.append(String.format("%s.\"%s\"=%s.\"%s\"", 
-    				table1Name, column.getName(), table2Name, column.getName()));
+    		builder.append(String.format("((%1$s.\"%2$s\" IS NOT NULL AND %3$s.\"%2$s\" IS NOT NULL AND %1$s.\"%2$s\"<>%3$s.\"%2$s\") or (%1$s.\"%2$s\" IS NULL AND %3$s.\"%2$s\" IS NOT NULL) or (%1$s.\"%2$s\" IS NOT NULL AND %3$s.\"%2$s\" IS NULL))", 
+    				table1Name, column.getName(), table2Name));
     		
     	}
     	
-    	return "not (" + builder.toString() + ")";
+    	return "(" + builder.toString() + ")";
     }
     
     private String buildNonLobColumnsString(Table table){


### PR DESCRIPTION
This is a bigger change, but it seems inevitable (to me).

I changed the MSSQL trigger to use DML via INSERT + SELECT instead of using a cursor. This has two reasons:
- I wanted to use a column value in my external_select statement, e.g.

```
$(curTriggerValue).$(curColumnPrefix)order_id

translated:

inserted.order_id
```

but I'm not able to get that value, because the cursor doesn't include the column values. Writing the select as 

```
select $(curTriggerValue).$(curColumnPrefix)order_id from $(curTriggerValue)

translated:

select inserted.order_id from inserted
```

even leads to returning multiple values or using just the first result (if you do a range insert/update/delete). 
I'm also not able to join via the pk, because this is also not included. 
- According to multiple sources, cursors are highly discouraged to use inside triggers. So this also has an impact on performance (should be faster).
