### PR TITLE
Increased size of EXTERNAL_DATA column to varchar(4000)

### DIFF
--- a/symmetric-core/src/main/resources/symmetric-schema.xml
+++ b/symmetric-core/src/main/resources/symmetric-schema.xml
@@ -81,7 +81,7 @@
         <column name="channel_id" type="VARCHAR" size="128"  description="The channel that this data belongs to, such as 'prices'" />
         <column name="transaction_id" type="VARCHAR" size="255"  description="An optional transaction identifier that links multiple data changes together as the same transaction." />
         <column name="source_node_id" type="VARCHAR" size="50"  description="If the data was inserted by a SymmetricDS data loader, then the id of the source node is record so that data is not re-routed back to it." />
-        <column name="external_data" type="VARCHAR" size="50"  description="A field that can be populated by a trigger that uses the EXTERNAL_SELECT" />
+        <column name="external_data" type="VARCHAR" size="4000"  description="A field that can be populated by a trigger that uses the EXTERNAL_SELECT" />
         <column name="node_list" type="VARCHAR" size="255"  description="A field that can be populated with a comma separated subset of node ids which will be the only nodes available to the router" />
         <column name="create_time" type="TIMESTAMP"  description="Timestamp when this entry was created." />
         <index name="idx_d_channel_id">


### PR DESCRIPTION
I increased the size of the EXTERNAL_DATA column to a bigger size, to allow storing of more informations in it.

The reason for this is that I want to store the target nodes comma separated inside this column (I know that there is the NODE_LIST column, but I can't fill this column inside the trigger.)

Additionally I use the Column Match Router with the expression `EXTERNAL_DATA=NULL OR EXTERNAL_DATA contains :NODE_ID`

The reason I don't want to use the Lookup Router is that in my scenario, there are a lot of different factors which define which nodes the data gets routed to. Which would require multiple different Lookup Routers with a lot of rows for some of them (>100.000).

If I create the correct routing inside EXTERNAL_SELECT, I can properly use the database indicies for reducing the rows in the lookup tables, the routing process is a lot simpler and faster because it doesn't require to load the lookup tables (for each routing process) and I can properly define the different factors via SQL queries, directly at the table trigger level and don't require separate viewes. 

I choosed VARCHAR(4000) to be able to define the routing to about 1000 different nodes, technically doesn't make a huge change storage/database wise and still can be indexed. (instead of LONGVARCHAR)
