### PR TITLE
Add configuration option to always right trim CHAR fields

### DIFF
--- a/symmetric-client/src/main/java/org/jumpmind/symmetric/ClientSymmetricEngine.java
+++ b/symmetric-client/src/main/java/org/jumpmind/symmetric/ClientSymmetricEngine.java
@@ -357,6 +357,7 @@ public class ClientSymmetricEngine extends AbstractSymmetricEngine {
         settings.setOverrideIsolationLevel(properties.getInt(ParameterConstants.JDBC_ISOLATION_LEVEL, -1));
         settings.setReadStringsAsBytes(properties.is(ParameterConstants.JDBC_READ_STRINGS_AS_BYTES, false));
         settings.setTreatBinaryAsLob(properties.is(ParameterConstants.TREAT_BINARY_AS_LOB_ENABLED, true));
+        settings.setRightTrimCharValues(properties.is(ParameterConstants.RIGHT_TRIM_CHAR_VALUES, false));
         LogSqlBuilder logSqlBuilder = new LogSqlBuilder();
         logSqlBuilder.setLogSlowSqlThresholdMillis(properties.getInt(ParameterConstants.LOG_SLOW_SQL_THRESHOLD_MILLIS, 20000));
         logSqlBuilder.setLogSqlParametersInline(properties.is(ParameterConstants.LOG_SQL_PARAMETERS_INLINE, true));

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/common/ParameterConstants.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/common/ParameterConstants.java
@@ -430,6 +430,8 @@ final public class ParameterConstants {
     
     public final static String TREAT_BINARY_AS_LOB_ENABLED = "treat.binary.as.lob.enabled";
     
+    public final static String RIGHT_TRIM_CHAR_VALUES = "right.trim.char.values";
+    
     public final static String NODE_LOAD_ONLY = "load.only";
     
     public final static String MYSQL_TINYINT_DDL_TO_BOOLEAN = "mysql.tinyint.ddl.to.boolean";

--- a/symmetric-core/src/main/resources/symmetric-default.properties
+++ b/symmetric-core/src/main/resources/symmetric-default.properties
@@ -2079,6 +2079,7 @@ node.offline.archive.dir=
 # Type: boolean
 monitor.events.capture.enabled=false
 
+
 # Determines if the *.DBF file headers should be validated when using the DBF Router
 #
 # DatabaseOverridable: true
@@ -2214,3 +2215,10 @@ log.conflict.resolution=false
 # Type: boolean
 # Tags: other
 treat.binary.as.lob.enabled=true
+
+# Whether char fields should be right trimmed
+#
+# DatabaseOverridable: true
+# Type: boolean
+# Tags: other
+right.trim.char.values=false

--- a/symmetric-db/src/main/java/org/jumpmind/db/platform/AbstractDatabasePlatform.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/platform/AbstractDatabasePlatform.java
@@ -402,7 +402,7 @@ public abstract class AbstractDatabasePlatform implements IDatabasePlatform {
                 String charValue = value.toString();
                 if ((StringUtils.isBlank(charValue) && getDdlBuilder().getDatabaseInfo().isBlankCharColumnSpacePadded())
                         || (StringUtils.isNotBlank(charValue) && getDdlBuilder().getDatabaseInfo().isNonBlankCharColumnSpacePadded())) {
-                    objectValue = StringUtils.rightPad(value.toString(), column.getSizeAsInt(), ' ');
+                    objectValue = StringUtils.rightPad(charValue, column.getSizeAsInt(), ' ');
                 }
             } else if (type == Types.BIGINT) {
                 objectValue = parseBigInteger(value);
@@ -433,6 +433,11 @@ public abstract class AbstractDatabasePlatform implements IDatabasePlatform {
         if (objectValue instanceof String) {
             String stringValue = cleanTextForTextBasedColumns((String) objectValue);
             int size = column.getSizeAsInt();
+            
+            if(settings.isRightTrimCharValues()){
+            	stringValue = StringUtils.stripEnd(stringValue, null);
+            }
+            
             if (fitToColumn && size > 0 && stringValue.length() > size) {
                 stringValue = stringValue.substring(0, size);
             }

--- a/symmetric-db/src/main/java/org/jumpmind/db/sql/SqlTemplateSettings.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/sql/SqlTemplateSettings.java
@@ -27,6 +27,7 @@ public class SqlTemplateSettings {
     protected int batchSize = 100;
     protected boolean readStringsAsBytes;
     protected boolean treatBinaryAsLob;
+    protected boolean rightTrimCharValues;
     protected int overrideIsolationLevel = -1;
     protected int resultSetType = java.sql.ResultSet.TYPE_FORWARD_ONLY;
     protected LogSqlBuilder logSqlBuilder;
@@ -96,6 +97,14 @@ public class SqlTemplateSettings {
 
     public void setResultSetType(int resultSetType) {
         this.resultSetType = resultSetType;
+    }
+    
+    public boolean isRightTrimCharValues() { 
+        return rightTrimCharValues; 
+    }
+
+    public void setRightTrimCharValues(boolean rightTrimCharValues) { 
+        this.rightTrimCharValues = rightTrimCharValues; 
     }
 
 }


### PR DESCRIPTION
This PR adds, that the already existing parameter `isCharColumnSpaceTrimmed` is used.

It also enables this parameter for Sqlite to trim char fields. 
If you have a MSSQL database with a CHAR(30) column in a table. If it syncs to a SQLite database it gets created as VARCHAR(30). Every data is padded with whitespaces. 
If you have a `=` compare on MSSQL Server it ignores the trailing spaces on SQLite it doesn't, so data is not found on mobile devices as it would on the central database.

Maybe it is better to make this a configurable options, let me know what you think, I'll add that if desired.
