### PR TITLE
Enable using of encrypted sqlite databases

### DIFF
--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/util/BasicDataSourceFactory.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/util/BasicDataSourceFactory.java
@@ -20,6 +20,7 @@
  */
 package org.jumpmind.db.util;
 
+import java.math.BigInteger;
 import java.sql.Driver;
 import java.sql.DriverManager;
 import java.util.ArrayList;
@@ -122,12 +123,24 @@ public class BasicDataSourceFactory {
             }
         }
         
-        String initSql = properties.get(BasicDataSourcePropertyConstants.DB_POOL_INIT_SQL, null);
-        if (StringUtils.isNotBlank(initSql)) {
-            List<String> initSqlList = new ArrayList<String>(1);
-            initSqlList.add(initSql);
-            dataSource.setConnectionInitSqls(initSqlList);
+        List<String> initSqlList = new ArrayList<String>(3);
+        
+        
+        if (dataSource.getDriverClassName().equals("org.sqlite.JDBC") && !password.isEmpty()) {
+            initSqlList.add(String.format("pragma hexkey = '%x'", new BigInteger(1, password.getBytes())));
+            initSqlList.add("select 1 from sqlite_master");
         }
+        
+        
+        String initSql = properties.get(BasicDataSourcePropertyConstants.DB_POOL_INIT_SQL, null);
+        if (StringUtils.isNotBlank(initSql)){
+        	initSqlList.add(initSql);
+        }
+        
+        if(!initSqlList.isEmpty()){
+        	dataSource.setConnectionInitSqls(initSqlList);
+        }
+        
         return dataSource;
 
     }


### PR DESCRIPTION
This PR adds support for encrypted SQLite databases.

It addes the `pragma hexkey` to the init sqls. 

Encryption is (currently) not working with the [xerial/sqlite-jdbc](https://github.com/xerial/sqlite-jdbc) driver. 

[But with custom/commercial builds.](https://www.sqlite.org/see/doc/trunk/www/readme.wiki)

Of course you could just add this statement to the init sqls, but you would loose the bonus of the encrypted password feature.
