### PR TITLE
0003312: Compare tablename case insensitiv on SQLite on trigger creation

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/db/sqlite/SqliteSymmetricDialect.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/db/sqlite/SqliteSymmetricDialect.java
@@ -99,7 +99,8 @@ public class SqliteSymmetricDialect extends AbstractSymmetricDialect {
 
     protected boolean doesTriggerExistOnPlatform(String catalogName, String schema, String tableName, String triggerName) {
         return platform.getSqlTemplate().queryForInt(
-                "select count(*) from sqlite_master where type='trigger' and name=? and tbl_name=?", triggerName, tableName) > 0;
+                "select count(*) from sqlite_master where type='trigger' and name=? and tbl_name=? COLLATE NOCASE", triggerName,
+                tableName) > 0;
     }
 
     public BinaryEncoding getBinaryEncoding() {


### PR DESCRIPTION
This PR changes the comparison if trigger exists on table to case insensitiv, otherwise this could lead to the following error (which gets ignored) if the tablename is quoted (somehow) 

```
[mobil-2] - TriggerRouterService - Cleaning up trigger hist row of 640 after fai
ling to create the associated trigger
[mobil-2] - TriggerRouterService - Failed to create triggers for GR_APPOINTMENT2
CUSTOMER
org.jumpmind.db.sql.SqlException: [SQLITE_ERROR] SQL error or missing database (
trigger SYM_ON_I_FOR_XXX_M2C_MBL already exists)
        at org.jumpmind.db.sql.AbstractSqlTemplate.translate(AbstractSqlTemplate
.java:288)
        at org.jumpmind.db.sql.AbstractSqlTemplate.translate(AbstractSqlTemplate
```
