### PR TITLE
Log message bug fix mongo -> redshift

### DIFF
--- a/symmetric-client/src/main/java/org/jumpmind/symmetric/ext/RedshiftBulkDataLoaderFactory.java
+++ b/symmetric-client/src/main/java/org/jumpmind/symmetric/ext/RedshiftBulkDataLoaderFactory.java
@@ -76,7 +76,7 @@ public class RedshiftBulkDataLoaderFactory implements IDataLoaderFactory, ISymme
                     maxRowsBeforeFlush, maxBytesBeforeFlush, bucket, accessKey, secretKey, appendToCopyCommand, s3Endpoint);
 
         } catch (Exception e) {
-            log.warn("Failed to create the mongo database writer.  Check to see if all of the required jars have been added");
+            log.warn("Failed to create the redshift database writer.  Check to see if all of the required jars have been added");
             if (e instanceof RuntimeException) {
                 throw (RuntimeException)e;
             } else {


### PR DESCRIPTION
Log messages reference mongo instead of redshift, a potential cause of confusion.  Presumably this was caused by not updating a copy and paste from the mongo DataLoaderFactory
