### PR TITLE
Prioritize custom extensions instead of undefinied order

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/ExtensionService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/ExtensionService.java
@@ -214,7 +214,13 @@ public class ExtensionService extends AbstractService implements IExtensionServi
     }
     
     public synchronized <T extends IExtensionPoint> T getExtensionPoint(Class<T> extensionClass) {
-        for (T extension : getExtensionPointList(extensionClass)) {
+        List<T> availableExtensions = getExtensionPointList(extensionClass);
+        for (T extension : availableExtensions) {
+            if(!(extension instanceof IBuiltInExtensionPoint)){
+            	return extension;
+            }
+        }
+        for (T extension : availableExtensions) {
             return extension;
         }
         return null;


### PR DESCRIPTION
`GetExtensionPointList` uses `Map.values()`. This leads to undefinied order of the extensions. 

We had the problem that our custom definied INodeIdCreator was not used. 

I changed the code to use any custom definied extensions (if any) and than falls back to the `IBuiltInExtensionPoint`
