### PR TITLE
Fix Slow performance of ConfigurationChangedDataRouter on trigger re-creation with many triggers

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/route/ConfigurationChangedDataRouter.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/route/ConfigurationChangedDataRouter.java
@@ -80,6 +80,9 @@ public class ConfigurationChangedDataRouter extends AbstractDataRouter implement
 
     final String CTX_KEY_REFRESH_EXTENSIONS_NEEDED = "RefreshExtensions."
             + ConfigurationChangedDataRouter.class.getSimpleName() + hashCode();
+    
+    final String CTX_KEY_FLUSHED_TRIGGER_ROUTERS = "FlushedTriggerRouters."
+            + ConfigurationChangedDataRouter.class.getSimpleName() + hashCode();
 
     public final static String KEY = "symconfig";
 
@@ -326,19 +329,27 @@ public class ConfigurationChangedDataRouter extends AbstractDataRouter implement
                 }
 
                 ITriggerRouterService triggerRouterService = engine.getTriggerRouterService();
+                
+                boolean refreshCache = false;
+                if (routingContext.get(CTX_KEY_FLUSHED_TRIGGER_ROUTERS) == null) {
+            	    triggerRouterService.clearCache();
+            	    refreshCache = true;
+            	    routingContext.put(CTX_KEY_FLUSHED_TRIGGER_ROUTERS, true);
+                }
+                
                 Trigger trigger = null;
                 Date lastUpdateTime = null;
                 String triggerId = columnValues.get("TRIGGER_ID");
                 if (tableMatches(dataMetaData, TableConstants.SYM_TRIGGER_ROUTER)) {
                     String routerId = columnValues.get("ROUTER_ID");
                     TriggerRouter tr = triggerRouterService.findTriggerRouterById(triggerId,
-                            routerId);
+                            routerId, refreshCache);
                     if (tr != null) {
                         trigger = tr.getTrigger();
                         lastUpdateTime = tr.getLastUpdateTime();
                     }
                 } else {
-                    trigger = triggerRouterService.getTriggerById(triggerId);
+                    trigger = triggerRouterService.getTriggerById(triggerId, refreshCache);
                     if (trigger != null) {
                         lastUpdateTime = trigger.getLastUpdateTime();
                     }

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/ITriggerRouterService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/ITriggerRouterService.java
@@ -139,6 +139,8 @@ public interface ITriggerRouterService {
     public Set<TriggerRouter> getTriggerRouterForTableForCurrentNode(String catalog, String schema, String tableName, boolean refreshCache); 
 
     public TriggerRouter findTriggerRouterById(String triggerId, String routerId);
+    
+    public TriggerRouter findTriggerRouterById(String triggerId, String routerId, boolean refreshCache);
 
     public void inactivateTriggerHistory(TriggerHistory history);
 

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/TriggerRouterServiceSqlMap.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/TriggerRouterServiceSqlMap.java
@@ -100,7 +100,9 @@ public class TriggerRouterServiceSqlMap extends AbstractSqlMap {
                 ""
                         + "select trigger_hist_id,trigger_id,source_table_name,table_hash,create_time,pk_column_names,column_names,last_trigger_build_reason,name_for_delete_trigger,name_for_insert_trigger,name_for_update_trigger,source_schema_name,source_catalog_name,trigger_row_hash,trigger_template_hash,error_message   "
                         + "  from $(trigger_hist)                                                                                                                                                                                                                                                      ");
-
+        putSql("activeTriggerHistSqlByTriggerId", ""
+                + "where trigger_id=? and inactive_time is null   ");
+        
         putSql("triggerHistBySourceTableWhereSql", ""
                 + "where source_table_name=? and inactive_time is null   ");
 

--- a/symmetric-core/src/main/resources/symmetric-schema.xml
+++ b/symmetric-core/src/main/resources/symmetric-schema.xml
@@ -741,6 +741,10 @@
         <column name="error_message" type="LONGVARCHAR" description="Record any errors or warnings that occurred when attempting to build the trigger." />
         <column name="create_time" type="TIMESTAMP" required="true"  description="Timestamp when this entry was created." />
         <column name="inactive_time" type="TIMESTAMP"  description="The date and time when a trigger was inactivated." />
+        <index name="idx_trigg_hist_1">
+            <index-column name="trigger_id"/>
+            <index-column name="inactive_time"/>
+        </index>
     </table>
 
     <table name="trigger_router" description="Map a trigger to a router.">


### PR DESCRIPTION
Fix for http://www.symmetricds.org/issues/view.php?id=2621 

I found another possible improvement but maybe some else could fix this, I'm not sure if extending all those methods with a true flag is a great idea. The "bad path" is:

```
engine.getTriggerRouterService().syncTrigger(trigger, null, false);

public void syncTrigger(Trigger trigger, ITriggerCreationListener listener, boolean force, boolean verifyInDatabase)
```

There `getActiveTriggerHistories` gets called for each trigger and shortly afterwards `getActiveTriggerHistories(trigger)` for the specific trigger. I think that a small refactoring would be useful here.

Sorry for the "big change" in `ITriggerRouterService.java` it seams there was a line ending missmatch in the base file.
