### PR TITLE
Clear NodeService cache if data changed

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/route/ConfigurationChangedDataRouter.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/route/ConfigurationChangedDataRouter.java
@@ -118,6 +118,9 @@ public class ConfigurationChangedDataRouter extends AbstractDataRouter implement
                  */
                 routeNodeTables(nodeIds, columnValues, rootNetworkedNode, me, routingContext,
                         dataMetaData, possibleTargetNodes, initialLoad);
+                        
+                engine.getNodeService().clearCache();
+                
             } else if (tableMatches(dataMetaData, TableConstants.SYM_TABLE_RELOAD_REQUEST)) {
                 String sourceNodeId = columnValues.get("SOURCE_NODE_ID");
                 String reloadEnabled = columnValues.get("RELOAD_ENABLED");


### PR DESCRIPTION
This changed adds clearing of the `NodeService` cache if it detects a change via the `ConfigurationChangedDataRouter`.

This is required so that the server is able to register nodes if they are added via external statements. 

Without this change `nodeService.findNode` would return `null` until you restart the server.
