### PR TITLE
Load node by id and sql instead of client side filtering

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/NodeService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/NodeService.java
@@ -127,7 +127,9 @@ public class NodeService extends AbstractService implements INodeService {
      * with it.
      */
     public Node findNode(String id) {
-        return findAllNodesAsMap().get(id);
+        List<Node> list = sqlTemplate.query(
+                getSql("selectNodePrefixSql", "findNodeSql"), new NodeRowMapper(), id);
+        return (Node) getFirstEntry(list);
     }
     
     public String getExternalId(String nodeId) {


### PR DESCRIPTION
Changset 04a5761721 is not complete reverting the previous changes from 2bb50bfb2. This pull request changes `findNode` back to load the node directly via sql and not loading any available nodes into a map.
