### PR TITLE
Store registration request update time with time fraction

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/RegistrationService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/RegistrationService.java
@@ -336,7 +336,7 @@ public class RegistrationService extends AbstractService implements IRegistratio
                             request.getLastUpdateTime(), request.getRegisteredNodeId(),
                             request.getStatus().name(), request.getErrorMessage(), nodeGroupId,
                             externalId, request.getIpAddress(), request.getHostName() }, new int[] {
-                            Types.NUMERIC, Types.VARCHAR, Types.DATE, Types.VARCHAR, Types.VARCHAR,
+                            Types.NUMERIC, Types.VARCHAR, Types.TIMESTAMP, Types.VARCHAR, Types.VARCHAR,
                             Types.VARCHAR, Types.VARCHAR, Types.VARCHAR, Types.VARCHAR,
                             Types.VARCHAR });
         }
@@ -347,7 +347,7 @@ public class RegistrationService extends AbstractService implements IRegistratio
                     new Object[] { request.getLastUpdateBy(), request.getLastUpdateTime(),
                             request.getRegisteredNodeId(), request.getStatus().name(), nodeGroupId,
                             externalId, request.getIpAddress(), request.getHostName(),
-                            request.getErrorMessage() }, new int[] { Types.VARCHAR, Types.DATE,
+                            request.getErrorMessage() }, new int[] { Types.VARCHAR, Types.TIMESTAMP,
                             Types.VARCHAR, Types.VARCHAR, Types.VARCHAR, Types.VARCHAR,
                             Types.VARCHAR, Types.VARCHAR, Types.VARCHAR });
         }


### PR DESCRIPTION
Currently the registration update time is stored only with the current date but not the time. I'm not sure if this is by intention, but it lead to confusion at least for me, because the `create_time` is bigger than `last_update_time`

This change stores the time also with the time fraction.
