### PR TITLE
Improve routing performance if there are pending initial loads

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/ITriggerRouterService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/ITriggerRouterService.java
@@ -44,6 +44,8 @@ public interface ITriggerRouterService {
     
     public List<TriggerHistory> getActiveTriggerHistories();
     
+    public boolean hasAnyActiveTriggerHistories();
+    
     public List<TriggerHistory> getActiveTriggerHistories(Trigger trigger);
     
     public List<TriggerHistory> getActiveTriggerHistories(String tableName);

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/RouterService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/RouterService.java
@@ -239,7 +239,7 @@ public class RouterService extends AbstractService implements IRouterService {
                                 .getRegistrationTime() != null)) {
 
                     List<NodeSecurity> nodeSecurities = findNodesThatAreReadyForInitialLoad();
-                    if (nodeSecurities != null) {
+                    if (nodeSecurities != null && nodeSecurities.size() > 0) {
                         boolean reverseLoadFirst = parameterService
                                 .is(ParameterConstants.INITIAL_LOAD_REVERSE_FIRST);
                         boolean isInitialLoadQueued = false;

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/RouterService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/RouterService.java
@@ -243,8 +243,9 @@ public class RouterService extends AbstractService implements IRouterService {
                         boolean reverseLoadFirst = parameterService
                                 .is(ParameterConstants.INITIAL_LOAD_REVERSE_FIRST);
                         boolean isInitialLoadQueued = false;
+                        boolean hasAnyActiveTriggerHistories = engine.getTriggerRouterService().hasAnyActiveTriggerHistories();
                         for (NodeSecurity security : nodeSecurities) {
-                            if (engine.getTriggerRouterService().hasAnyActiveTriggerHistories()) {
+                            if (hasAnyActiveTriggerHistories) {
                                 boolean thisMySecurityRecord = security.getNodeId().equals(
                                         identity.getNodeId());
                                 boolean reverseLoadQueued = security.isRevInitialLoadEnabled();

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/RouterService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/RouterService.java
@@ -244,7 +244,7 @@ public class RouterService extends AbstractService implements IRouterService {
                                 .is(ParameterConstants.INITIAL_LOAD_REVERSE_FIRST);
                         boolean isInitialLoadQueued = false;
                         for (NodeSecurity security : nodeSecurities) {
-                            if (engine.getTriggerRouterService().getActiveTriggerHistories().size() > 0) {
+                            if (engine.getTriggerRouterService().hasAnyActiveTriggerHistories()) {
                                 boolean thisMySecurityRecord = security.getNodeId().equals(
                                         identity.getNodeId());
                                 boolean reverseLoadQueued = security.isRevInitialLoadEnabled();

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/TriggerRouterService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/TriggerRouterService.java
@@ -382,6 +382,10 @@ public class TriggerRouterService extends AbstractService implements ITriggerRou
         }
         return history;
     }
+    
+    public boolean hasAnyActiveTriggerHistories(){
+    	return sqlTemplate.queryForInt(getSql("selectCountOfTriggerHistory", "activeTriggerHistSql")) > 0;
+    }
 
     public List<TriggerHistory> getActiveTriggerHistories(Trigger trigger) {
         List<TriggerHistory> active = sqlTemplate.query(getSql("allTriggerHistSql", "activeTriggerHistSqlByTriggerId"),

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/TriggerRouterServiceSqlMap.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/TriggerRouterServiceSqlMap.java
@@ -85,7 +85,7 @@ public class TriggerRouterServiceSqlMap extends AbstractSqlMap {
                         + "select count(*) from $(trigger_hist) where (name_for_update_trigger=? or name_for_insert_trigger=? or name_for_delete_trigger=?) and trigger_id != ? and inactive_time is null   ");
 
         putSql("selectCountOfTriggerHistory", ""
-                + "select count(*) from $(trigger_hist)");
+                + "select count(*) from $(trigger_hist)     ");
 
         putSql("selectGroupTriggersSql", ""
                 + "where r.source_node_group_id = ? or r.target_node_group_id = ? order by t.channel_id   ");

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/TriggerRouterServiceSqlMap.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/TriggerRouterServiceSqlMap.java
@@ -84,6 +84,9 @@ public class TriggerRouterServiceSqlMap extends AbstractSqlMap {
                 ""
                         + "select count(*) from $(trigger_hist) where (name_for_update_trigger=? or name_for_insert_trigger=? or name_for_delete_trigger=?) and trigger_id != ? and inactive_time is null   ");
 
+        putSql("selectCountOfTriggerHistory", ""
+                + "select count(*) from $(trigger_hist)");
+
         putSql("selectGroupTriggersSql", ""
                 + "where r.source_node_group_id = ? or r.target_node_group_id = ? order by t.channel_id   ");
 


### PR DESCRIPTION
This PR reduces heavy database calls if there are nodes which have pending initial loads.

It replaces the call to  "load any active trigger_histories and compare the result > 0" with a direct call of count(*) on the database side and compare that result.

This is a partial fix to reduce: http://www.symmetricds.org/issues/view.php?id=2669
