### PR TITLE
Create initial loads only to nodes which have sync enabled

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/RouterService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/RouterService.java
@@ -308,6 +308,7 @@ public class RouterService extends AbstractService implements IRouterService {
         IConfigurationService configurationService = engine.getConfigurationService();
         String me = nodeService.findIdentityNodeId();
         List<NodeSecurity> toReturn = new ArrayList<NodeSecurity>();
+        Map<String, Node> nodes = nodeService.findAllNodesAsMap();
         List<NodeSecurity> securities = nodeService.findNodeSecurityWithLoadEnabled();
         for (NodeSecurity nodeSecurity : securities) {
             if (((!nodeSecurity.getNodeId().equals(me)
@@ -316,7 +317,11 @@ public class RouterService extends AbstractService implements IRouterService {
                     || (!nodeSecurity.getNodeId().equals(me) && configurationService
                             .isMasterToMaster()) || (nodeSecurity.getNodeId().equals(me) && nodeSecurity
                     .isRevInitialLoadEnabled()))) {
-                toReturn.add(nodeSecurity);
+            	
+            	Node node = nodes.get(nodeSecurity.getNodeId());
+            	if(node != null && node.isSyncEnabled()){
+            		toReturn.add(nodeSecurity);
+            	}
             }
         }
         return toReturn;

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/RouterService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/RouterService.java
@@ -308,7 +308,7 @@ public class RouterService extends AbstractService implements IRouterService {
         IConfigurationService configurationService = engine.getConfigurationService();
         String me = nodeService.findIdentityNodeId();
         List<NodeSecurity> toReturn = new ArrayList<NodeSecurity>();
-        Map<String, Node> nodes = nodeService.findAllNodesAsMap();
+        Map<String, Node> nodes = null;
         List<NodeSecurity> securities = nodeService.findNodeSecurityWithLoadEnabled();
         for (NodeSecurity nodeSecurity : securities) {
             if (((!nodeSecurity.getNodeId().equals(me)
@@ -317,6 +317,10 @@ public class RouterService extends AbstractService implements IRouterService {
                     || (!nodeSecurity.getNodeId().equals(me) && configurationService
                             .isMasterToMaster()) || (nodeSecurity.getNodeId().equals(me) && nodeSecurity
                     .isRevInitialLoadEnabled()))) {
+            	
+            	if(nodes == null){
+            		nodes = nodeService.findAllNodesAsMap();
+            	}
             	
             	Node node = nodes.get(nodeSecurity.getNodeId());
             	if(node != null && node.isSyncEnabled()){


### PR DESCRIPTION
This PR changes `findNodesThatAreReadyForInitialLoad` to return only nodes which have `sync_enabled=1`.

If you create a lot of nodes which are `sync_enabled=0` but have `initial_load_enabled=1` to start initial loading on first register (which already flips `sync_enabled` to 1) and some of the nodes won't register for a while it recreates the initalloads over and over again. It reduces the call to a heavy database call, which is already reduced via PR #36.

I think this change is performing even better if `findAllNodesAsMap` is cached again (see 04a5761 and 2bb50bf)
