### PR TITLE
Delete staged resources if batch manually set to "NE" to recreate batch

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/DataExtractorService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/DataExtractorService.java
@@ -779,6 +779,13 @@ public class DataExtractorService extends AbstractService implements IDataExtrac
             long byteCount = 0l;
             long transformTimeInMs = 0l;
 
+            if (currentBatch.getStatus() == Status.NE) {
+                IStagedResource resource = getStagedResource(currentBatch);
+                if (resource != null) {
+                    resource.delete();
+                }
+            }
+
             if (currentBatch.getStatus() == Status.IG) {
                 Batch batch = new Batch(BatchType.EXTRACT, currentBatch.getBatchId(),
                         currentBatch.getChannelId(), symmetricDialect.getBinaryEncoding(),


### PR DESCRIPTION
This PR leads to recreating the staged resources if a batch is manually set to "NE". This is required as according to the documentation you have to wait either until the resource times out or you have to clear the staged area, if you manually adjust the batch content on conflict or error.

> After modifying the batch you will have to clear the Staging Area manually or wait for the staged version of the batch to timeout and clear itself.

With this change you can fully control the resolving scenario via sql, without having to additionally log into the application server and manually delete the file or even have to restart the service.

Additionally it ensures that any new batch is really extracted and cannot be hijacked with a random file.
