### PR TITLE
Fixed typo on "Queueing up an initial load"

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/DataService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/DataService.java
@@ -350,7 +350,7 @@ public class DataService extends AbstractService implements IDataService {
                             || (reloadRequests.size() == 1 && reloadRequests.get(0).isFullLoadRequest());
                     
                     if (!reverse) {
-                        log.info("Queueing up " + (isFullLoad ? "an initial" : "a" + " load to node ") + targetNode.getNodeId());
+                        log.info("Queueing up " + (isFullLoad ? "an initial" : "a") + " load to node " + targetNode.getNodeId());
                     } else {
                         log.info("Queueing up a reverse " + (isFullLoad ? "initial" : "") + " load to node " + targetNode.getNodeId());
                     }


### PR DESCRIPTION
Little PR which fixed the log output for:

>  Queueing up an initial load to node XYZ
