### PR TITLE
Send schema changes via configured trigger channel instead of hardwired config channel

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/DataService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/DataService.java
@@ -1115,12 +1115,18 @@ public class DataService extends AbstractService implements IDataService {
 
         Trigger trigger = engine.getTriggerRouterService().getTriggerById(
                 triggerHistory.getTriggerId(), false);
-        String reloadChannelId = getReloadChannelIdForTrigger(trigger, engine
-                .getConfigurationService().getChannels(false));
+
+        String triggerChannelId = trigger != null 
+        		? trigger.getChannelId() 
+        		: Constants.CHANNEL_CONFIG;
+        		
+        if(isLoad){
+        	triggerChannelId = getReloadChannelIdForTrigger(trigger, engine
+                    .getConfigurationService().getChannels(false));
+        }
 
         Data data = new Data(triggerHistory.getSourceTableName(), DataEventType.CREATE,
-                null, null, triggerHistory, isLoad ? reloadChannelId
-                        : Constants.CHANNEL_CONFIG, null, null);
+                null, null, triggerHistory, triggerChannelId, null, null);
         try {
             if (isLoad) {
                 insertDataAndDataEventAndOutgoingBatch(transaction, data, targetNode.getNodeId(),


### PR DESCRIPTION
This PR changes sendSchema() to send the change via the configured channel of the trigger. This is required to prevent out of order changes of the table schema before all pending data changes have been transmitted. As the 'config' channel is always transmitted first before 'default' this could lead to some nasty conflicts, where old data on the 'default' channel are causing unique index conflicts (which would have been cleared afterwards, before the schema change should happen)

This changes also removes the overhead of finding the reloadChannel if it isn't required.

I'm not sure if this should be a configurable option. Please let me know what you think!
