### PR TITLE
Added option for immediate re-pull if data found

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/common/ParameterConstants.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/common/ParameterConstants.java
@@ -69,6 +69,7 @@ final public class ParameterConstants {
     public final static String PULL_THREAD_COUNT_PER_SERVER = "pull.thread.per.server.count";
     public final static String PULL_MINIMUM_PERIOD_MS = "pull.period.minimum.ms";
     public final static String PULL_LOCK_TIMEOUT_MS = "pull.lock.timeout.ms";
+    public final static String PULL_IMMEDIATE_IF_DATA_FOUND = "pull.immediate.if.data.found";
 
     public final static String PUSH_THREAD_COUNT_PER_SERVER = "push.thread.per.server.count";
     public final static String PUSH_MINIMUM_PERIOD_MS = "push.period.minimum.ms";


### PR DESCRIPTION
This PR addes a parameter to do an immediate re-pull if the client got data. This is a useful option to speed up dataloading if you have a lot of unsynced big batches, which gets cutoff via `transport.max.bytes.to.sync`. If this is set to 1MB (default) and you have about 200 MB to sync, and the pull job runs every 10 seconds (default), it needs at least 30 Minutes to transfer all data.

Of course you can increate the max bytes to sync to a higher value, or increase the pull job frequency, but these parameters have other trade-offs, you need to consider.

I changed the log output a little bit so that you only get the "Immediate pull request" if you already ran a second cycle, to not clutter the log. Maybe this line should be changed to `log.debug`?
