### PR TITLE
Support for Sybase ASE v16 w/ jConnect driver

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/SequenceService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/SequenceService.java
@@ -169,9 +169,9 @@ public class SequenceService extends AbstractService implements ISequenceService
             nextVal = endVal;
         }
 
-        int updateCount = transaction.prepareAndExecute(getSql("updateCurrentValueSql"), nextVal,
+        int updateCount = transaction.prepareAndExecute(this.platform.scrubSql(getSql("updateCurrentValueSql")), nextVal,
                 name, currVal);
-        if (updateCount != 1) {
+        if (!this.platform.isSuccessfulUpdateCount(updateCount)) {
             nextVal = -1;
         } else if (range != null) {
             sequenceCache.put(name, range);
@@ -230,7 +230,7 @@ public class SequenceService extends AbstractService implements ISequenceService
     }
 
     public void create(Sequence sequence) {
-        sqlTemplate.update(getSql("insertSequenceSql"), sequence.getSequenceName(),
+        sqlTemplate.update(this.platform.scrubSql(getSql("insertSequenceSql")), sequence.getSequenceName(),
                 sequence.getCurrentValue(), sequence.getIncrementBy(), sequence.getMinValue(),
                 sequence.getMaxValue(), sequence.isCycle() ? 1 : 0, sequence.getCacheSize(), sequence.getLastUpdateBy());
     }

--- a/symmetric-db/src/main/java/org/jumpmind/db/platform/AbstractDatabasePlatform.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/platform/AbstractDatabasePlatform.java
@@ -902,6 +902,10 @@ public abstract class AbstractDatabasePlatform implements IDatabasePlatform {
         return tz;
     }
     
+    public boolean isSuccessfulUpdateCount(int count) {
+        return (count > 0) ? true : false;
+    }
+    
     @Override
     public void makePlatformSpecific(Database database) {
         Table[] tables = database.getTables();

--- a/symmetric-db/src/main/java/org/jumpmind/db/platform/IDatabasePlatform.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/platform/IDatabasePlatform.java
@@ -183,4 +183,6 @@ public interface IDatabasePlatform {
     
     public void makePlatformSpecific(Database database);
     
+    public boolean isSuccessfulUpdateCount(int count);
+    
 }

--- a/symmetric-db/src/test/java/org/jumpmind/db/platform/AbstractDatabasePlatformTest.java
+++ b/symmetric-db/src/test/java/org/jumpmind/db/platform/AbstractDatabasePlatformTest.java
@@ -78,6 +78,15 @@ public class AbstractDatabasePlatformTest {
         assertEquals(3, testDatabasePlatform.parseQualifiedTableName("\"CATALOG\".\"SCHEMA\".\"TABLE\"").size());
     }
     
+    @Test
+    public void testisSuccessfulUpdateCount() {
+    	
+    	assertFalse(testDatabasePlatform.isSuccessfulUpdateCount(-1));
+    	assertFalse(testDatabasePlatform.isSuccessfulUpdateCount(0));
+        assertTrue(testDatabasePlatform.isSuccessfulUpdateCount(1));
+        
+    }
+    
     private AbstractDatabasePlatform testDatabasePlatform = new AbstractDatabasePlatform() {
         @Override
         public String getName() {

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/ase/AseDatabasePlatform.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/ase/AseDatabasePlatform.java
@@ -94,4 +94,10 @@ public class AseDatabasePlatform extends AbstractJdbcDatabasePlatform {
     public Map<String, String> getSqlScriptReplacementTokens() {
         return sqlScriptReplacementTokens;
     }
+
+    @Override
+    public boolean isSuccessfulUpdateCount(int count) {
+        return (count >= 0) ? true : false;
+    }
 }
+

--- a/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/ase/AseDatabasePlatformTest.java
+++ b/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/ase/AseDatabasePlatformTest.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed to JumpMind Inc under one or more contributor
+ * license agreements.  See the NOTICE file distributed
+ * with this work for additional information regarding
+ * copyright ownership.  JumpMind Inc licenses this file
+ * to you under the GNU General Public License, version 3.0 (GPLv3)
+ * (the "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3.0 (GPLv3) along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jumpmind.db.platform.ase;
+
+import static org.junit.Assert.*;
+
+import org.jumpmind.db.platform.IDatabasePlatform;
+import org.junit.Test;
+import org.jumpmind.db.platform.ase.AseDatabasePlatform;
+
+public class AseDatabasePlatformTest {
+    
+    @Test
+    public void testisSuccessfulUpdateCount() {
+    	
+        assertFalse(aseDatabasePlatform.isSuccessfulUpdateCount(-1));
+    	assertTrue(aseDatabasePlatform.isSuccessfulUpdateCount(0));
+        assertTrue(aseDatabasePlatform.isSuccessfulUpdateCount(1));
+        
+    }
+        
+    private IDatabasePlatform aseDatabasePlatform = new AseDatabasePlatform(null, null);
+}


### PR DESCRIPTION
- Unable to create-sym-tables, sync-triggers w/o **all** of these changes
- jconn4.jar used
- Tested against Sybase ASE version 16
- ./gradle test in symmetric-assemble still green
- jConnect driver returns -1 with stmts and prepared stmt's
- getUpdateCount() method unless "?IGNORE_DONE_IN_PROC=true" is added
- to the db.url, but even with this parameter added there are still
- cases where getUpdateCount() returns 0 instead of 1
- this was tested with the latest jconn4.jar from latest ASE download
- scrubSql on several SQL statements that used current_timestamp, 
- which is not a fn in ASE 16
