### PR TITLE
Prevent reading out database password via rest api

### DIFF
--- a/symmetric-server/src/main/java/org/jumpmind/symmetric/web/rest/RestService.java
+++ b/symmetric-server/src/main/java/org/jumpmind/symmetric/web/rest/RestService.java
@@ -47,6 +47,7 @@ import org.apache.log4j.MDC;
 import org.jumpmind.db.model.Table;
 import org.jumpmind.db.sql.ISqlTemplate;
 import org.jumpmind.db.sql.Row;
+import org.jumpmind.db.util.BasicDataSourcePropertyConstants;
 import org.jumpmind.exception.IoException;
 import org.jumpmind.symmetric.ISymmetricEngine;
 import org.jumpmind.symmetric.common.Constants;
@@ -1255,7 +1256,7 @@ public class RestService {
     @ResponseStatus(HttpStatus.OK)
     @ResponseBody
     public final String getParameter(@PathVariable("name") String name) {
-        return getSymmetricEngine().getParameterService().getString(name.replace('_', '.'));
+        return getParameterImpl(getSymmetricEngine(), name);
     }
 
     @ApiOperation(value = "Read paramater value for the specified engine")
@@ -1263,7 +1264,15 @@ public class RestService {
     @ResponseStatus(HttpStatus.OK)
     @ResponseBody
     public final String getParameter(@PathVariable("engine") String engineName, @PathVariable("name") String name) {
-        return getSymmetricEngine(engineName).getParameterService().getString(name.replace('_', '.'));
+        return getParameterImpl(getSymmetricEngine(engineName), name);
+    }
+    
+    private String getParameterImpl(ISymmetricEngine service, String name){
+    	String parameterName = name.replace('_', '.');
+    	if(parameterName.equals(BasicDataSourcePropertyConstants.DB_POOL_PASSWORD)){
+    		return "";
+    	}
+    	return service.getParameterService().getString(parameterName);
     }
 
     @ExceptionHandler(Exception.class)


### PR DESCRIPTION
This PR prevents reading the database password via accessing the rest api. It simply returns an empty string instead. 
