### PR TITLE
Keep varchar(max) columns comparable on MSSQL

### DIFF
--- a/symmetric-client/src/main/java/org/jumpmind/symmetric/db/mssql/MsSqlTriggerTemplate.java
+++ b/symmetric-client/src/main/java/org/jumpmind/symmetric/db/mssql/MsSqlTriggerTemplate.java
@@ -233,10 +233,9 @@ public class MsSqlTriggerTemplate extends AbstractTriggerTemplate {
     	StringBuilder builder = new StringBuilder();
     	
     	for(Column column : table.getColumns()){
-    		boolean isLob = symmetricDialect.getPlatform().isLob(column.getMappedTypeCode());
-    		if(isLob){
-    			continue;
-    		}
+    		if(isNotComparable(column)){
+     			continue;
+     		}
     		if(builder.length() > 0){
     			builder.append(",");
     		}


### PR DESCRIPTION
If you have a ```varchar(max)``` column in MSSQL and you want to only capture changes. We need to add those columns to the ```inserted```/```deleted``` select, in order to access them via the sql builded in ```buildNonLobColumnsAreNotEqualString```. Otherwise the trigger creation failes with ```invalid column name```.