### PR TITLE
Partial table reload, to not purge incoming and fix NPE

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/DataService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/DataService.java
@@ -508,7 +508,7 @@ public class DataService extends AbstractService implements IDataService {
                         close(transaction);
                     }
 
-                    if (!reverse) {
+                    if (!reverse && isFullLoad) {
                         /*
                          * Remove all incoming events for the node that we are
                          * starting a reload for
@@ -631,7 +631,13 @@ public class DataService extends AbstractService implements IDataService {
                     List<TriggerRouter> triggerRouters = triggerRoutersByHistoryId.get(triggerHistory
                             .getTriggerHistoryId());
                     for (TriggerRouter triggerRouter : triggerRouters) {
-                        TableReloadRequest currentRequest = reloadRequests.get(triggerRouter.getTriggerId() + triggerRouter.getRouterId());
+                        String lookupName = triggerRouter.getTriggerId() + triggerRouter.getRouterId();
+                        TableReloadRequest currentRequest = reloadRequests.get(lookupName);
+                        if(currentRequest == null){
+                            log.info("Could not find valid reload request for '" + lookupName + "' trigger/router combination");
+                            continue;
+                        }
+
                         beforeSql = currentRequest.getBeforeCustomSql();
                         
                         if (isNotBlank(beforeSql)) {


### PR DESCRIPTION
This PR fixes two things:

1. If you make a partial initial load it purges the incoming events. In my opinion this is mostly not desired, as we could loose events from other tables, which are currently floating in.

2. If you create an entry in `TABLE_RELOAD_REQUEST` with an invalid `TRIGGER`/`ROUTER` combination, it failes with an NPE. This change adds a more usefull log message.