### PR TITLE
Move loading of trigger_routers to more specific execution branch to reduce unneeded db calls

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/RouterService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/RouterService.java
@@ -259,12 +259,7 @@ public class RouterService extends AbstractService implements IRouterService {
                         for (NodeSecurity security : nodeSecurities) {
                             if (activeHistories.size() > 0) {
                                 Node targetNode = engine.getNodeService().findNode(security.getNodeId());
-                                List<TriggerRouter> triggerRouters = triggerRoutersByTargetNodeGroupId.get(targetNode.getNodeGroupId());
-                                if (triggerRouters == null) {
-                                    triggerRouters = triggerRouterService.getAllTriggerRoutersForReloadForCurrentNode(parameterService.getNodeGroupId(), targetNode.getNodeGroupId());
-                                    triggerRoutersByTargetNodeGroupId.put(targetNode.getNodeGroupId(), triggerRouters);
-                                }
-                                
+                                                               
                                 boolean thisMySecurityRecord = security.getNodeId().equals(
                                         identity.getNodeId());
                                 boolean reverseLoadQueued = security.isRevInitialLoadEnabled();
@@ -276,6 +271,13 @@ public class RouterService extends AbstractService implements IRouterService {
                                 } else if (!thisMySecurityRecord && registered && initialLoadQueued
                                         &&  (!reverseLoadFirst || !reverseLoadQueued)) {
                                     long ts = System.currentTimeMillis();
+                                    
+                                    List<TriggerRouter> triggerRouters = triggerRoutersByTargetNodeGroupId.get(targetNode.getNodeGroupId());
+                                    if (triggerRouters == null) {
+                                        triggerRouters = triggerRouterService.getAllTriggerRoutersForReloadForCurrentNode(parameterService.getNodeGroupId(), targetNode.getNodeGroupId());
+                                        triggerRoutersByTargetNodeGroupId.put(targetNode.getNodeGroupId(), triggerRouters);
+                                    }
+                                    
                                     dataService.insertReloadEvents(
                                             targetNode,
                                             false, processInfo, activeHistories, triggerRouters);


### PR DESCRIPTION
This is a more superior fix to the problem discussed in #37, without needed to filter the nodes . This moves the call to ```getAllTriggerRoutersForReloadForCurrentNode``` to the execution branch where it is needed. This mostly reduces calls the database where it loads all the triggers and trigger_routers on any routing pass (e.g. every 5 seconds).