### PR TITLE
0003287: Invalid symbols in index name lead to sync error on SQLite

### DIFF
--- a/symmetric-db/src/main/java/org/jumpmind/db/platform/sqlite/SqliteDdlBuilder.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/platform/sqlite/SqliteDdlBuilder.java
@@ -137,6 +137,11 @@ public class SqliteDdlBuilder extends AbstractDdlBuilder {
     }
     
     @Override
+    public String getIndexName(IIndex index) {
+        return super.getIndexName(index).replace("-", "_");
+    }
+    
+    @Override
     protected String mapDefaultValue(Object defaultValue, int typeCode) {
         if (TypeMap.isDateTimeType(typeCode) && defaultValue != null) {
             String defaultValueStr = defaultValue.toString();


### PR DESCRIPTION
If you create an index on Mssql via the SMMS and won't provide a name they are created with the pattern "NonClusteredIndex-20171019-102802". If this index is synced to SQLite it lead to a syntax error. 

This replaces a "-" with a "_" in an index name on SQLite.