### PR TITLE
0003310: Refactored auto.sync.config.at.startup and auto.sync.config.after.upgrade to be independent

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/AbstractSymmetricEngine.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/AbstractSymmetricEngine.java
@@ -682,8 +682,9 @@ abstract public class AbstractSymmetricEngine implements ISymmetricEngine {
                             heartbeat(false);
                         }
 
-                        if (parameterService.is(ParameterConstants.AUTO_SYNC_CONFIG_AT_STARTUP, true)) {
-                            pullService.pullConfigData(false);
+                        if (parameterService.is(ParameterConstants.AUTO_SYNC_CONFIG_AT_STARTUP, true) 
+                                || parameterService.is(ParameterConstants.AUTO_SYNC_CONFIG_AFTER_UPGRADE, true)) {
+                            pullService.pullConfigData(parameterService.is(ParameterConstants.AUTO_SYNC_CONFIG_AT_STARTUP, true));
                         }
 
                     } else {

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/PullService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/PullService.java
@@ -181,8 +181,10 @@ public class PullService extends AbstractOfflineDetectorService implements IPull
         Node local = nodeService.findIdentity();
         RemoteNodeStatus status = null;
 
-        if (parameterService.is(ParameterConstants.AUTO_SYNC_CONFIG_AFTER_UPGRADE, true) &&
-                !parameterService.isRegistrationServer() && local != null && (force || !Version.version().equals(local.getConfigVersion()))) {
+        if (!parameterService.isRegistrationServer() && local != null 
+            && (force || 
+                (parameterService.is(ParameterConstants.AUTO_SYNC_CONFIG_AFTER_UPGRADE, true) 
+                    && !Version.version().equals(local.getConfigVersion())))) {
             Node remote = new Node();
             remote.setSyncUrl(parameterService.getRegistrationUrl());    
             status = new RemoteNodeStatus(remote.getNodeId(), Constants.CHANNEL_CONFIG, configurationService.getChannels(false));


### PR DESCRIPTION
Currently `auto.sync.config.at.startup` only works in conjunction with `auto.sync.config.after.upgrade`. 

And there is no way to force an update of the configuration without requiring a version upgrade.

This PR changes that behaviour so that `auto.sync.config.at.startup` always syncs the config at startup, While `auto.sync.config.after.upgrade` only syncs the config after an upgrade. So both parameter do now what they are named as.