### PR TITLE
0003311: MSSQL select varbinary from insert/deleted instead of origin table

### DIFF
--- a/symmetric-client/src/main/java/org/jumpmind/symmetric/db/mssql/MsSqlTriggerTemplate.java
+++ b/symmetric-client/src/main/java/org/jumpmind/symmetric/db/mssql/MsSqlTriggerTemplate.java
@@ -62,7 +62,7 @@ public class MsSqlTriggerTemplate extends AbstractTriggerTemplate {
         datetimeColumnTemplate = "case when $(tableAlias).\"$(columnName)\" is null then '' else ('\"' + convert(varchar,$(tableAlias).\"$(columnName)\",121) + '\"') end" ;
         clobColumnTemplate = "case when $(origTableAlias).\"$(columnName)\" is null then '' else '\"' + replace(replace(cast($(origTableAlias).\"$(columnName)\" as "+(castToNVARCHAR ? "n" : "")+"varchar(max)),'\\','\\\\'),'\"','\\\"') + '\"' end" ;
         blobColumnTemplate =   "case when $(origTableAlias).\"$(columnName)\" is null then '' else '\"' + replace(replace(" + defaultCatalog + "dbo.$(prefixName)_base64_encode(CONVERT(VARBINARY(max), $(origTableAlias).\"$(columnName)\")),'\\','\\\\'),'\"','\\\"') + '\"' end" ;
-        binaryColumnTemplate = blobColumnTemplate;
+        binaryColumnTemplate = "case when $(tableAlias).\"$(columnName)\" is null then '' else '\"' + replace(replace(" + defaultCatalog + "dbo.$(prefixName)_base64_encode(CONVERT(VARBINARY(max), $(tableAlias).\"$(columnName)\")),'\\','\\\\'),'\"','\\\"') + '\"' end" ;
         booleanColumnTemplate = "case when $(tableAlias).\"$(columnName)\" is null then '' when $(tableAlias).\"$(columnName)\" = 1 then '\"1\"' else '\"0\"' end" ;
         triggerConcatCharacter = "+" ;
         newTriggerValue = "inserted" ;

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/db/AbstractTriggerTemplate.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/db/AbstractTriggerTemplate.java
@@ -850,6 +850,10 @@ abstract public class AbstractTriggerTemplate {
                         }
                     } else if (isOld && symmetricDialect.needsToSelectLobData()) {
                         templateToUse = emptyColumnTemplate;
+                    } else if(this.getClass().getName().equals("org.jumpmind.symmetric.db.mssql.MsSqlTriggerTemplate") 
+                        && column.getJdbcTypeName() != null 
+                        && StringUtils.equalsIgnoreCase(column.getJdbcTypeName(), "VARBINARY")) {
+                        templateToUse = binaryColumnTemplate;
                     } else {
                         templateToUse = blobColumnTemplate;
                     }


### PR DESCRIPTION
This PR changes the trigger so that on MSSQL the value of blob fields are selected from the inserted/deleted virtual table instead of selecting it from the origin table.

This only works if it is a `varbinary(max)` field, so we filter based on that. 

This reduces the access to the origin table and thus improves the trigger performance.