### PR TITLE
0003319: Stoping the engine on the main node via rest stops the whole system

### DIFF
--- a/symmetric-server/src/main/java/org/jumpmind/symmetric/web/rest/RestService.java
+++ b/symmetric-server/src/main/java/org/jumpmind/symmetric/web/rest/RestService.java
@@ -1323,7 +1323,10 @@ public class RestService {
     }
 
     private void startImpl(ISymmetricEngine engine) {
-        engine.getParameterService().saveParameter(ParameterConstants.AUTO_START_ENGINE, "true", Constants.SYSTEM_USER);
+        org.jumpmind.symmetric.model.Node thisNode = engine.getNodeService().findIdentity();
+        if(thisNode != null) {
+            engine.getParameterService().saveParameter(thisNode.getExternalId(), thisNode.getNodeGroupId(), ParameterConstants.AUTO_START_ENGINE, "true", Constants.SYSTEM_USER);
+        }
         if (!engine.start()) {
             throw new InternalServerErrorException();
         }
@@ -1331,8 +1334,10 @@ public class RestService {
 
     private void stopImpl(ISymmetricEngine engine) {
         engine.stop();
-        engine.getParameterService().saveParameter(ParameterConstants.AUTO_START_ENGINE, "false", Constants.SYSTEM_USER);
-
+        org.jumpmind.symmetric.model.Node thisNode = engine.getNodeService().findIdentity();
+        if(thisNode != null) {
+            engine.getParameterService().saveParameter(thisNode.getExternalId(), thisNode.getNodeGroupId(), ParameterConstants.AUTO_START_ENGINE, "false", Constants.SYSTEM_USER);
+        }
     }
 
     private void syncTriggersImpl(ISymmetricEngine engine, boolean force) {


### PR DESCRIPTION
Stoping the engine on the main node via rest stops the whole system. As it writes into sym_parameter with

`ALL	ALL	auto.start.engine	false 2016-02-16 13:49:52.383	system	2017-11-16 10:58:55.800`

if this is synced down to the nodes, you'll have to manually adjust all nodes.

This PR writes this value only for the current engine node.



