### PR TITLE
Fix user-guide: node registration

### DIFF
--- a/symmetric-assemble/src/asciidoc/manage/node-registration.ad
+++ b/symmetric-assemble/src/asciidoc/manage/node-registration.ad
@@ -17,7 +17,7 @@ endif::pro[]
 
 You can open registration from the command line with the following command:
 
-`bin/symadmin --engine <engine name> <node group> <external id>`
+`bin/symadmin --engine <engine name> open-registration <node group> <external id>`
 
 The <node group> and <external id> should match the `group.id` and `external.id` in the registering node's <<Node Properties File>>.
 


### PR DESCRIPTION
add the following command to the node registration section of the User Guide:
- open-registration

The open-registration keyword was missing from the command for registering a node:

![image](https://user-images.githubusercontent.com/24815820/33351448-22b372fa-d4a4-11e7-8dd6-24178b4e3371.png)

The actual command in SymmetricDS:

```
bin/symadmin --engine <engine-name> open-registration <node group> <external id>
```