### PR TITLE
0003356: transport.max.bytes.to.sync not respected

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/common/ParameterConstants.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/common/ParameterConstants.java
@@ -155,6 +155,7 @@ final public class ParameterConstants {
     public final static String INITIAL_LOAD_SCHEMA_DUMP_COMMAND = "initial.load.schema.dump.command";
     public final static String INITIAL_LOAD_SCHEMA_LOAD_COMMAND = "initial.load.schema.load.command";
     public final static String INITIAL_LOAD_EXTRACT_AND_SEND_WHEN_STAGED = "initial.load.extract.and.send.when.staged";
+    public final static String INITIAL_LOAD_TRANSPORT_MAX_BYTES_TO_SYNC = "initial.load.transport.max.bytes.to.sync";
     
     public final static String CREATE_TABLE_WITHOUT_DEFAULTS = "create.table.without.defaults";
     public final static String CREATE_TABLE_WITHOUT_FOREIGN_KEYS = "create.table.without.foreign.keys";

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/DataExtractorService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/DataExtractorService.java
@@ -658,7 +658,7 @@ public class DataExtractorService extends AbstractService implements IDataExtrac
                     }
                 }
 
-                final long maxBytesToSync = parameterService.getLong(ParameterConstants.TRANSPORT_MAX_BYTES_TO_SYNC);
+                final long initialLoadMaxBytesToSync = parameterService.getLong(ParameterConstants.INITIAL_LOAD_TRANSPORT_MAX_BYTES_TO_SYNC);
                 long totalBytesSend = 0;
                 boolean logMaxBytesReached = false;
                 Iterator<OutgoingBatch> activeBatchIter = activeBatches.iterator();                
@@ -688,11 +688,11 @@ public class DataExtractorService extends AbstractService implements IDataExtrac
 
                             if (streamToFileEnabled || mode == ExtractMode.FOR_PAYLOAD_CLIENT || (currentBatch.isExtractJobFlag() && parameterService.is(ParameterConstants.INITIAL_LOAD_USE_EXTRACT_JOB))) {
                                 
-                                if(totalBytesSend > maxBytesToSync) {
+                                if(totalBytesSend > initialLoadMaxBytesToSync) {
                                     if(!logMaxBytesReached) {
                                         logMaxBytesReached = true;
                                         log.info(
-                                                "Reached the total byte threshold after {} of {} batches were send for node '{}' (send {} bytes, the max is {}).  "
+                                                "Reached the total byte threshold for initial load after {} of {} batches were send for node '{}' (send {} bytes, the max is {}).  "
                                                         + "The remaining batches will be send on a subsequent sync.",
                                                 new Object[] { i, futures.size(), targetNode.getNodeId(), totalBytesSend, maxBytesToSync });
                                     }

--- a/symmetric-core/src/main/resources/symmetric-default.properties
+++ b/symmetric-core/src/main/resources/symmetric-default.properties
@@ -518,6 +518,12 @@ registration.require.initial.load=true
 # Type: boolean
 initial.load.block.channels=true
 
+# This is the number of maximum number of bytes to synchronize in one connect during an initial load.
+#
+# DatabaseOverridable: true
+# Tags: load
+initial.load.transport.max.bytes.to.sync=10485760
+
 # Allow other channels to load when initial.load.block.channels is true and the
 # reload channel goes into error.  When the initial load runs while changes are
 # being made, it can lead to foreign key errors that might resolve when the other


### PR DESCRIPTION
After the upgrade to 3.9, the setting transport.max.bytes.to.sync isn't respected anymore. It now sends all the data until the max_batch_to_send limit for the channel is reached.

This PR fixes that behaviour while retaining the extracting of the other batches.
  