### PR TITLE
0003360: Fix exception on startup in StatisticManager if no sym tables exists

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/AbstractSymmetricEngine.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/AbstractSymmetricEngine.java
@@ -699,6 +699,7 @@ abstract public class AbstractSymmetricEngine implements ISymmetricEngine {
                     }
                     
                     lastRestartTime = new Date();
+                    statisticManager.incrementRestart();
                     started = true;
 
                 } else {

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/statistic/StatisticManager.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/statistic/StatisticManager.java
@@ -102,7 +102,6 @@ public class StatisticManager implements IStatisticManager {
     }
 
     protected void init() {
-        incrementRestart();
     }
 
 


### PR DESCRIPTION
If no sym table exists an initial start leads to an exception in StatisticManager as it tries to access those tables in `incrementRestart()`. This PR changes the call to a place after the tables have been created.