### PR TITLE
0003361: Update beanshell to 2.0b6 because of CVE

### DIFF
--- a/symmetric-assemble/common.gradle
+++ b/symmetric-assemble/common.gradle
@@ -162,7 +162,7 @@ subprojects { subproject ->
     artifacts { testArtifacts testJar }
 
     ext {
-        bshVersion = '2.0b5'
+        bshVersion = '2.0b6'
         commonsBeanUtilsVersion = '1.9.3'
         commonsCliVersion = '1.2'
         commonsDbcpVersion = '1.3'

--- a/symmetric-io/build.gradle
+++ b/symmetric-io/build.gradle
@@ -5,7 +5,7 @@ apply from: symAssembleDir + '/common.gradle'
     dependencies {
         compile project(":symmetric-csv")
         compile project(":symmetric-db")
-        compile "org.beanshell:bsh:$bshVersion"
+        compile "org.apache-extras.beanshell:bsh:$bshVersion"
         compile "net.sourceforge.jeval:jeval:0.9.4"
         testCompile project(path: ':symmetric-util', configuration: 'testArtifacts')
         testCompile project(":symmetric-jdbc")


### PR DESCRIPTION
Updates to latest beanshell to fix CVE-2016-2510 (see https://github.com/beanshell/beanshell)