### PR TITLE
0003464: RemoteNodeStatuses actively waits for completeness

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/model/RemoteNodeStatuses.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/model/RemoteNodeStatuses.java
@@ -87,9 +87,9 @@ public class RemoteNodeStatuses extends ArrayList<RemoteNodeStatus> {
     }
 
     public boolean isComplete() {
-        boolean complete = false;
+        boolean complete = true;
         for (RemoteNodeStatus status : this) {
-            complete |= status.isComplete();
+            complete &= status.isComplete();
         }
         return complete;
     }

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/model/RemoteNodeStatuses.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/model/RemoteNodeStatuses.java
@@ -95,14 +95,19 @@ public class RemoteNodeStatuses extends ArrayList<RemoteNodeStatus> {
     }
 
     public void waitForComplete(long timeout) {
-        long ts = System.currentTimeMillis();
-        while (!isComplete() && System.currentTimeMillis() - ts < timeout) {
-            AppUtils.sleep(50);
-        }
-
-        if (!isComplete()) {
-            throw new InterruptedException(String.format(
-                    "Timed out after %sms", timeout));
+        long deadline = System.currentTimeMillis() + timeout;
+        for (RemoteNodeStatus status : this) {
+            long timeLeft = deadline-System.currentTimeMillis();
+            
+            try {
+                if(timeLeft <= 0 || !status.waitCompleted(timeLeft)){
+                    throw new InterruptedException(String.format(
+                            "Timed out after %sms", timeout));
+                }
+            } catch (java.lang.InterruptedException e) {
+                throw new InterruptedException(String.format(
+                        "Timed out after %sms", timeout));
+            }
         }
     }
 }


### PR DESCRIPTION
RemoteNodeStatuses actively waits for completeness, via polling the variable. This leads to a higher cpu value, and additonally it allows only a complete time in 50ms steps.

Additonally I saw that the isComplete function already returns true if a single status is complete while it should check all.

This RP fixes both issues.