### PR TITLE
0003474: java.lang.AbstractMethodError: java/sql/PreparedStatement.setNString

### DIFF
--- a/symmetric-assemble/common.gradle
+++ b/symmetric-assemble/common.gradle
@@ -165,7 +165,7 @@ subprojects { subproject ->
         bshVersion = '2.0b6'
         commonsBeanUtilsVersion = '1.9.3'
         commonsCliVersion = '1.2'
-        commonsDbcpVersion = '1.3'
+        commonsDbcpVersion = '1.4'
         commonsFileuploadVersion = '1.3.3'
         commonsIoVersion = '2.4'
         commonsLangVersion = '2.6'


### PR DESCRIPTION
The following error occures if you have MSSQL and a NVARCHAR column with the 3.9 branch:

```
java.lang.AbstractMethodError: Method org/apache/commons/dbcp/DelegatingPreparedStatement.setNString(ILjava/lang/String;)V is abstract
at org.apache.commons.dbcp.DelegatingPreparedStatement.setNString(DelegatingPreparedStatement.java)
at org.springframework.jdbc.core.StatementCreatorUtils.setValue(StatementCreatorUtils.java:349)
at org.springframework.jdbc.core.StatementCreatorUtils.setParameterValueInternal(StatementCreatorUtils.java:241)
at org.springframework.jdbc.core.StatementCreatorUtils.setParameterValue(StatementCreatorUtils.java:172)
at org.jumpmind.db.sql.JdbcSqlTemplate.setValues(JdbcSqlTemplate.java:1013)
at org.jumpmind.db.sql.JdbcSqlTransaction.addRow(JdbcSqlTransaction.java:455)
at org.jumpmind.symmetric.io.data.writer.DefaultDatabaseWriter.execute(DefaultDatabaseWriter.java:865)
at org.jumpmind.symmetric.io.data.writer.DefaultDatabaseWriter.insert(DefaultDatabaseWriter.java:202)
at org.jumpmind.symmetric.io.data.writer.AbstractDatabaseWriter.write(AbstractDatabaseWriter.java:191)
```

this PR updates the dbcp dependency to fix this.