### PR TITLE
0003487: Executing ISqlTemplate.update() with multiple statements swallows errors

### DIFF
--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/sql/JdbcSqlTemplate.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/sql/JdbcSqlTemplate.java
@@ -352,7 +352,12 @@ public class JdbcSqlTemplate extends AbstractSqlTemplate implements ISqlTemplate
                         long endTime = System.currentTimeMillis();
                         logSqlBuilder.logSql(log, sql, args, types, (endTime-startTime));
 
-                        return stmt.getUpdateCount();
+                        int updateCount;
+                        do{
+                            updateCount = stmt.getUpdateCount();
+                        }while(stmt.getMoreResults() || stmt.getUpdateCount() != -1);
+
+                        return updateCount;
                     } catch (SQLException e) {
                         throw logSqlBuilder.logSqlAfterException(log, sql, args, e);
                     } finally {
@@ -375,7 +380,12 @@ public class JdbcSqlTemplate extends AbstractSqlTemplate implements ISqlTemplate
                         long endTime = System.currentTimeMillis();
                         logSqlBuilder.logSql(log, sql, args, types, (endTime-startTime));
 
-                        return ps.getUpdateCount();
+                        int updateCount;
+                        do{
+                            updateCount = ps.getUpdateCount();
+                        }while(ps.getMoreResults() || ps.getUpdateCount() != -1);
+
+                        return updateCount;
                     } catch (SQLException e) {
                         throw logSqlBuilder.logSqlAfterException(log, sql, args, e);
                     } finally {


### PR DESCRIPTION
If you execute a ISQLTemplate.update() with multiple statements at once, and one of the later statements are leading to an error (e.g. foreign key constraint violation) this exception is not thrown back to the user.

This PR reads all the result counts so that if an error is read it will be rethrown. This is also the documented behaviour of JDBC.