### PR TITLE
0003540: Do not send sync_disabled during registration attempt

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/NodeService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/NodeService.java
@@ -924,7 +924,11 @@ public class NodeService extends AbstractService implements INodeService {
         if (node == null) {
             retVal = AuthenticationStatus.REGISTRATION_REQUIRED;
         } else if (!syncEnabled(node)) {
-            retVal = AuthenticationStatus.SYNC_DISABLED;
+            if(registrationOpen(node)){
+                retVal = AuthenticationStatus.REGISTRATION_REQUIRED;
+            }else{
+                retVal = AuthenticationStatus.SYNC_DISABLED;
+            }
         } else if (!isNodeAuthorized(nodeId, securityToken)) {
             retVal = AuthenticationStatus.FORBIDDEN;
         }
@@ -937,6 +941,14 @@ public class NodeService extends AbstractService implements INodeService {
             syncEnabled = node.isSyncEnabled();
         }
         return syncEnabled;
-    }    
+    }
+
+    protected boolean registrationOpen(Node node){
+        NodeSecurity security = findNodeSecurity(node.getNodeId());
+        if(security != null){
+            return security.isRegistrationEnabled();
+        }
+        return false;
+    } 
 
 }


### PR DESCRIPTION
This PR fixes https://www.symmetricds.org/issues/view.php?id=3540

I experience the following race condition, if I register a node, it sometimes gets unregistered during the registration process. 

It looks like that the `FileSyncService` is removing the identity, because it is running during the time where the `sym_node_identity` is created on the client and it has been acknowledged on the server.

I fixed this case, so that the in a scenario where the node is available but disabled while the registration is open, the `REGISTRATION_REQUIRED` result code is sent, which doesn't remove the identity from the client.