### PR TITLE
0003542: Prevent jobs on running on not assigned nodes groups

### DIFF
--- a/symmetric-client/src/main/java/org/jumpmind/symmetric/job/AbstractJob.java
+++ b/symmetric-client/src/main/java/org/jumpmind/symmetric/job/AbstractJob.java
@@ -276,6 +276,11 @@ abstract public class AbstractJob implements Runnable, IJob {
             }
         }
 
+        if(jobDefinition.getNodeGroupId() != null && !jobDefinition.getNodeGroupId().equals("ALL") && !jobDefinition.getNodeGroupId().equals(engine.getNodeService().findIdentity().getNodeGroupId())){
+            log.info("Job should be only run on node groups '{}' but this is '{}'", jobDefinition.getNodeGroupId(), engine.getNodeService().findIdentity().getNodeGroupId());
+            return false;
+        }
+
         return true;
     }
 


### PR DESCRIPTION
Somestimes jobs are loaded and executed on not assigned node groups

This PR assures that jobs are running only on node groups which they are assigned to.