### PR TITLE
0003543: Ignore system tables on MssqlDdlReader

### DIFF
--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/mssql/MsSqlDdlReader.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/mssql/MsSqlDdlReader.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.commons.lang.StringUtils;
 import org.jumpmind.db.model.Column;
 import org.jumpmind.db.model.IIndex;
 import org.jumpmind.db.model.PlatformColumn;
@@ -93,6 +94,10 @@ public class MsSqlDdlReader extends AbstractJdbcDdlReader {
         }
 
         Table table = super.readTable(connection, metaData, values);
+        
+        if(StringUtils.equalsIgnoreCase(table.getSchema(),"sys")){
+            return null;
+        }
 
         if (table != null) {
             // Sql Server does not return the auto-increment status via the


### PR DESCRIPTION
This PR ignores all system tables from being read by the `MssqlDdlReader`, this fixes problems when you have tables with the same name like schema tables, e.g. `events`