### PR TITLE
0003544: Extend the detection of UniqueKeyViolation on Sqlite

### DIFF
--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/sqlite/SqliteJdbcSqlTemplate.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/sqlite/SqliteJdbcSqlTemplate.java
@@ -51,7 +51,10 @@ public class SqliteJdbcSqlTemplate extends JdbcSqlTemplate {
     @Override
     public boolean isUniqueKeyViolation(Throwable ex) {
         SQLException sqlEx = findSQLException(ex);
-        return (sqlEx != null && sqlEx.getMessage() != null && sqlEx.getMessage().contains("[SQLITE_CONSTRAINT]"));
+        return (sqlEx != null && sqlEx.getMessage() != null && (
+                sqlEx.getMessage().contains("[SQLITE_CONSTRAINT]") || 
+                sqlEx.getMessage().contains("[SQLITE_CONSTRAINT_PRIMARYKEY]") ||
+                sqlEx.getMessage().contains("[SQLITE_CONSTRAINT_UNIQUE]")));
     }
     
     @Override


### PR DESCRIPTION
Adds `[SQLITE_CONSTRAINT_PRIMARYKEY]` and `[SQLITE_CONSTRAINT_UNIQUE]` error messages to detection of unique key violations.