### PR TITLE
StagingManger.clean should also use createStagedResource

### DIFF
--- a/symmetric-io/src/main/java/org/jumpmind/symmetric/io/stage/StagingManager.java
+++ b/symmetric-io/src/main/java/org/jumpmind/symmetric/io/stage/StagingManager.java
@@ -96,7 +96,7 @@ public class StagingManager implements IStagingManager {
             long purgedMemCount = 0;
             long purgedMemSize = 0;
             for (String key : keys) {
-                IStagedResource resource = new StagedResource(directory, key, this);
+                IStagedResource resource = createStagedResource(key);
                 /* resource could have deleted itself between the time the keys were cloned and now */
                 if (resource != null) {
                     boolean resourceIsOld = (System.currentTimeMillis() - resource


### PR DESCRIPTION
I stumbled over this changeset b76a12ceb9e9e3297aa3c6f2e6527c9da654ab07 . And I think `StagingManger.clean(long ttlInMs)` should use the `createStagedResource` instead of handling the creation by itself, too.