### PR TITLE
0003545: Consider mapped default value on model compare

### DIFF
--- a/symmetric-db/src/main/java/org/jumpmind/db/alter/ModelComparator.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/alter/ModelComparator.java
@@ -376,7 +376,7 @@ public class ModelComparator {
                 || (sourceDefaultValue != null && targetDefaultValue == null)
                 || (sourceDefaultValue != null && targetDefaultValue != null &&
                 ((isBigDecimal && ((BigDecimal) sourceDefaultValue).compareTo((BigDecimal) targetDefaultValue) != 0) ||
-                (!isBigDecimal && !sourceDefaultValue.toString().equals(targetDefaultValue.toString()))))) {
+                (!isBigDecimal && !ddlBuilder.mapDefaultValue(targetDefaultValue, desiredTypeCode).equals(sourceDefaultValue.toString()))))) {
             log.debug(
                     "The {} column on the {} table changed default value from {} to {} ",
                     new Object[] { sourceColumn.getName(), sourceTable.getName(),

--- a/symmetric-db/src/main/java/org/jumpmind/db/platform/AbstractDdlBuilder.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/platform/AbstractDdlBuilder.java
@@ -2032,7 +2032,7 @@ public abstract class AbstractDdlBuilder implements IDdlBuilder {
 		}
 	}
 
-	protected String mapDefaultValue(Object defaultValue, int typeCode) {
+	public String mapDefaultValue(Object defaultValue, int typeCode) {
 		if (defaultValue == null) {
 			defaultValue = "NULL";
 		}

--- a/symmetric-db/src/main/java/org/jumpmind/db/platform/IDdlBuilder.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/platform/IDdlBuilder.java
@@ -47,6 +47,8 @@ public interface IDdlBuilder {
     public String alterTable(Table currentTable, Table desiredTable, IAlterDatabaseInterceptor... alterDatabaseInterceptors);
     
     public String dropTables(Database database);
+
+    public String mapDefaultValue(Object defaultValue, int typeCode);
     
     /*
      * Determines whether delimited identifiers are used or normal SQL92

--- a/symmetric-db/src/main/java/org/jumpmind/db/platform/oracle/OracleDdlBuilder.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/platform/oracle/OracleDdlBuilder.java
@@ -107,7 +107,7 @@ public class OracleDdlBuilder extends AbstractDdlBuilder {
     }
     
     @Override
-    protected String mapDefaultValue(Object defaultValue, int typeCode) {
+    public String mapDefaultValue(Object defaultValue, int typeCode) {
         String newValue = super.mapDefaultValue(defaultValue, typeCode).trim();
         if (newValue.startsWith("(") && newValue.endsWith(")")) {
             newValue = newValue.substring(1, newValue.length()-1);

--- a/symmetric-db/src/main/java/org/jumpmind/db/platform/sqlite/SqliteDdlBuilder.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/platform/sqlite/SqliteDdlBuilder.java
@@ -142,7 +142,7 @@ public class SqliteDdlBuilder extends AbstractDdlBuilder {
     }
     
     @Override
-    protected String mapDefaultValue(Object defaultValue, int typeCode) {
+    public String mapDefaultValue(Object defaultValue, int typeCode) {
         if (TypeMap.isDateTimeType(typeCode) && defaultValue != null) {
             String defaultValueStr = defaultValue.toString();
             if (defaultValueStr.toUpperCase().startsWith("SYSDATE")

--- a/symmetric-db/src/main/java/org/jumpmind/db/platform/tibero/TiberoDdlBuilder.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/platform/tibero/TiberoDdlBuilder.java
@@ -85,7 +85,7 @@ public class TiberoDdlBuilder extends AbstractDdlBuilder {
     }
     
     @Override
-    protected String mapDefaultValue(Object defaultValue, int typeCode) {
+    public String mapDefaultValue(Object defaultValue, int typeCode) {
         String newValue = super.mapDefaultValue(defaultValue, typeCode).trim();
         if (newValue.startsWith("(") && newValue.endsWith(")")) {
             newValue = newValue.substring(1, newValue.length()-1);


### PR DESCRIPTION
A mapped default values lead to always detecting a model change. This PR changes the `ModelComperator` to take the mapped value into account.