### PR TITLE
FileSyncService should use the file_trigger table for cache invalidation

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/FileSyncService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/FileSyncService.java
@@ -119,7 +119,7 @@ INodeCommunicationExecutor {
     }
 
     public boolean refreshFromDatabase() {
-        Date date1 = sqlTemplate.queryForObject(getSql("selectMaxTriggerLastUpdateTime"), Date.class);
+        Date date1 = sqlTemplate.queryForObject(getSql("selectMaxFileTriggerLastUpdateTime"), Date.class);
         Date date2 = sqlTemplate.queryForObject(getSql("selectMaxRouterLastUpdateTime"), Date.class);
         Date date3 = sqlTemplate.queryForObject(getSql("selectMaxFileTriggerRouterLastUpdateTime"), Date.class);
         Date date = maxDate(date1, date2, date3);


### PR DESCRIPTION
`FileSyncService.refreshFromDatabase` should invalidate based on the `file_trigger` table and not the `trigger` table.