### PR TITLE
0003547: Improve Sqlite DdlBuilder support

### DIFF
--- a/symmetric-db/src/main/java/org/jumpmind/db/platform/AbstractDdlBuilder.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/platform/AbstractDdlBuilder.java
@@ -821,14 +821,8 @@ public abstract class AbstractDdlBuilder implements IDdlBuilder {
 
 			Table realTargetTable = getRealTargetTableFor(desiredModel, sourceTable, targetTable);
 
-			dropTemporaryTable(tempTable, ddl);
-			createTemporaryTable(tempTable, ddl);
-			writeCopyDataStatement(sourceTable, tempTable, ddl);
-			/*
-			 * Note that we don't drop the indices here because the DROP TABLE will take
-			 * care of that Likewise, foreign keys have already been dropped as necessary
-			 */
-			dropTable(sourceTable, ddl, false, true);
+			renameTable(sourceTable, tempTable, ddl);
+
 			createTable(realTargetTable, ddl, false, true);
 			if (canMigrateData) {
 				writeCopyDataStatement(tempTable, targetTable, ddl);
@@ -839,6 +833,18 @@ public abstract class AbstractDdlBuilder implements IDdlBuilder {
 			ddl.append(tableDdl);
 		}
 	}
+    
+    protected void renameTable(Table sourceTable, Table tempTable, StringBuilder ddl) {
+        dropTemporaryTable(tempTable, ddl);
+        createTemporaryTable(tempTable, ddl);
+        writeCopyDataStatement(sourceTable, tempTable, ddl);
+        /*
+         * Note that we don't drop the indices here because the DROP
+         * TABLE will take care of that Likewise, foreign keys have
+         * already been dropped as necessary
+         */
+        dropTable(sourceTable, ddl, false, true);
+    }
 
 	protected Database copy(Database currentModel) {
 		try {

--- a/symmetric-db/src/main/java/org/jumpmind/db/platform/sqlite/SqliteDdlBuilder.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/platform/sqlite/SqliteDdlBuilder.java
@@ -172,6 +172,13 @@ public class SqliteDdlBuilder extends AbstractDdlBuilder {
     }
 
     @Override
+    protected void writeColumnDefaultValue(Table table, Column column, StringBuilder ddl) {
+        ddl.append("(");
+        super.writeColumnDefaultValue(table, column, ddl);
+        ddl.append(")");
+    }
+
+    @Override
     protected void createTable(Table table, StringBuilder ddl, boolean temporary, boolean recreate) {
         // SQL Lite does not allow auto increment columns on a composite primary key.  Solution is to turn off
         // Auto increment and still support composite key


### PR DESCRIPTION
This PR improves the DdlBuilder support on Sqlite.

Due to the fact that ddl support on Sqlite is very limited, most of the changes in schema lead to recreating the whole table which can take quite some time.

I implemented the following changes:

- A rename of the table is now executed with the `alter table ... rename` syntax
- Adding of columns is now supported via the `alter table ... add column` syntax
- Default values are surounded with parenthesis to prevent some syntax errors

This changes sum up in much less preasure on the database on schema changes.