### PR TITLE
0003548: Fix NPE on processing schema only batches

### DIFF
--- a/symmetric-io/src/main/java/org/jumpmind/symmetric/io/data/DataProcessor.java
+++ b/symmetric-io/src/main/java/org/jumpmind/symmetric/io/data/DataProcessor.java
@@ -205,7 +205,10 @@ public class DataProcessor {
                         batch.startTimer(STAT_WRITE_DATA);
                         batch.incrementLineCount();
                         if (context.getWriter() == null) {
-                        		context.setWriter(chooseDataWriter(batch));
+                                IDataWriter writer = chooseDataWriter(batch);
+                                writer.open(context);
+                                writer.start(batch);
+                                context.setWriter(writer);
                         }
                         context.getWriter().write(currentData);
                         batch.incrementDataWriteMillis(batch.endTimer(STAT_WRITE_DATA));


### PR DESCRIPTION
If you process schema only batches you sometimes get NPE at random places. We need to open the context and batch on the datawriter as those will be accessed at later steps (`errorFilter`, `statistics ` etc.)
