### PR TITLE
0003553: Fix npe in SnapshotUtil by respecting possible null value on getImpmentation* for packages

### DIFF
--- a/symmetric-client/src/main/java/org/jumpmind/symmetric/util/SnapshotUtil.java
+++ b/symmetric-client/src/main/java/org/jumpmind/symmetric/util/SnapshotUtil.java
@@ -541,9 +541,12 @@ public class SnapshotUtil {
             runtimeProperties.setProperty("data.id.min", Long.toString(engine.getDataService().findMinDataId()));
             runtimeProperties.setProperty("data.id.max", Long.toString(engine.getDataService().findMaxDataId()));
 
-            runtimeProperties.put("jvm.title", Runtime.class.getPackage().getImplementationTitle());
-            runtimeProperties.put("jvm.vendor", Runtime.class.getPackage().getImplementationVendor());
-            runtimeProperties.put("jvm.version", Runtime.class.getPackage().getImplementationVersion());
+            String jvmTitle = Runtime.class.getPackage().getImplementationTitle();
+            runtimeProperties.put("jvm.title", jvmTitle != null ? jvmTitle : "Unknown");
+            String jvmVendor = Runtime.class.getPackage().getImplementationVendor();
+            runtimeProperties.put("jvm.vendor", jvmVendor != null ? jvmVendor : "Unknown");
+            String jvmVersion = Runtime.class.getPackage().getImplementationVersion();
+            runtimeProperties.put("jvm.version", jvmVersion != null ? jvmVersion : "Unknown");
             RuntimeMXBean runtimeMxBean = ManagementFactory.getRuntimeMXBean();
             List<String> arguments = runtimeMxBean.getInputArguments();
             runtimeProperties.setProperty("jvm.arguments", arguments.toString());


### PR DESCRIPTION
According to the documentation `getImplementationTitle()` can return `null` if is unknown, this leads to the folling exception on snapshot creation:

```
2018-05-07 23:57:03,983 WARN [central-0] [SnapshotUtil] [qtp1825719826-21] Failed to export runtime-stats information StackTraceKey.init [NullPointerException:3790101681]
java.lang.NullPointerException
        at java.base/java.util.concurrent.ConcurrentHashMap.putVal(ConcurrentHashMap.java:1021)
        at java.base/java.util.concurrent.ConcurrentHashMap.put(ConcurrentHashMap.java:1016)
        at java.base/java.util.Properties.put(Properties.java:1309)
        at org.jumpmind.symmetric.util.SnapshotUtil.writeRuntimeStats(SnapshotUtil.java:545)
        at org.jumpmind.symmetric.util.SnapshotUtil.createSnapshot(SnapshotUtil.java:360)
```

see: https://docs.oracle.com/javase/7/docs/api/java/lang/Package.html#getImplementationTitle()