### PR TITLE
0003505: Throw error if it can't update a table_reload_request

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/DataService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/DataService.java
@@ -55,6 +55,7 @@ import org.jumpmind.db.sql.UniqueKeyException;
 import org.jumpmind.db.sql.mapper.NumberMapper;
 import org.jumpmind.exception.IoException;
 import org.jumpmind.symmetric.ISymmetricEngine;
+import org.jumpmind.symmetric.SymmetricException;
 import org.jumpmind.symmetric.common.Constants;
 import org.jumpmind.symmetric.common.ParameterConstants;
 import org.jumpmind.symmetric.common.TableConstants;
@@ -520,9 +521,11 @@ public class DataService extends AbstractService implements IDataService {
 
                         if (reloadRequests != null && reloadRequests.size() > 0) {
                             for (TableReloadRequest request : reloadRequests) {
-                                transaction.prepareAndExecute(getSql("updateProcessedTableReloadRequest"), loadId, new Date(),
+                                if(0 >= transaction.prepareAndExecute(getSql("updateProcessedTableReloadRequest"), loadId, new Date(),
                                         request.getTargetNodeId(), request.getSourceNodeId(), request.getTriggerId(), 
-                                        request.getRouterId(), request.getCreateTime());
+                                        request.getRouterId(), request.getCreateTime())){
+                                    throw new SymmetricException("Failed to update a table_reload_request");
+                                }
                             }
                             log.info("Table reload request(s) for load id " + loadId + " have been processed.");
                         }


### PR DESCRIPTION
Until 0003505 is fully fixed, we should throw an error to the user if an update on `table_reload_request` fails to show up in the logs.