### PR TITLE
Excluded columns that are part of an index the index remains in table object

### DIFF
--- a/symmetric-db/src/main/java/org/jumpmind/db/model/Table.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/model/Table.java
@@ -30,6 +30,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.TreeSet;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.EqualsBuilder;
@@ -1234,6 +1235,25 @@ public class Table implements Serializable, Cloneable, Comparable<Table> {
         Table table = copy();
         table.orderColumns(orderedColumnNames);
         
+        Set<String> columnNameSet = new TreeSet<String>(String.CASE_INSENSITIVE_ORDER);
+        columnNameSet.addAll(Arrays.asList(orderedColumnNames));
+
+        List<IIndex> indices = new ArrayList<IIndex>();
+        for(IIndex index : table.getIndices()){
+            boolean keepIndex = true;
+            for(IndexColumn columnInIndex : index.getColumns()){
+                if(columnInIndex == null || !columnNameSet.contains(columnInIndex.getName())){
+                    keepIndex = false;
+                    break;
+                }
+            }
+            if(keepIndex){
+                indices.add(index);
+            }
+        }
+        table.removeAllIndices();
+        table.addIndices(indices);
+
         if (setPrimaryKeys && columns != null) {
             for (Column column : table.columns) {
                 if (column != null) {


### PR DESCRIPTION
This is similar to 208106c (0003689: Excluded columns that are part of a foreign key the foreign key remains in table object). If you exclude a column, and it is part of an index, the index still gets synced and thus creates an exception on the client.