### PR TITLE
Added SQL that was removed in 3.9+ that generated SQLException

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/ConfigurationServiceSqlMap.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/ConfigurationServiceSqlMap.java
@@ -92,6 +92,11 @@ public class ConfigurationServiceSqlMap extends AbstractSqlMap {
 	              " select channel_id, last_extract_time, suspend_enabled, ignore_enabled   "
 	              + "  from $(node_channel_ctl) where node_id = ?   "
 	              + "  order by channel_id                                ");
+				  
+		putSql("selectNodeChannelControlLastExtractTimeSql", ""
+				 + "select channel_id, last_extract_time                 "
+				 + "  from $(node_channel_ctl) where node_id = ?   "
+				 + "  order by channel_id                                ");
 
         putSql("insertChannelSql",
            "insert into $(channel) (channel_id, processing_order, max_batch_size,                 "


### PR DESCRIPTION
When upgrading from 3.8.43 to 3.9.x or 3.10.x there was an issue where the ConfigurationService class was trying to retrieve Node Channels. The ConfigurationService calls for the query "selectNodeChannelControlLastExtractTimeSql" which does not exist in the ConfigurationServiceSqlMap. I added the query from the 3.8 branch and was able to successfully upgrade from 3.8.43 to 3.10.2. 

[SQLException_message.txt](https://github.com/JumpMind/symmetric-ds/files/3179554/SQLException_message.txt)
