### PR TITLE
Kafka timeouts now throw an exception instead of marking the batch complete

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/load/KafkaWriterFilter.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/load/KafkaWriterFilter.java
@@ -224,7 +224,7 @@ public class KafkaWriterFilter implements IDatabaseWriterFilter {
                                 }
                             }
                             Future<RecordMetadata> kafkaResult = sendKafkaMessageByObject(pojo, kafkaDataKey);
-                            kafkaResult.get();
+                            kafkaResult.get(); //Wait for Kafka to send pending messages or throw an exception
                         } else {
                             throw new RuntimeException(
                                     "Unable to find a POJO to load for AVRO based message onto Kafka for table : " + tableName);
@@ -421,6 +421,7 @@ public class KafkaWriterFilter implements IDatabaseWriterFilter {
                     }
 
                     for (Future<RecordMetadata> request : pending) {
+                        //Wait for Kafka to send pending messages or throw an exception
                         request.get();
                     }
                     kafkaDataMap = new HashMap<String, List<String>>();

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/load/KafkaWriterFilter.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/load/KafkaWriterFilter.java
@@ -145,6 +145,9 @@ public class KafkaWriterFilter implements IDatabaseWriterFilter {
             if (data.getDataEventType() == DataEventType.DELETE) {
                 rowData = data.getParsedData(CsvData.OLD_DATA);
             }
+            else if (data.getDataEventType() == DataEventType.CREATE) {
+                return false;
+            } 
 
             StringBuffer kafkaText = new StringBuffer();
 


### PR DESCRIPTION
KafkaWriterFilter will now throw an RuntimeException instead of failing silently (only with a log message) and marking the batch as complete. 

Calling get() on the Future is necessary because producer.close() doesn't do anything on timeout.

This is the result after this patch:

`[data-116] - NetworkClient - [Producer clientId=SymmetricDS] Connection to node -1 could not be established. Broker may not be available.
[data-116] - NetworkClient - [Producer clientId=SymmetricDS] Connection to node -1 could not be established. Broker may not be available.
[data-116] - NetworkClient - [Producer clientId=SymmetricDS] Connection to node -1 could not be established. Broker may not be available.
[data-116] - NetworkClient - [Producer clientId=SymmetricDS] Connection to node -1 could not be established. Broker may not be available.
[data-116] - NetworkClient - [Producer clientId=SymmetricDS] Connection to node -1 could not be established. Broker may not be available.
[data-116] - NetworkClient - [Producer clientId=SymmetricDS] Connection to node -1 could not be established. Broker may not be available.
[data-116] - NetworkClient - [Producer clientId=SymmetricDS] Connection to node -1 could not be established. Broker may not be available.
[data-116] - IDatabaseWriterFilter - Unable to write batch to Kafka batch-000-143
java.util.concurrent.ExecutionException: org.apache.kafka.common.errors.TimeoutException: Failed to update metadata after 60000 ms.
...
[data-116] - ManageIncomingBatchListener - Failed to load batch 000-143
java.lang.RuntimeException: Unable to write batch to Kafka batch-000-143
...
[data-116] - DataLoaderService - 1 data and 1 batches loaded during push request from 166:000:000.  There were 1 batches in error
[data-166] - AcknowledgeService - The outgoing batch 001-143 failed: Failed to update metadata after 60000 ms.
[data-116] - IncomingBatchService - Retrying batch 000-143


`