### PR TITLE
0004296: On MySQL, if some SymmetricDS table columns are uppercase and others are lowercase in the same table you get a null pointer

### DIFF
--- a/symmetric-db/src/main/java/org/jumpmind/db/platform/mysql/MySqlDdlBuilder.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/platform/mysql/MySqlDdlBuilder.java
@@ -253,7 +253,7 @@ public class MySqlDdlBuilder extends AbstractDdlBuilder {
         for (Iterator<Column> columnIt = changedColumns.iterator(); columnIt.hasNext();) {
             Column sourceColumn = columnIt.next();
             Column targetColumn = targetTable.findColumn(sourceColumn.getName(),
-                    delimitedIdentifierModeOn);
+                    false);
 
             processColumnChange(sourceTable, targetTable, sourceColumn, targetColumn, ddl);
         }


### PR DESCRIPTION
This was caused because the findColumn method takes a parameter that is whether to use case insensitive logic and we were passing in the setting to use delimiters.   This was false so the target column was never found.