### PR TITLE
android: Use SupportSQLite instead of the framework version

### DIFF
--- a/symmetric-android/src/main/java/org/jumpmind/symmetric/android/AndroidDatabasePlatform.java
+++ b/symmetric-android/src/main/java/org/jumpmind/symmetric/android/AndroidDatabasePlatform.java
@@ -34,17 +34,18 @@ import org.jumpmind.db.sql.ISqlTemplate;
 import org.jumpmind.db.sql.SqlTemplateSettings;
 
 import android.content.Context;
-import android.database.sqlite.SQLiteOpenHelper;
+
+import androidx.sqlite.db.SupportSQLiteOpenHelper;
 
 public class AndroidDatabasePlatform extends AbstractDatabasePlatform {
 
-    protected SQLiteOpenHelper database;
+    protected SupportSQLiteOpenHelper database;
 
     protected AndroidSqlTemplate sqlTemplate;
     
     protected Context androidContext;
 
-    public AndroidDatabasePlatform(SQLiteOpenHelper database, Context androidContext) {
+    public AndroidDatabasePlatform(SupportSQLiteOpenHelper database, Context androidContext) {
         super(new SqlTemplateSettings());
         this.database = database;
         this.androidContext = androidContext;

--- a/symmetric-android/src/main/java/org/jumpmind/symmetric/android/AndroidSqlReadCursor.java
+++ b/symmetric-android/src/main/java/org/jumpmind/symmetric/android/AndroidSqlReadCursor.java
@@ -25,7 +25,8 @@ import org.jumpmind.db.sql.ISqlRowMapper;
 import org.jumpmind.db.sql.Row;
 
 import android.database.Cursor;
-import android.database.sqlite.SQLiteDatabase;
+
+import androidx.sqlite.db.SupportSQLiteDatabase;
 
 public class AndroidSqlReadCursor<T> implements ISqlReadCursor<T> {
 
@@ -37,7 +38,7 @@ public class AndroidSqlReadCursor<T> implements ISqlReadCursor<T> {
 
     protected int rowNumber = 0;
     
-    protected SQLiteDatabase database;
+    protected SupportSQLiteDatabase database;
 
     public AndroidSqlReadCursor(String sql, String[] selectionArgs, ISqlRowMapper<T> mapper,
             AndroidSqlTemplate sqlTemplate) {
@@ -45,7 +46,7 @@ public class AndroidSqlReadCursor<T> implements ISqlReadCursor<T> {
             this.mapper = mapper;
             this.sqlTemplate = sqlTemplate;
             this.database = sqlTemplate.getDatabaseHelper().getWritableDatabase();
-            this.cursor = database.rawQuery(sql, selectionArgs);
+            this.cursor = database.query(sql, selectionArgs);
         } catch (Exception ex) {
             throw this.sqlTemplate.translate(ex);
         }

--- a/symmetric-android/src/main/java/org/jumpmind/symmetric/android/AndroidSqlTemplate.java
+++ b/symmetric-android/src/main/java/org/jumpmind/symmetric/android/AndroidSqlTemplate.java
@@ -40,20 +40,21 @@ import android.content.Context;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteConstraintException;
-import android.database.sqlite.SQLiteDatabase;
-import android.database.sqlite.SQLiteOpenHelper;
+
+import androidx.sqlite.db.SupportSQLiteDatabase;
+import androidx.sqlite.db.SupportSQLiteOpenHelper;
 
 public class AndroidSqlTemplate extends AbstractSqlTemplate {
 
-    protected SQLiteOpenHelper databaseHelper;
+    protected SupportSQLiteOpenHelper databaseHelper;
     protected Context androidContext;
 
-    public AndroidSqlTemplate(SQLiteOpenHelper databaseHelper, Context androidContext) {
+    public AndroidSqlTemplate(SupportSQLiteOpenHelper databaseHelper, Context androidContext) {
         this.databaseHelper = databaseHelper;
         this.androidContext = androidContext;
     }
 
-    public SQLiteOpenHelper getDatabaseHelper() {
+    public SupportSQLiteOpenHelper getDatabaseHelper() {
         return databaseHelper;
     }
     
@@ -75,7 +76,7 @@ public class AndroidSqlTemplate extends AbstractSqlTemplate {
     }
 
     public <T> T queryForObject(String sql, Class<T> clazz, Object... params) {
-        SQLiteDatabase database = databaseHelper.getWritableDatabase();
+        SupportSQLiteDatabase database = databaseHelper.getWritableDatabase();
         try {
             return queryForObject(database, sql, clazz, params);
         } catch (Exception ex) {
@@ -85,12 +86,12 @@ public class AndroidSqlTemplate extends AbstractSqlTemplate {
         }
     }
 
-    protected <T> T queryForObject(SQLiteDatabase database, String sql, Class<T> clazz,
+    protected <T> T queryForObject(SupportSQLiteDatabase database, String sql, Class<T> clazz,
             Object... params) {
         Cursor cursor = null;
         try {
             T result = null;
-            cursor = database.rawQuery(sql, toStringArray(params));
+            cursor = database.query(sql, toStringArray(params));
             if (cursor.moveToFirst()) {
                 result = get(cursor, clazz, 0);
             }
@@ -125,7 +126,7 @@ public class AndroidSqlTemplate extends AbstractSqlTemplate {
     public int update(final boolean autoCommit, final boolean failOnError, boolean failOnDrops,
             boolean failOnSequenceCreate, final int commitRate, final ISqlResultsListener resultsListener, final ISqlStatementSource source) {
         int row = 0;
-        SQLiteDatabase database = this.databaseHelper.getWritableDatabase();
+        SupportSQLiteDatabase database = this.databaseHelper.getWritableDatabase();
         String currentStatement = null;
         try {
             if (!autoCommit) {
@@ -172,7 +173,7 @@ public class AndroidSqlTemplate extends AbstractSqlTemplate {
     }
 
     public int update(String sql, Object[] values, int[] types) {
-        SQLiteDatabase database = this.databaseHelper.getWritableDatabase();
+        SupportSQLiteDatabase database = this.databaseHelper.getWritableDatabase();
         try {
             return update(database, sql, values, types);
         } finally {
@@ -180,7 +181,7 @@ public class AndroidSqlTemplate extends AbstractSqlTemplate {
         }
     }
 
-    protected int update(SQLiteDatabase database, String sql, Object[] values, int[] types) {
+    protected int update(SupportSQLiteDatabase database, String sql, Object[] values, int[] types) {
         try {
             if (values != null) {
                 database.execSQL(sql, toStringArray(values));
@@ -220,7 +221,7 @@ public class AndroidSqlTemplate extends AbstractSqlTemplate {
     }
 
     public void testConnection() {
-        SQLiteDatabase database = this.databaseHelper.getWritableDatabase();
+        SupportSQLiteDatabase database = this.databaseHelper.getWritableDatabase();
         close(database);
     }
 
@@ -242,7 +243,7 @@ public class AndroidSqlTemplate extends AbstractSqlTemplate {
     }
 
     public int getDatabaseMajorVersion() {
-        SQLiteDatabase database = this.databaseHelper.getWritableDatabase();
+        SupportSQLiteDatabase database = this.databaseHelper.getWritableDatabase();
         try {
             return database.getVersion();
         } catch (Exception ex) {
@@ -299,7 +300,7 @@ public class AndroidSqlTemplate extends AbstractSqlTemplate {
 
     public long insertWithGeneratedKey(String sql, String column, String sequenceName,
             Object[] params, int[] types) {
-        SQLiteDatabase database = databaseHelper.getWritableDatabase();
+        SupportSQLiteDatabase database = databaseHelper.getWritableDatabase();
         try {
             return insertWithGeneratedKey(database, sql, column, sequenceName, params, types);
         } finally {
@@ -307,7 +308,7 @@ public class AndroidSqlTemplate extends AbstractSqlTemplate {
         }
     }
 
-    protected long insertWithGeneratedKey(SQLiteDatabase database, String sql, String column,
+    protected long insertWithGeneratedKey(SupportSQLiteDatabase database, String sql, String column,
             String sequenceName, Object[] params, int[] types) {
         int updateCount = update(database, sql, params, types);
         if (updateCount > 0) {
@@ -318,7 +319,7 @@ public class AndroidSqlTemplate extends AbstractSqlTemplate {
         }
     }
 
-    protected void close(SQLiteDatabase database) {
+    protected void close(SupportSQLiteDatabase database) {
     }
 
     protected void close(Cursor cursor) {

--- a/symmetric-android/src/main/java/org/jumpmind/symmetric/android/AndroidSqlTransaction.java
+++ b/symmetric-android/src/main/java/org/jumpmind/symmetric/android/AndroidSqlTransaction.java
@@ -31,13 +31,13 @@ import org.jumpmind.db.sql.ISqlTransactionListener;
 import org.jumpmind.db.sql.Row;
 import org.jumpmind.db.sql.mapper.RowMapper;
 
-import android.database.sqlite.SQLiteDatabase;
+import androidx.sqlite.db.SupportSQLiteDatabase;
 
 public class AndroidSqlTransaction implements ISqlTransaction {
 
     protected AndroidSqlTemplate sqlTemplate;
 
-    protected SQLiteDatabase database;
+    protected SupportSQLiteDatabase database;
     
     protected boolean autoCommit = false;
 

--- a/symmetric-android/src/main/java/org/jumpmind/symmetric/android/AndroidSymmetricEngine.java
+++ b/symmetric-android/src/main/java/org/jumpmind/symmetric/android/AndroidSymmetricEngine.java
@@ -60,7 +60,8 @@ import org.jumpmind.symmetric.statistic.IStatisticManager;
 import org.jumpmind.symmetric.statistic.StatisticManager;
 
 import android.content.Context;
-import android.database.sqlite.SQLiteOpenHelper;
+
+import androidx.sqlite.db.SupportSQLiteOpenHelper;
 
 public class AndroidSymmetricEngine extends AbstractSymmetricEngine {
 
@@ -68,11 +69,11 @@ public class AndroidSymmetricEngine extends AbstractSymmetricEngine {
     protected String externalId;
     protected String nodeGroupId;
     protected Properties properties;
-    protected SQLiteOpenHelper databaseHelper;
+    protected SupportSQLiteOpenHelper databaseHelper;
     protected Context androidContext;
 
     public AndroidSymmetricEngine(String registrationUrl, String externalId, String nodeGroupId,
-            Properties properties, SQLiteOpenHelper databaseHelper, Context androidContext) {
+            Properties properties, SupportSQLiteOpenHelper databaseHelper, Context androidContext) {
         super(true);
         this.deploymentType = "android";
         this.registrationUrl = registrationUrl;

--- a/symmetric-android/src/main/java/org/jumpmind/symmetric/android/SQLiteOpenHelperRegistry.java
+++ b/symmetric-android/src/main/java/org/jumpmind/symmetric/android/SQLiteOpenHelperRegistry.java
@@ -23,17 +23,17 @@ package org.jumpmind.symmetric.android;
 import java.util.HashMap;
 import java.util.Map;
 
-import android.database.sqlite.SQLiteOpenHelper;
+import androidx.sqlite.db.SupportSQLiteOpenHelper;
 
 public class SQLiteOpenHelperRegistry {
     
-    static private Map<String, SQLiteOpenHelper> sqliteOpenHelpers = new HashMap<String, SQLiteOpenHelper>();
+    static private Map<String, SupportSQLiteOpenHelper> sqliteOpenHelpers = new HashMap<String, SupportSQLiteOpenHelper>();
     
-    public static void register(String name, SQLiteOpenHelper helper) {
+    public static void register(String name, SupportSQLiteOpenHelper helper) {
         sqliteOpenHelpers.put(name, helper);
     }
     
-    public static SQLiteOpenHelper lookup(String name) {
+    public static SupportSQLiteOpenHelper lookup(String name) {
         return sqliteOpenHelpers.get(name);
     }
 

--- a/symmetric-android/src/main/java/org/jumpmind/symmetric/android/SymmetricService.java
+++ b/symmetric-android/src/main/java/org/jumpmind/symmetric/android/SymmetricService.java
@@ -26,9 +26,10 @@ import java.util.Properties;
 
 import android.app.Service;
 import android.content.Intent;
-import android.database.sqlite.SQLiteOpenHelper;
 import android.os.IBinder;
 import android.util.Log;
+
+import androidx.sqlite.db.SupportSQLiteOpenHelper;
 
 /**
  * This is an Android Service that can be used to start SymmetricDS embedded in
@@ -64,7 +65,7 @@ public class SymmetricService extends Service {
                 Log.i(TAG, "creating engine");
                 String key = intent.getStringExtra(INTENTKEY_SQLITEOPENHELPER_REGISTRY_KEY);
                 if (key != null) {
-                    SQLiteOpenHelper databaseHelper = SQLiteOpenHelperRegistry.lookup(key);
+                    SupportSQLiteOpenHelper databaseHelper = SQLiteOpenHelperRegistry.lookup(key);
                     if (databaseHelper != null) {
                         String registrationUrl = intent.getStringExtra(INTENTKEY_REGISTRATION_URL);
                         String externalId = intent.getStringExtra(INTENTKEY_EXTERNAL_ID);


### PR DESCRIPTION
This PR replaces the framework SQLite version with the new SupportSQLite from AndroidX. (https://developer.android.com/reference/androidx/sqlite/db/SupportSQLiteDatabase)

This new implementation allows to use more SQL implementations besides the framework one, like [room](https://developer.android.com/topic/libraries/architecture/room), [sqldelight](https://github.com/cashapp/sqldelight). I can create a PR to the android client demo once this gets merged but the changes required are minimal.

