### PR TITLE
0004925: Add a new parameter that allows you to control the trigger prefix independent of the table prefix

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/common/ParameterConstants.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/common/ParameterConstants.java
@@ -320,6 +320,7 @@ final public class ParameterConstants {
     public final static String DB_JNDI_NAME = "db.jndi.name";
     public final static String DB_SPRING_BEAN_NAME = "db.spring.bean.name";
 
+    public final static String RUNTIME_CONFIG_TRIGGER_PREFIX = "sync.trigger.prefix";
     public final static String RUNTIME_CONFIG_TABLE_PREFIX = "sync.table.prefix";
 
     public final static String NODE_ID_CREATOR_SCRIPT = "node.id.creator.script";

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/TriggerRouterService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/TriggerRouterService.java
@@ -2009,7 +2009,8 @@ public class TriggerRouterService extends AbstractService implements ITriggerRou
         }
 
         if (StringUtils.isBlank(triggerName)) {
-            String triggerPrefix1 = tablePrefix + "_";
+            String triggerPrefix = parameterService.getString(ParameterConstants.RUNTIME_CONFIG_TRIGGER_PREFIX, tablePrefix);
+            String triggerPrefix1 = triggerPrefix + "_";
             String triggerSuffix1 = "on_" + dml.getCode().toLowerCase() + "_for_";
             String triggerSuffix2 = FormatUtils.replaceCharsToShortenName(trigger.getTriggerId());
             if (trigger.isSourceTableNameWildCarded()) {

--- a/symmetric-core/src/main/resources/symmetric-default.properties
+++ b/symmetric-core/src/main/resources/symmetric-default.properties
@@ -285,6 +285,11 @@ target.log.slow.sql.threshold.millis=
 # Tags: database
 target.log.sql.parameters.inline=
 
+# When symmetric triggers are created and accessed, this is the prefix to use for the tables.
+# If this is not set, it will use the sync.table.prefix as the trigger prefix
+# Tags: database
+sync.trigger.prefix=
+
 # When symmetric tables are created and accessed, this is the prefix to use for the tables.
 #
 # Tags: database


### PR DESCRIPTION
Add a new parameter that allows you to control the trigger prefix independent of the table prefix