### PR TITLE
5018: Add permission check for database altering before allowing user to install SQL Server node with log-based replication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 /.DS_Store
 /.project
 *.iml
-
+.clover/*
 /.idea/*
 *.ipr
 *.iws

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/mssql/MsSql2008DatabasePlatform.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/mssql/MsSql2008DatabasePlatform.java
@@ -72,8 +72,22 @@ public class MsSql2008DatabasePlatform extends MsSql2005DatabasePlatform {
     @Override
     protected PermissionResult getLogMinePermission() {
         final PermissionResult result = new PermissionResult(PermissionType.LOG_MINE, "");
-        result.setStatus(Status.PASS);
+        try {
+            if (getSqlTemplate().queryForInt("SELECT COUNT(*) FROM fn_my_permissions(NULL, 'SERVER') WHERE permission_name='ALTER'") > 0) {
+                result.setStatus(Status.PASS);
+            } else {
+                result.setStatus(Status.FAIL);
+                result.setSolution("Grant alter any database to this user."); 
+            }
+            
+        } catch (Exception e) {
+            result.setSolution("Error occurred checking user permissions");
+            result.setException(e);
+        }
         return result;
     }
+
+    
+    
 
 }


### PR DESCRIPTION
Refer to [this pro PR](https://github.com/JumpMind/symmetric-pro/pull/198). In order for a user to set snapshot isolation level on a database so that change tracking works properly,  they must have the ALTER ANY DATABASE permission in SQL server. We now check for the ALTER ANY DATABASE PERMISSION within the getLogMinePermission method. 