### PR TITLE
Fix initial load inseting create table data events under phantom channel id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 /.DS_Store
 /.project
 *.iml
-
+.clover/*
 /.idea/*
 *.ipr
 *.iws

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/DataService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/DataService.java
@@ -1299,7 +1299,7 @@ public class DataService extends AbstractService implements IDataService {
                     if (currentRequest != null && currentRequest.isCreateTable()
                             && engine.getGroupletService().isTargetEnabled(triggerRouter,
                                     targetNode)) {
-                        insertCreateEvent(transaction, targetNode, triggerHistory, triggerRouter.getRouter().getRouterId(), true,
+                        insertCreateEvent(transaction, targetNode, triggerHistory, triggerRouter.getTrigger().getReloadChannelId(), true,
                                 loadId, createBy, false, false, false);
                         createEventsSent++;
                         if (!transactional) {

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/mssql/MsSql2008DatabasePlatform.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/mssql/MsSql2008DatabasePlatform.java
@@ -72,8 +72,22 @@ public class MsSql2008DatabasePlatform extends MsSql2005DatabasePlatform {
     @Override
     protected PermissionResult getLogMinePermission() {
         final PermissionResult result = new PermissionResult(PermissionType.LOG_MINE, "");
-        result.setStatus(Status.PASS);
+        try {
+            if (getSqlTemplate().queryForInt("SELECT COUNT(*) FROM fn_my_permissions(NULL, 'SERVER') WHERE permission_name='ALTER'") > 0) {
+                result.setStatus(Status.PASS);
+            } else {
+                result.setStatus(Status.FAIL);
+                result.setSolution("Grant alter any database to this user."); 
+            }
+            
+        } catch (Exception e) {
+            result.setSolution("Error occurred checking user permissions");
+            result.setException(e);
+        }
         return result;
     }
+
+    
+    
 
 }


### PR DESCRIPTION
A small typo in `DataService` led to "create table" data events being stored under a phantom channel ID (actually the router ID of the `TriggerRouter`). This led to table creation data being purged since the phantom channel was marked as stranded. Correct this typo and use the `TriggerRouter`'s reload channel ID instead. 