### PR TITLE
fix inserting create table events under phantom channel in data service

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/DataService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/DataService.java
@@ -1299,7 +1299,7 @@ public class DataService extends AbstractService implements IDataService {
                     if (currentRequest != null && currentRequest.isCreateTable()
                             && engine.getGroupletService().isTargetEnabled(triggerRouter,
                                     targetNode)) {
-                        insertCreateEvent(transaction, targetNode, triggerHistory, triggerRouter.getRouter().getRouterId(), true,
+                        insertCreateEvent(transaction, targetNode, triggerHistory, triggerRouter.getTrigger().getReloadChannelId(), true,
                                 loadId, createBy, false, false, false);
                         createEventsSent++;
                         if (!transactional) {


### PR DESCRIPTION
A small typo in `DataService` led to "create table" data events being stored under a phantom channel ID (actually the router ID of the `TriggerRouter`). This led to table creation data being purged since the phantom channel was marked as stranded. Correct this typo and use the `TriggerRouter`'s reload channel ID instead. 