### PR TITLE
Fix: V14 label tweak

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,7 +23,7 @@ steps:
     gradleWrapperFile: 'symmetric-assemble/gradlew'
     gradleOptions: '-Xmx3072m'
     javaHomeOption: 'JDKVersion'
-    jdkVersionOption: '1.11'
+    jdkVersionOption: '1.8'
     jdkArchitectureOption: 'x64'
     publishJUnitResults: true
     testResultsFiles: '**/TEST-*.xml'

--- a/symmetric-sqlexplorer/src/main/java/org/jumpmind/vaadin/ui/common/Label.java
+++ b/symmetric-sqlexplorer/src/main/java/org/jumpmind/vaadin/ui/common/Label.java
@@ -28,81 +28,81 @@ import com.vaadin.flow.component.icon.VaadinIcon;
 
 public class Label extends Span {
 
-	private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
 
-	private Html html;
+    private Html html;
 
-	private Component icon;
+    private Component icon;
 
-	public Label() {
-		super();
-	}
+    public Label() {
+        super();
+    }
 
-	public Label(String text) {
-		html = new Html("<div>" + text + "</div>");
-		getElement().getStyle().set("display", "flex");
-		getElement().getStyle().set("margin", "auto");
-		add(html);
-	}
+    public Label(String text) {
+        html = new Html("<div>" + text + "</div>");
+        getElement().getStyle().set("display", "flex");
+        getElement().getStyle().set("margin", "auto");
+        add(html);
+    }
 
-	public Label(VaadinIcon icon, String text) {
-		this(new Icon(icon), text);
+    public Label(VaadinIcon icon, String text) {
+        this(new Icon(icon), text);
 
-	}
+    }
 
-	public Label(String text, VaadinIcon icon) {
-		this(text, new Icon(icon));
-	}
+    public Label(String text, VaadinIcon icon) {
+        this(text, new Icon(icon));
+    }
 
-	public Label(Icon icon, String text) {
-		this(text);
-		setRightIcon(icon);
-	}
+    public Label(Icon icon, String text) {
+        this(text);
+        setRightIcon(icon);
+    }
 
-	public Label(String text, Icon icon) {
-		this(text);
-		setLeftIcon(icon);
-	}
+    public Label(String text, Icon icon) {
+        this(text);
+        setLeftIcon(icon);
+    }
 
-	public Label(Component component) {
-		setText(component.getElement().getOuterHTML());
-	}
+    public Label(Component component) {
+        setText(component.getElement().getOuterHTML());
+    }
 
-	public String getText() {
-		return getElement().getProperty("innerHTML");
-	}
+    public String getText() {
+        return getElement().getProperty("innerHTML");
+    }
 
-	public void setText(String text) {
-		if (html != null) {
-			remove(html);
-		}
-		html = new Html("<div>" + text + "</div>");
-		add(html);
-	}
+    public void setText(String text) {
+        if (html != null) {
+            remove(html);
+        }
+        html = new Html("<div>" + text + "</div>");
+        add(html);
+    }
 
-	public void setRightIcon(VaadinIcon icon) {
-		setRightIcon(new Icon(icon));
-	}
+    public void setRightIcon(VaadinIcon icon) {
+        setRightIcon(new Icon(icon));
+    }
 
-	public void setLeftIcon(VaadinIcon icon) {
-		setLeftIcon(new Icon(icon));
-	}
+    public void setLeftIcon(VaadinIcon icon) {
+        setLeftIcon(new Icon(icon));
+    }
 
-	public void setLeftIcon(Component icon) {
-		if (this.icon != null) {
-			remove(this.icon);
-		}
-		icon.getElement().getStyle().set("align-self", "flex-start");
-		this.icon = icon;
-		add(icon);
-	}
+    public void setLeftIcon(Component icon) {
+        if (this.icon != null) {
+            remove(this.icon);
+        }
+        icon.getElement().getStyle().set("align-self", "flex-start");
+        this.icon = icon;
+        add(icon);
+    }
 
-	public void setRightIcon(Component icon) {
-		if (this.icon != null) {
-			remove(this.icon);
-		}
-		icon.getElement().getStyle().set("align-self", "flex-end");
-		this.icon = icon;
-		add(icon);
-	}
+    public void setRightIcon(Component icon) {
+        if (this.icon != null) {
+            remove(this.icon);
+        }
+        icon.getElement().getStyle().set("align-self", "flex-end");
+        this.icon = icon;
+        add(icon);
+    }
 }

--- a/symmetric-sqlexplorer/src/main/java/org/jumpmind/vaadin/ui/common/Label.java
+++ b/symmetric-sqlexplorer/src/main/java/org/jumpmind/vaadin/ui/common/Label.java
@@ -56,16 +56,12 @@ public class Label extends Span {
     
     public Label(Icon icon, String text) {
         this(text);
-        this.icon = icon;
-        this.icon.getElement().getStyle().set("float", "right");
-        configureIcon(this.icon);
+		setRightIcon(icon);
     }
     
     public Label(String text, Icon icon) {
         this(text);
-        this.icon = icon;
-        this.icon.getElement().getStyle().set("float", "left");
-        configureIcon(this.icon);
+		setLeftIcon(icon);
     }
     
     public Label(Component component) {
@@ -98,7 +94,7 @@ public class Label extends Span {
         }
         icon.getElement().getStyle().set("align-self", "flex-start");
         this.icon = icon;
-        configureIcon(this.icon);
+		add(icon);
     }
 
     public void setRightIcon(Component icon) {
@@ -107,11 +103,6 @@ public class Label extends Span {
         }
         icon.getElement().getStyle().set("align-self", "flex-end");
         this.icon = icon;
-        configureIcon(this.icon);
+		add(icon);
     }
-    
-    private void configureIcon(Component icon) {
-        add(icon);
-    }
-
 }

--- a/symmetric-sqlexplorer/src/main/java/org/jumpmind/vaadin/ui/common/Label.java
+++ b/symmetric-sqlexplorer/src/main/java/org/jumpmind/vaadin/ui/common/Label.java
@@ -21,6 +21,7 @@
 package org.jumpmind.vaadin.ui.common;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Html;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.icon.Icon;
 import com.vaadin.flow.component.icon.VaadinIcon;
@@ -29,97 +30,88 @@ public class Label extends Span {
     
     private static final long serialVersionUID = 1L;
     
-    private String text;
+    private Html text;
     
-    private Component leftIcon;
-    
-    private Component rightIcon;
+    private Component icon;
 
     public Label() {
         super();
     }
     
     public Label(String text) {
-        setText(text);
+        this.text = new Html("<div>"+text+"</div>");
+        getElement().getStyle().set("display-items", "center");
+        add(this.text);
     }
     
     public Label(VaadinIcon icon, String text) {
-        setText(text);
-        setLeftIcon(icon);
+        this(new Icon(icon), text);
+        
     }
     
     public Label(String text, VaadinIcon icon) {
-        setText(text);
-        setRightIcon(icon);
+        this(text, new Icon(icon));
     }
     
     public Label(Icon icon, String text) {
-        setText(text);
-        setLeftIcon(icon);
+        this(text);
+        this.icon = icon;
+        this.icon.getElement().getStyle().set("float", "right");
+        configureIcon(this.icon);
     }
     
     public Label(String text, Icon icon) {
-        setText(text);
-        setRightIcon(icon);
+        this(text);
+        this.icon = icon;
+        this.icon.getElement().getStyle().set("float", "left");
+        configureIcon(this.icon);
     }
     
     public Label(Component component) {
         setText(component.getElement().getOuterHTML());
     }
     
-    public void setLeftIcon(VaadinIcon icon) {
-        leftIcon = new Icon(icon);
-        configureIcon(leftIcon);
-        updateLabel();
-    }
-    
-    public void setRightIcon(VaadinIcon icon) {
-        rightIcon = new Icon(icon);
-        configureIcon(rightIcon);
-        updateLabel();
-    }
-    
-    public void setLeftIcon(Component icon) {
-        leftIcon = icon;
-        configureIcon(leftIcon);
-        updateLabel();
-    }
-    
-    public void setRightIcon(Component icon) {
-        rightIcon = icon;
-        configureIcon(rightIcon);
-        updateLabel();
-    }
-    
-    @Override
     public String getText() {
         return getElement().getProperty("innerHTML");
     }
     
-    @Override
     public void setText(String text) {
-        this.text = text;
-        updateLabel();
+        if (this.text != null) {
+            remove(this.text);
+        }
+        this.text = new Html("<div>"+text+"</div>");
+        add(this.text);
+    }
+
+    public void setRightIcon(VaadinIcon icon) {
+        setRightIcon(new Icon(icon));
     }
     
-    @Override
-    public void removeAll() {
-        super.removeAll();
-        text = null;
-        leftIcon = null;
-        rightIcon = null;
+    public void setLeftIcon(VaadinIcon icon) {
+        setLeftIcon(new Icon(icon));
     }
     
-    private void updateLabel() {
-        getElement().setProperty("innerHTML", (leftIcon != null ? leftIcon.getElement().getOuterHTML() + " " : "")
-                + (text != null ? text : "") + (rightIcon != null ? " " + rightIcon.getElement().getOuterHTML() : ""));
+    public void setLeftIcon(Component icon) {
+        if (this.icon != null) {
+            remove(this.icon);
+        }
+        icon.getElement().getStyle().set("align-self", "flex-start");
+        this.icon = icon;
+        configureIcon(this.icon);
+    }
+
+    public void setRightIcon(Component icon) {
+        if (this.icon != null) {
+            remove(this.icon);
+        }
+        icon.getElement().getStyle().set("align-self", "flex-end");
+        this.icon = icon;
+        configureIcon(this.icon);
     }
     
     private void configureIcon(Component icon) {
         icon.getElement().getStyle().set("margin-top", "-4px");
-        if (icon != null && icon instanceof Icon) {
-            ((Icon) icon).setSize("1em");
-        }
+        add(icon);
     }
 
 }

--- a/symmetric-sqlexplorer/src/main/java/org/jumpmind/vaadin/ui/common/Label.java
+++ b/symmetric-sqlexplorer/src/main/java/org/jumpmind/vaadin/ui/common/Label.java
@@ -27,82 +27,82 @@ import com.vaadin.flow.component.icon.Icon;
 import com.vaadin.flow.component.icon.VaadinIcon;
 
 public class Label extends Span {
-    
-    private static final long serialVersionUID = 1L;
-    
-    private Html text;
-    
-    private Component icon;
 
-    public Label() {
-        super();
-    }
-    
-    public Label(String text) {
-        this.text = new Html("<div>"+text+"</div>");
-        getElement().getStyle().set("display", "flex");
-        getElement().getStyle().set("margin", "auto");
-        add(this.text);
-    }
-    
-    public Label(VaadinIcon icon, String text) {
-        this(new Icon(icon), text);
-        
-    }
-    
-    public Label(String text, VaadinIcon icon) {
-        this(text, new Icon(icon));
-    }
-    
-    public Label(Icon icon, String text) {
-        this(text);
+	private static final long serialVersionUID = 1L;
+
+	private Html html;
+
+	private Component icon;
+
+	public Label() {
+		super();
+	}
+
+	public Label(String text) {
+		html = new Html("<div>" + text + "</div>");
+		getElement().getStyle().set("display", "flex");
+		getElement().getStyle().set("margin", "auto");
+		add(html);
+	}
+
+	public Label(VaadinIcon icon, String text) {
+		this(new Icon(icon), text);
+
+	}
+
+	public Label(String text, VaadinIcon icon) {
+		this(text, new Icon(icon));
+	}
+
+	public Label(Icon icon, String text) {
+		this(text);
 		setRightIcon(icon);
-    }
-    
-    public Label(String text, Icon icon) {
-        this(text);
+	}
+
+	public Label(String text, Icon icon) {
+		this(text);
 		setLeftIcon(icon);
-    }
-    
-    public Label(Component component) {
-        setText(component.getElement().getOuterHTML());
-    }
-    
-    public String getText() {
-        return getElement().getProperty("innerHTML");
-    }
-    
-    public void setText(String text) {
-        if (this.text != null) {
-            remove(this.text);
-        }
-        this.text = new Html("<div>"+text+"</div>");
-        add(this.text);
-    }
+	}
 
-    public void setRightIcon(VaadinIcon icon) {
-        setRightIcon(new Icon(icon));
-    }
-    
-    public void setLeftIcon(VaadinIcon icon) {
-        setLeftIcon(new Icon(icon));
-    }
-    
-    public void setLeftIcon(Component icon) {
-        if (this.icon != null) {
-            remove(this.icon);
-        }
-        icon.getElement().getStyle().set("align-self", "flex-start");
-        this.icon = icon;
-		add(icon);
-    }
+	public Label(Component component) {
+		setText(component.getElement().getOuterHTML());
+	}
 
-    public void setRightIcon(Component icon) {
-        if (this.icon != null) {
-            remove(this.icon);
-        }
-        icon.getElement().getStyle().set("align-self", "flex-end");
-        this.icon = icon;
+	public String getText() {
+		return getElement().getProperty("innerHTML");
+	}
+
+	public void setText(String text) {
+		if (html != null) {
+			remove(html);
+		}
+		html = new Html("<div>" + text + "</div>");
+		add(html);
+	}
+
+	public void setRightIcon(VaadinIcon icon) {
+		setRightIcon(new Icon(icon));
+	}
+
+	public void setLeftIcon(VaadinIcon icon) {
+		setLeftIcon(new Icon(icon));
+	}
+
+	public void setLeftIcon(Component icon) {
+		if (this.icon != null) {
+			remove(this.icon);
+		}
+		icon.getElement().getStyle().set("align-self", "flex-start");
+		this.icon = icon;
 		add(icon);
-    }
+	}
+
+	public void setRightIcon(Component icon) {
+		if (this.icon != null) {
+			remove(this.icon);
+		}
+		icon.getElement().getStyle().set("align-self", "flex-end");
+		this.icon = icon;
+		add(icon);
+	}
 }

--- a/symmetric-sqlexplorer/src/main/java/org/jumpmind/vaadin/ui/common/Label.java
+++ b/symmetric-sqlexplorer/src/main/java/org/jumpmind/vaadin/ui/common/Label.java
@@ -40,7 +40,7 @@ public class Label extends Span {
     
     public Label(String text) {
         this.text = new Html("<div>"+text+"</div>");
-        getElement().getStyle().set("display-items", "center");
+        getElement().getStyle().set("display", "flex");
         add(this.text);
     }
     
@@ -110,7 +110,6 @@ public class Label extends Span {
     }
     
     private void configureIcon(Component icon) {
-        icon.getElement().getStyle().set("margin-top", "-4px");
         add(icon);
     }
 

--- a/symmetric-sqlexplorer/src/main/java/org/jumpmind/vaadin/ui/common/Label.java
+++ b/symmetric-sqlexplorer/src/main/java/org/jumpmind/vaadin/ui/common/Label.java
@@ -41,6 +41,7 @@ public class Label extends Span {
     public Label(String text) {
         this.text = new Html("<div>"+text+"</div>");
         getElement().getStyle().set("display", "flex");
+        getElement().getStyle().set("margin", "auto");
         add(this.text);
     }
     


### PR DESCRIPTION
Configure labels to use Vaadin components instead of innerHTML. This allows us to avoid re-rendering the entire span when right icon, left icon, or text is set. Also resolves the bugs with Label being refreshed and removed on the dashboards.  Label is now a Span with `display: flex` property set. 