### PR TITLE
fix: 0005067, mssql stored procedures with parentheses won't replicate

### DIFF
--- a/symmetric-client/src/main/java/org/jumpmind/symmetric/db/mssql/MsSqlTriggerTemplate.java
+++ b/symmetric-client/src/main/java/org/jumpmind/symmetric/db/mssql/MsSqlTriggerTemplate.java
@@ -369,8 +369,7 @@ getCreateTriggerString() + " $(triggerName) on database\n" +
 "  values ('$(prefixName)_node', '" + DataEventType.SQL.getCode() + "', @histId,\n" +
 " '\"delimiter " + delimiter + ";' + CHAR(13) + char(10) + replace(replace(@data.value('(/EVENT_INSTANCE/TSQLCommand/CommandText)[1]', 'nvarchar(max)'),'\\','\\\\'),'\"','\\\"') + '\",ddl',\n" +
 "  'config', dbo.$(prefixName)_node_disabled(), current_timestamp)\n" +
-"end\n" +   
-"---- go");
+"end\n" + "---- go");
         
         sqlTemplates.put("initialLoadSqlTemplate" ,
 "select $(columns) from $(schemaName)$(tableName) t where $(whereClause) " );

--- a/symmetric-client/src/main/java/org/jumpmind/symmetric/db/mssql/MsSqlTriggerTemplate.java
+++ b/symmetric-client/src/main/java/org/jumpmind/symmetric/db/mssql/MsSqlTriggerTemplate.java
@@ -42,11 +42,13 @@ import org.jumpmind.util.FormatUtils;
 public class MsSqlTriggerTemplate extends AbstractTriggerTemplate {
 
     boolean castToNVARCHAR;
+    String delimiter;
 
     public MsSqlTriggerTemplate(ISymmetricDialect symmetricDialect) {
         super(symmetricDialect);
 
         castToNVARCHAR = symmetricDialect.getParameterService().is(ParameterConstants.MSSQL_USE_NTYPES_FOR_SYNC);
+        delimiter = symmetricDialect.getParameterService().getString(ParameterConstants.TRIGGER_CAPTURE_DDL_DELIMITER, "$");
         
         String triggerExecuteAs = symmetricDialect.getParameterService().getString(ParameterConstants.MSSQL_TRIGGER_EXECUTE_AS, "self");
         
@@ -365,9 +367,9 @@ getCreateTriggerString() + " $(triggerName) on database\n" +
 "  insert into " + defaultCatalog + "$(defaultSchema)$(prefixName)_data\n" +
 "  (table_name, event_type, trigger_hist_id, row_data, channel_id, source_node_id, create_time)\n" +
 "  values ('$(prefixName)_node', '" + DataEventType.SQL.getCode() + "', @histId,\n" +
-"  '\"' + replace(replace(@data.value('(/EVENT_INSTANCE/TSQLCommand/CommandText)[1]', 'nvarchar(max)'),'\\','\\\\'),'\"','\\\"') + '\",ddl',\n" +
+" '\"delimiter " + delimiter + ";' + CHAR(13) + char(10) + replace(replace(@data.value('(/EVENT_INSTANCE/TSQLCommand/CommandText)[1]', 'nvarchar(max)'),'\\','\\\\'),'\"','\\\"') + '\",ddl',\n" +
 "  'config', dbo.$(prefixName)_node_disabled(), current_timestamp)\n" +
-"end\n" +
+"end\n" +   
 "---- go");
         
         sqlTemplates.put("initialLoadSqlTemplate" ,

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/common/ParameterConstants.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/common/ParameterConstants.java
@@ -313,6 +313,7 @@ final public class ParameterConstants {
     public final static String TRIGGER_UPDATE_CAPTURE_CHANGED_DATA_ONLY = "trigger.update.capture.changed.data.only.enabled";
     public final static String TRIGGER_CREATE_BEFORE_INITIAL_LOAD = "trigger.create.before.initial.load.enabled";
     public final static String TRIGGER_CAPTURE_DDL_CHANGES = "trigger.capture.ddl.changes";
+    public final static String TRIGGER_CAPTURE_DDL_DELIMITER = "trigger.capture.ddl.delimiter";
 
     public final static String DB_METADATA_IGNORE_CASE = "db.metadata.ignore.case";
     public final static String DB_NATIVE_EXTRACTOR = "db.native.extractor";

--- a/symmetric-core/src/main/resources/symmetric-default.properties
+++ b/symmetric-core/src/main/resources/symmetric-default.properties
@@ -2200,6 +2200,12 @@ trigger.create.before.initial.load.enabled=true
 # Type: boolean
 trigger.capture.ddl.changes=false
 
+# The delimiter to use when capturing changes from a DDL trigger. MS SQL-Server only.
+# See: trigger.capture.ddl.changes
+# DatabaseOverridable: true
+# Tags: other
+trigger.capture.ddl.delimiter=$
+
 # Enable or disabled use of create or replace syntax on Oracle and MS-SQL 2016 and newer.
 #
 # Tags: other

--- a/symmetric-io/src/main/java/org/jumpmind/symmetric/io/data/writer/DefaultDatabaseWriter.java
+++ b/symmetric-io/src/main/java/org/jumpmind/symmetric/io/data/writer/DefaultDatabaseWriter.java
@@ -687,7 +687,7 @@ public class DefaultDatabaseWriter extends AbstractDatabaseWriter {
                         if (log.isDebugEnabled()) {
                             log.debug("About to run: {}", sql);
                         }
-                        count += newTransaction.execute(sql);
+                        count += newTransaction.prepareAndExecute(sql);
                         if (log.isDebugEnabled()) {
                             log.debug("{} rows updated when running: {}", count, sql);
                         }

--- a/symmetric-io/src/main/java/org/jumpmind/symmetric/io/data/writer/DefaultDatabaseWriter.java
+++ b/symmetric-io/src/main/java/org/jumpmind/symmetric/io/data/writer/DefaultDatabaseWriter.java
@@ -687,7 +687,7 @@ public class DefaultDatabaseWriter extends AbstractDatabaseWriter {
                         if (log.isDebugEnabled()) {
                             log.debug("About to run: {}", sql);
                         }
-                        count += newTransaction.prepareAndExecute(sql);
+                        count += newTransaction.execute(sql);
                         if (log.isDebugEnabled()) {
                             log.debug("{} rows updated when running: {}", count, sql);
                         }


### PR DESCRIPTION
- mssql procedures with parentheses wouldn't replicate before, i provided code for reproducing this issue in the [issue tracker](https://www.symmetricds.org/issues/view.php?id=5067)
- shout out to @jkarvanen for providing his workaround in MsSqlTriggerTemplate
- i modified this code by adding a parameter that allows users to set their own delimiter just in case they were already using `$` as a delimiter. it defaults to '$'