### PR TITLE
fix: 0004658 problem with postgressql varchar types

### DIFF
--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/postgresql/PostgreSqlDdlReader.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/postgresql/PostgreSqlDdlReader.java
@@ -164,7 +164,9 @@ public class PostgreSqlDdlReader extends AbstractJdbcDdlReader {
                 if (column.getMappedTypeCode() == Types.VARCHAR) {
                     if(column.getJdbcTypeName().equalsIgnoreCase("TEXT")) {
                         column.setMappedTypeCode(Types.LONGVARCHAR);
-                        column.setSize(null);
+                    }
+                    if (platformColumn != null) {
+                        platformColumn.setSize(-1);
                     }
                 } else if (column.getMappedTypeCode() == Types.BINARY) {
                     column.setMappedTypeCode(Types.LONGVARBINARY);

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/postgresql/PostgreSqlDdlReader.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/postgresql/PostgreSqlDdlReader.java
@@ -164,6 +164,7 @@ public class PostgreSqlDdlReader extends AbstractJdbcDdlReader {
                 if (column.getMappedTypeCode() == Types.VARCHAR) {
                     if(column.getJdbcTypeName().equalsIgnoreCase("TEXT")) {
                         column.setMappedTypeCode(Types.LONGVARCHAR);
+                        column.setSize(null);
                     }
                     if (platformColumn != null) {
                         platformColumn.setSize(-1);


### PR DESCRIPTION
- the linked [issue tracker issue](https://www.symmetricds.org/issues/view.php?id=4658) involves a problem with postgres table creation
- i reproduced the issue on 3.12 with two postgres-13.1-alpine containers
- we were inferring the platform column size from the column size (`INT_MAX`), but postgres only supports size 10,485,760
- i made a change in `PostgresSqlDdlReader` to set the platform column size to -1 when we hit this case
- this makes it so that the `size` parameter is left out of the platform column xml specification
- i tried an initial load again and the issue was resolved