### PR TITLE
fix: 0005059 mariadb/mysql large mediumtext value problems

### DIFF
--- a/symmetric-client/src/main/java/org/jumpmind/symmetric/db/mysql/MySqlTriggerTemplate.java
+++ b/symmetric-client/src/main/java/org/jumpmind/symmetric/db/mysql/MySqlTriggerTemplate.java
@@ -87,8 +87,8 @@ public class MySqlTriggerTemplate extends AbstractTriggerTemplate {
         sqlTemplates.put("updateTriggerTemplate" ,
 "create trigger $(triggerName) after update on $(schemaName)$(tableName)                                                                                                                                \n" +
 "                                for each row begin                                                                                                                                                     \n" +
-"                                  DECLARE var_row_data mediumtext character set " + characterSet + ";\n" +
-"                                  DECLARE var_old_data mediumtext character set " + characterSet + ";\n" +
+"                                  DECLARE var_row_data longtext character set " + characterSet + ";\n" +
+"                                  DECLARE var_old_data longtext character set " + characterSet + ";\n" +
 "                                  $(custom_before_update_text) \n" +
 "                                  if $(syncOnUpdateCondition) and $(syncOnIncomingBatchCondition) then                                                                                                 \n" +
 "                                   set var_row_data = concat($(columns));                                                                                                                              \n" +


### PR DESCRIPTION
- the [issue in the tracker] reported problems replicating a column of type mediumtext on the mariadb/mysql dialect
- i attempted to reproduce this issue and had no problem with initial load/insert
- eric told me to try updates and they would not insert due to one of our triggers blocking, reporting `ERROR 1406 (22001): Data too long for column 'var_row_data' at row 1` 
- i changed this column to a longtext and reran the updates. they are now allowed to go through on MariaDB without error