### PR TITLE
0002233: fix handling of ignorecolumnexception for bsh transforms imported as spring beans

### DIFF
--- a/symmetric-io/build.gradle
+++ b/symmetric-io/build.gradle
@@ -8,7 +8,7 @@ apply from: symAssembleDir + '/common.gradle'
         compile "org.apache-extras.beanshell:bsh:$bshVersion"
         compile "net.sourceforge.jeval:jeval:0.9.4"
         compile "com.google.code.gson:gson:$gsonVersion"
-	    compile "org.springframework:spring-core:$springVersion"
+        compile "org.springframework:spring-core:$springVersion"
         compileOnly ("com.datastax.cassandra:cassandra-driver-core:3.1.4") {
             exclude group: 'org.slf4j'
             exclude group: 'com.google.guava'

--- a/symmetric-io/build.gradle
+++ b/symmetric-io/build.gradle
@@ -8,7 +8,7 @@ apply from: symAssembleDir + '/common.gradle'
         compile "org.apache-extras.beanshell:bsh:$bshVersion"
         compile "net.sourceforge.jeval:jeval:0.9.4"
         compile "com.google.code.gson:gson:$gsonVersion"
-        
+	    compile "org.springframework:spring-core:$springVersion"
         compileOnly ("com.datastax.cassandra:cassandra-driver-core:3.1.4") {
             exclude group: 'org.slf4j'
             exclude group: 'com.google.guava'

--- a/symmetric-io/src/main/java/org/jumpmind/symmetric/io/data/transform/IColumnTransform.java
+++ b/symmetric-io/src/main/java/org/jumpmind/symmetric/io/data/transform/IColumnTransform.java
@@ -26,6 +26,8 @@ import org.jumpmind.db.platform.IDatabasePlatform;
 import org.jumpmind.extension.IExtensionPoint;
 import org.jumpmind.symmetric.io.data.DataContext;
 
+import bsh.TargetError;
+
 /**
  * An extension point that can be implemented to provide custom transformation
  * logic. Column transforms are stateless and so should not keep references to
@@ -35,7 +37,7 @@ public interface IColumnTransform<T> extends IExtensionPoint {
 
     public T transform(IDatabasePlatform platform, DataContext context, TransformColumn column,
             TransformedData data, Map<String, String> sourceValues, String newValue, String oldValue)
-            throws IgnoreColumnException, IgnoreRowException;
+            throws IgnoreColumnException, IgnoreRowException, TargetError;
 
     public boolean isExtractColumnTransform();
 

--- a/symmetric-io/src/main/java/org/jumpmind/symmetric/io/data/transform/IColumnTransform.java
+++ b/symmetric-io/src/main/java/org/jumpmind/symmetric/io/data/transform/IColumnTransform.java
@@ -26,8 +26,6 @@ import org.jumpmind.db.platform.IDatabasePlatform;
 import org.jumpmind.extension.IExtensionPoint;
 import org.jumpmind.symmetric.io.data.DataContext;
 
-import bsh.TargetError;
-
 /**
  * An extension point that can be implemented to provide custom transformation
  * logic. Column transforms are stateless and so should not keep references to
@@ -37,7 +35,7 @@ public interface IColumnTransform<T> extends IExtensionPoint {
 
     public T transform(IDatabasePlatform platform, DataContext context, TransformColumn column,
             TransformedData data, Map<String, String> sourceValues, String newValue, String oldValue)
-            throws IgnoreColumnException, IgnoreRowException, TargetError;
+            throws IgnoreColumnException, IgnoreRowException;
 
     public boolean isExtractColumnTransform();
 

--- a/symmetric-io/src/main/java/org/jumpmind/symmetric/io/data/writer/TransformWriter.java
+++ b/symmetric-io/src/main/java/org/jumpmind/symmetric/io/data/writer/TransformWriter.java
@@ -49,6 +49,7 @@ import org.jumpmind.symmetric.io.data.transform.TransformedData;
 import org.jumpmind.util.Statistics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.core.NestedRuntimeException;
 
 import bsh.TargetError;
 
@@ -456,6 +457,15 @@ public class TransformWriter extends NestedDataWriter {
             		throw (IgnoreColumnException) ex;
             	} else if (ex instanceof IgnoreRowException) {
             		throw (IgnoreRowException) ex;
+            	}
+            } catch (NestedRuntimeException nestedRuntimeException) {
+            	Throwable rootCause = nestedRuntimeException.getRootCause();
+            	if (rootCause instanceof IgnoreColumnException) {
+            		throw (IgnoreColumnException) rootCause;
+            	} else if (rootCause instanceof IgnoreRowException) {
+            		throw (IgnoreRowException) rootCause;
+            	} else {
+            		throw nestedRuntimeException;
             	}
             } catch (RuntimeException ex) {
                 log.warn("Column transform failed {}.{} ({}) for source values of {}", new Object[] { transformColumn.getTransformId(), transformColumn.getTargetColumnName(), transformColumn.getIncludeOn().name(), sourceValues.toString() });

--- a/symmetric-io/src/main/java/org/jumpmind/symmetric/io/data/writer/TransformWriter.java
+++ b/symmetric-io/src/main/java/org/jumpmind/symmetric/io/data/writer/TransformWriter.java
@@ -450,14 +450,14 @@ public class TransformWriter extends NestedDataWriter {
                 returnValue = transform.transform(platform, context, transformColumn, data,
                         sourceValues, value, oldValue);
             } catch (NestedRuntimeException nestedRuntimeException) {
-            	Throwable rootCause = nestedRuntimeException.getRootCause();
-            	if (rootCause instanceof IgnoreColumnException) {
-            		throw (IgnoreColumnException) rootCause;
-            	} else if (rootCause instanceof IgnoreRowException) {
-            		throw (IgnoreRowException) rootCause;
-            	} else {
-            		throw nestedRuntimeException;
-            	}
+                Throwable rootCause = nestedRuntimeException.getRootCause();
+                if (rootCause instanceof IgnoreColumnException) {
+                    throw (IgnoreColumnException) rootCause;
+                } else if (rootCause instanceof IgnoreRowException) {
+                    throw (IgnoreRowException) rootCause;
+                } else {
+                    throw nestedRuntimeException;
+                }
             } catch (RuntimeException ex) {
                 log.warn("Column transform failed {}.{} ({}) for source values of {}", new Object[] { transformColumn.getTransformId(), transformColumn.getTargetColumnName(), transformColumn.getIncludeOn().name(), sourceValues.toString() });
                 throw ex;

--- a/symmetric-io/src/main/java/org/jumpmind/symmetric/io/data/writer/TransformWriter.java
+++ b/symmetric-io/src/main/java/org/jumpmind/symmetric/io/data/writer/TransformWriter.java
@@ -51,8 +51,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.NestedRuntimeException;
 
-import bsh.TargetError;
-
 public class TransformWriter extends NestedDataWriter {
 
     protected static final Logger log = LoggerFactory.getLogger(TransformWriter.class);
@@ -451,13 +449,6 @@ public class TransformWriter extends NestedDataWriter {
                 }
                 returnValue = transform.transform(platform, context, transformColumn, data,
                         sourceValues, value, oldValue);
-            } catch (TargetError trg) {
-            	Throwable ex = trg.getTarget();
-            	if (ex instanceof IgnoreColumnException) {
-            		throw (IgnoreColumnException) ex;
-            	} else if (ex instanceof IgnoreRowException) {
-            		throw (IgnoreRowException) ex;
-            	}
             } catch (NestedRuntimeException nestedRuntimeException) {
             	Throwable rootCause = nestedRuntimeException.getRootCause();
             	if (rootCause instanceof IgnoreColumnException) {

--- a/symmetric-io/src/main/java/org/jumpmind/symmetric/io/data/writer/TransformWriter.java
+++ b/symmetric-io/src/main/java/org/jumpmind/symmetric/io/data/writer/TransformWriter.java
@@ -50,6 +50,8 @@ import org.jumpmind.util.Statistics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import bsh.TargetError;
+
 public class TransformWriter extends NestedDataWriter {
 
     protected static final Logger log = LoggerFactory.getLogger(TransformWriter.class);
@@ -448,6 +450,13 @@ public class TransformWriter extends NestedDataWriter {
                 }
                 returnValue = transform.transform(platform, context, transformColumn, data,
                         sourceValues, value, oldValue);
+            } catch (TargetError trg) {
+            	Throwable ex = trg.getTarget();
+            	if (ex instanceof IgnoreColumnException) {
+            		throw (IgnoreColumnException) ex;
+            	} else if (ex instanceof IgnoreRowException) {
+            		throw (IgnoreRowException) ex;
+            	}
             } catch (RuntimeException ex) {
                 log.warn("Column transform failed {}.{} ({}) for source values of {}", new Object[] { transformColumn.getTransformId(), transformColumn.getTargetColumnName(), transformColumn.getIncludeOn().name(), sourceValues.toString() });
                 throw ex;


### PR DESCRIPTION
- the [linked issue tracker issue](https://www.symmetricds.org/issues/view.php?id=2233) describes steps for replicating a scenario in which symmetric will not correctly handle `IgnoreColumnException` and `IgnoreRowException` in beanshell transforms that have been imported using the `ExtensionService`
- i was able to reproduce this issue on 3.12 by following the steps provided
- the issue only occurs when a bsh transform is included in `symmetric-extensions.xml` 
- the problem was that bsh transforms that are included as beans throw a `NestedRuntimeException`, and exception which the `TransformWriter` and related code do not handle
- I unwrap this exception in `TransformWriter` and handle it in the same way we handle `TargetError`, getting the innermost exception and throwing it back if it's an instance of `IgnoreColumnException or `IgnoreRowException`
- I had to add a  compile time symmetric-io dependency on Spring so that I could handle this exception