### PR TITLE
fix: 0004957 large column values cannot fit into derby sym_data

### DIFF
--- a/symmetric-db/src/main/java/org/jumpmind/db/platform/derby/DerbyDdlBuilder.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/platform/derby/DerbyDdlBuilder.java
@@ -53,7 +53,7 @@ public class DerbyDdlBuilder extends AbstractDdlBuilder {
         databaseInfo.addNativeTypeMapping(Types.DISTINCT, "BLOB", Types.BLOB);
         databaseInfo.addNativeTypeMapping(Types.JAVA_OBJECT, "BLOB", Types.BLOB);
         databaseInfo.addNativeTypeMapping(Types.LONGVARBINARY, "LONG VARCHAR FOR BIT DATA");
-        databaseInfo.addNativeTypeMapping(Types.LONGVARCHAR, "LONG VARCHAR", Types.LONGVARCHAR);
+        databaseInfo.addNativeTypeMapping(Types.LONGVARCHAR, "CLOB", Types.LONGVARCHAR);
         databaseInfo.addNativeTypeMapping(Types.NULL, "LONG VARCHAR FOR BIT DATA", Types.LONGVARBINARY);
         databaseInfo.addNativeTypeMapping(Types.OTHER, "BLOB", Types.BLOB);
         databaseInfo.addNativeTypeMapping(Types.REF, "LONG VARCHAR FOR BIT DATA", Types.LONGVARBINARY);


### PR DESCRIPTION
- the [linked issue](https://www.symmetricds.org/issues/view.php?id=4957) describes an issue with large derby columns causing symmetric to throw sqlexceptions
- [another issue](https://www.symmetricds.org/issues/view.php?id=5072) saw the same problem affect conflict resolution
- i changed the mapping for "LONG VARCHAR" to make it map to the JDBC CLOB type instead of the JDBC LONGVARCHAR type
- i confirmed that this fixes the issue by creating a 1GB CLOB column and loading it into an H2 database
- this change does not seem to affect existing schemas that have the JDBC LONGVARCHAR instead of CLOB