### PR TITLE
fix: 0005070 parse double as long in longValue to fix firebird dialect 1 purge error

### DIFF
--- a/symmetric-db/src/main/java/org/jumpmind/db/sql/Row.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/sql/Row.java
@@ -115,7 +115,7 @@ public class Row extends LinkedCaseInsensitiveMap<Object> {
     public Long longValue() {
         Object obj = this.values().iterator().next();
         if (obj != null) {
-            if (obj instanceof Long) {
+            if (obj instanceof Long || obj instanceof Double) {
                 return (Long)obj;
             } else {
                 return Long.valueOf(obj.toString());    

--- a/symmetric-db/src/main/java/org/jumpmind/db/sql/Row.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/sql/Row.java
@@ -115,8 +115,10 @@ public class Row extends LinkedCaseInsensitiveMap<Object> {
     public Long longValue() {
         Object obj = this.values().iterator().next();
         if (obj != null) {
-            if (obj instanceof Long || obj instanceof Double) {
+            if (obj instanceof Long) {
                 return (Long)obj;
+            } else if (obj instanceof Double) {
+                return ((Double) obj).longValue();   
             } else {
                 return Long.valueOf(obj.toString());    
             }            


### PR DESCRIPTION
- the [linked issue](https://www.symmetricds.org/issues/view.php?id=5070) describes a user who is not able to run purgeservice on firebird dialect 1
- i figured out that this is because we convert JDBC BIGINT to NUMERIC(18) on firebird dialect 1
- according to firebird docs, NUMERIC with precision > 9  becomes DOUBLE PRECISION on dialect 1
- thus our sym table JDBC BIGINT columns are DOUBLE PRECISION, which works fine, but leads to fatal formatting errors when we try to get the value back out as a long (see [linked issue](https://www.symmetricds.org/issues/view.php?id=5070)), because the string of the object comes out in decimal format, Long.valueOf can't handle it
- I added a check in row to cast double to long when we ask for the long value, fixing this error without changing the way our DDL builder for Dialect 1 works