### PR TITLE
fix: 0005074 CSV to database replication not working

### DIFF
--- a/symmetric-assemble/src/asciidoc/examples/csv2db.ad
+++ b/symmetric-assemble/src/asciidoc/examples/csv2db.ad
@@ -85,7 +85,7 @@ NOTE: 'TARGET_BASE_DIR' should be changed to your target base directory.
 
 endif::pro[]
 
-* Testing.  You are now ready to test your csv to database routing. Add a csv file that matches your table specifications to your base directory or make a change to a pre-existing csv file in the directory. File sync tracker checks for changes in already sync'd files and runs every 5 minutes. File sync pull checks for new files to pull down and runs every 1 minute. Depending on the change you choose (changing a file or adding a file), wait the appropriate amount of time and then verify that the changes are shown in the target table.
+* Testing.  You are now ready to test your csv to database routing. Add a csv file that matches your table specifications to your base directory or make a change to a pre-existing csv file in the directory. Note that this CSV file must have a first row containing the column names for the table into which you want to insert.  File sync tracker checks for changes in already sync'd files and runs every 5 minutes. File sync pull checks for new files to pull down and runs every 1 minute. Depending on the change you choose (changing a file or adding a file), wait the appropriate amount of time and then verify that the changes are shown in the target table.
 
 .The following SQL statement will verify changes to the person table.
 [source, SQL]

--- a/symmetric-client/src/integrationTest/java/org/jumpmind/symmetric/service/impl/DataExtractorServiceTest.java
+++ b/symmetric-client/src/integrationTest/java/org/jumpmind/symmetric/service/impl/DataExtractorServiceTest.java
@@ -1,0 +1,88 @@
+/**
+ * Licensed to JumpMind Inc under one or more contributor
+ * license agreements.  See the NOTICE file distributed
+ * with this work for additional information regarding
+ * copyright ownership.  JumpMind Inc licenses this file
+ * to you under the GNU General Public License, version 3.0 (GPLv3)
+ * (the "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3.0 (GPLv3) along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jumpmind.symmetric.service.impl;
+
+import org.junit.Assert;
+import java.lang.reflect.Field;
+import java.util.Date;
+
+import org.jumpmind.db.sql.ISqlReadCursor;
+import org.jumpmind.db.util.BinaryEncoding;
+import org.jumpmind.symmetric.db.ISymmetricDialect;
+import org.jumpmind.symmetric.io.data.DataEventType;
+import org.jumpmind.symmetric.model.Data;
+import org.jumpmind.symmetric.model.Node;
+import org.jumpmind.symmetric.model.OutgoingBatch;
+import org.jumpmind.symmetric.model.ProcessInfo;
+import org.jumpmind.symmetric.model.Router;
+import org.jumpmind.symmetric.model.TriggerHistory;
+import org.jumpmind.symmetric.model.TriggerReBuildReason;
+import org.jumpmind.symmetric.route.AbstractFileParsingRouter;
+import org.jumpmind.symmetric.service.impl.DataExtractorService.SelectFromSymDataSource;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class DataExtractorServiceTest {
+    @SuppressWarnings("unchecked")
+    @Test
+    public void selectFromSymDataSource_csvValuesAreExtracted_triggerRouterIsNotMarkedAsMissing()
+            throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
+        DataExtractorService dataExtractorService = Mockito.mock(DataExtractorService.class);
+        TriggerRouterService triggerRouterService = Mockito.mock(TriggerRouterService.class);
+        Mockito.when(triggerRouterService.getTriggerRoutersByTriggerHist("target", false)).thenReturn(null);
+        Mockito.when(triggerRouterService.getRouterById("fooCsvRouter")).thenReturn(new Router());
+        ISymmetricDialect symmetricDialect = Mockito.mock(ISymmetricDialect.class);
+        Mockito.when(symmetricDialect.getBinaryEncoding()).thenReturn(BinaryEncoding.NONE);
+        Mockito.when(symmetricDialect.getName()).thenReturn("H2");
+        // mock a cursor with some data from csv router
+        ISqlReadCursor<Data> mockedCursor = Mockito.mock(ISqlReadCursor.class);
+        Data csvCapturedData = new Data(1, "1", "1", DataEventType.INSERT, "foo", new Date(), buildVirtualTriggerHistoryForParsedFile(),
+                "default", null, null);
+        Mockito.when(mockedCursor.next()).thenReturn(csvCapturedData);
+
+        setPrivateField(DataExtractorService.class.getSuperclass(), dataExtractorService, "symmetricDialect", symmetricDialect);
+        setPrivateField(DataExtractorService.class, dataExtractorService, "triggerRouterService", triggerRouterService);
+
+        SelectFromSymDataSource selectFromSymDataSource = dataExtractorService.new SelectFromSymDataSource(new OutgoingBatch(), new Node(),
+                new Node(), new ProcessInfo(), false);
+        setPrivateField(SelectFromSymDataSource.class, selectFromSymDataSource, "cursor", mockedCursor);
+        Assert.assertTrue(selectFromSymDataSource.next().equals(csvCapturedData));
+    }
+
+    protected TriggerHistory buildVirtualTriggerHistoryForParsedFile() {
+        TriggerHistory virtualTriggerHistory = new TriggerHistory();
+        virtualTriggerHistory.setColumnNames("foo");
+        virtualTriggerHistory.setCreateTime(new Date());
+        virtualTriggerHistory.setLastTriggerBuildReason(TriggerReBuildReason.NEW_TRIGGERS);
+        virtualTriggerHistory.setPkColumnNames("foo");
+        virtualTriggerHistory.setSourceTableName("foo");
+        virtualTriggerHistory.setTriggerHistoryId(1);
+        virtualTriggerHistory.setTriggerId(AbstractFileParsingRouter.TRIGGER_ID_FILE_PARSER);
+        return virtualTriggerHistory;
+    }
+
+    protected void setPrivateField(Class<?> objectClass, Object objectWithPrivateField, String fieldName, Object value)
+            throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
+        Field field = objectClass.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(objectWithPrivateField, value);
+    }
+}

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/DataExtractorService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/DataExtractorService.java
@@ -2542,7 +2542,7 @@ public class DataExtractorService extends AbstractService implements IDataExtrac
                         triggerRouter = new TriggerRouter();
                         triggerRouter.setTriggerId(AbstractFileParsingRouter.TRIGGER_ID_FILE_PARSER);
                         String routerId = AbstractFileParsingRouter.getRouterIdFromExternalData(data.getExternalData());
-                        triggerRouter.setRouter(engine.getTriggerRouterService().getRouterById(routerId));
+                        triggerRouter.setRouter(triggerRouterService.getRouterById(routerId));
                         triggerRouter.setTrigger(new Trigger());
                     } else {
                         triggerRouter = triggerRoutersByTriggerHist.get(triggerHistory.getTriggerHistoryId());

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/DataExtractorService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/DataExtractorService.java
@@ -2547,7 +2547,7 @@ public class DataExtractorService extends AbstractService implements IDataExtrac
                     } else {
                         triggerRouter = triggerRoutersByTriggerHist.get(triggerHistory.getTriggerHistoryId());
                     }
-                    if (triggerRouter == null && !isFileParserRouter) {
+                    if (triggerRouter == null) {
                         CounterStat counterStat = missingTriggerRoutersByTriggerHist.get(triggerHistory.getTriggerHistoryId());
                         if (counterStat == null) {
                             triggerRouter = triggerRouterService.getTriggerRouterByTriggerHist(targetNode.getNodeGroupId(), 
@@ -2600,7 +2600,6 @@ public class DataExtractorService extends AbstractService implements IDataExtrac
                                         initialLoadSelect.length() - platform.getDatabaseInfo().getSqlCommandDelimiter().length());
                             }
                         }
-
                         SelectFromTableEvent event = new SelectFromTableEvent(targetNode,
                                 triggerRouter, triggerHistory, initialLoadSelect);
                         this.reloadSource = new SelectFromTableSource(outgoingBatch, batch,


### PR DESCRIPTION
- a [user on the forum](https://sourceforge.net/p/symmetricds/discussion/1354726/thread/86e46e7027/) was having trouble with CSV to database replication
- josh was able to reproduce this issue and so was i
- the extractor service was not respecting the virtual CSV trigger because its triggerhistory was null, and was marking the data as having a missing trigger so that it could not be extracted
- i moved the check for whether the trigger is the  virtual one up higher and added a triggerhistory entry for it
- this resolves the issue and allows batches to be extracted

I also added to the docs to explain that users have to put the column names at the top of the CSV file for proper CSV routing