### PR TITLE
fix: 0004116 syncing postgres timestamp to time produces inaccurate vals

### DIFF
--- a/symmetric-util/src/main/java/org/jumpmind/util/FormatUtils.java
+++ b/symmetric-util/src/main/java/org/jumpmind/util/FormatUtils.java
@@ -23,9 +23,11 @@ package org.jumpmind.util;
 import java.sql.Timestamp;
 import java.text.ParsePosition;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -49,7 +51,7 @@ public final class FormatUtils {
             "HH:mm:ss.S", "HH:mm:ss" };
 
     public static final String[] TIME_PATTERNS = { "HH:mm:ss.S", "HH:mm:ss",
-            "yyyy-MM-dd HH:mm:ss.S", "yyyy-MM-dd HH:mm:ss" };
+            "yyyy-MM-dd HH:mm:ss.S", "yyyy-MM-dd HH:mm:ss"};
     
     public static final String[] TIMESTAMP_WITH_TIMEZONE_PATTERNS = {
             "yyyy-MM-dd HH:mm:ss.n xxx"
@@ -400,6 +402,12 @@ public final class FormatUtils {
             throw new IllegalArgumentException("Date and Patterns must not be null");
         }
         
+        // handle accuracy beyond milliseconds. soon we should switch to java.time for nanosecond accuracy
+        // note that im just truncating here and NOT rounding up
+        int periodIndex = str.indexOf(".");
+        if (str.length() - periodIndex > 3) { 
+            str = str.substring(0, periodIndex+4);
+        }
         SimpleDateFormat parser = null;
         ParsePosition pos = new ParsePosition(0);
         for (int i = 0; i < parsePatterns.length; i++) {

--- a/symmetric-util/src/test/java/org/jumpmind/util/FormatUtilsTest.java
+++ b/symmetric-util/src/test/java/org/jumpmind/util/FormatUtilsTest.java
@@ -20,6 +20,7 @@
  */
 package org.jumpmind.util;
 
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -71,5 +72,12 @@ public class FormatUtilsTest {
         assertTrue(FormatUtils.isWildCardMatch("A_B", "*A*B"));        
         assertFalse(FormatUtils.isWildCardMatch("TEST_NO_MATCH", "TEST_*,!TEST_NO_MATCH"));
         assertTrue(FormatUtils.isWildCardMatch("A_B", "A*B"));
+    }
+    
+    @Test
+    public void parseDate_precisionAboveMillisIsIgnored_timeStillCorrect() {
+        Date parsedPreciseDate = FormatUtils.parseDate("2021-08-20 17:50:53.820838", FormatUtils.TIME_PATTERNS);
+        Date impreciseDate = FormatUtils.parseDate("2021-08-20 17:50:53.820", FormatUtils.TIME_PATTERNS);
+        assertTrue(parsedPreciseDate.equals(impreciseDate));
     }
 }

--- a/symmetric-util/src/test/java/org/jumpmind/util/FormatUtilsTest.java
+++ b/symmetric-util/src/test/java/org/jumpmind/util/FormatUtilsTest.java
@@ -76,8 +76,9 @@ public class FormatUtilsTest {
     
     @Test
     public void parseDate_precisionAboveMillisIsIgnored_timeStillCorrect() {
-        Date parsedPreciseDate = FormatUtils.parseDate("2021-08-20 17:50:53.820838", FormatUtils.TIME_PATTERNS);
-        Date impreciseDate = FormatUtils.parseDate("2021-08-20 17:50:53.820", FormatUtils.TIME_PATTERNS);
-        assertTrue(parsedPreciseDate.equals(impreciseDate));
+        Date parsedPreciseDate = FormatUtils.parseDate("2021-08-20 17:50:53.820838", FormatUtils.TIMESTAMP_PATTERNS);
+        assertEquals(parsedPreciseDate.getHours(), 17);
+        assertEquals(parsedPreciseDate.getMinutes(), 50);
+        assertEquals(parsedPreciseDate.getSeconds(), 53);
     }
 }


### PR DESCRIPTION
- the [linked issue in the issue tracker] describes a problem a user had when going from timestamps in postgres to other databases
- i was able to reproduce this in 3.12
- i tracked the issue down to FormatUtils - the problem is that Java does not support time precision above milliseconds, so it was trying to use the nanosecond value provided by postgres as additional milliseconds, pushing the time up a couple of minutes
- i added a check for times with precision greater than milliseconds. i just truncate the value instead of rounding it since that's more accurate to what would actually be recorded 
- i added a regression test to format utils for detecting this bug