### PR TITLE
Fix that MS SQL initial load with VARCHAR > 8000 will succeed

### DIFF
--- a/symmetric-db/src/main/java/org/jumpmind/db/platform/mssql/MsSql2005DdlBuilder.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/platform/mssql/MsSql2005DdlBuilder.java
@@ -90,6 +90,8 @@ public class MsSql2005DdlBuilder extends MsSql2000DdlBuilder {
         String sqlType = super.getSqlType(column);
         if (column.getMappedTypeCode() == Types.VARBINARY && column.getSizeAsInt() > 8000) {
             sqlType = "VARBINARY(MAX)";
+        } else if (column.getMappedTypeCode() == Types.VARCHAR && column.getSizeAsInt() > 8000) {
+            sqlType = "VARCHAR(MAX)";
         }
         return sqlType;
     }


### PR DESCRIPTION
I had an issue where I cannot import a database with tables where the VARCHAR size was bigger than 8000 bytes. With this change SymmetricDS will create the column with `VARCHAR(MAX)` on Microsoft SQL Server when the size of VARCHAR is bigger than 8000 bytes, which in my case succeed.