### PR TITLE
Fix for (0003295) initial sync to MS SQL with precision more than 38

### DIFF
--- a/symmetric-db/src/main/java/org/jumpmind/db/platform/mssql/MsSql2005DdlBuilder.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/platform/mssql/MsSql2005DdlBuilder.java
@@ -92,6 +92,8 @@ public class MsSql2005DdlBuilder extends MsSql2000DdlBuilder {
             sqlType = "VARBINARY(MAX)";
         } else if (column.getMappedTypeCode() == Types.VARCHAR && column.getSizeAsInt() > 8000) {
             sqlType = "VARCHAR(MAX)";
+        } else if (column.getMappedTypeCode() == Types.DECIMAL && column.getSizeAsInt() > 38) {
+            sqlType = String.format("DECIMAL(38,%d)", column.getScale());
         }
         return sqlType;
     }


### PR DESCRIPTION
Fix for issue https://www.symmetricds.org/issues/view.php?id=3295. When the precision of `DECIMALS` is bigger than 38, MS SQL refuses to create the type. With this "fix" it will create the `DECIMALS` type with the max precision, which is 38.