### PR TITLE
0005381: allow cast to inet type in Postgres

### DIFF
--- a/symmetric-db/src/main/java/org/jumpmind/db/model/TypeMap.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/model/TypeMap.java
@@ -131,6 +131,7 @@ public abstract class TypeMap {
     public static final String TSVECTOR = "TSVECTOR";
     public static final String JSONB = "JSONB";
     public static final String JSON = "JSON";
+    public static final String INET = "INET";
     /** Maps type names to the corresponding {@link java.sql.Types} constants. */
     private static HashMap<String, Integer> _typeNameToTypeCode = new HashMap<String, Integer>();
     /** Maps {@link java.sql.Types} type code constants to the corresponding type names. */

--- a/symmetric-db/src/main/java/org/jumpmind/db/platform/postgresql/PostgreSqlDmlStatement.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/platform/postgresql/PostgreSqlDmlStatement.java
@@ -161,6 +161,8 @@ public class PostgreSqlDmlStatement extends DmlStatement {
             typeToCast = "json";
         } else if (column.getJdbcTypeName() != null && column.getJdbcTypeName().toUpperCase().contains(TypeMap.JSON)) {
             typeToCast = "json";
+        } else if (column.getJdbcTypeName() != null && column.getJdbcTypeName().toUpperCase().contains(TypeMap.INET)) {
+            typeToCast = "inet";
         }
         if (typeToCast != null && column.getMappedType() != null && column.getMappedType().equals(TypeMap.ARRAY)) {
             typeToCast = typeToCast + "[]";


### PR DESCRIPTION
This fix allows the use of the `inet` data type in Postgres. This resolves the issue as reported in https://www.symmetricds.org/issues/view.php?id=5381