### PR TITLE
fix: 0005481 mssql text for symmetric tables to varchar

### DIFF
--- a/symmetric-client/src/main/java/org/jumpmind/symmetric/db/mssql/MsSqlSymmetricDialect.java
+++ b/symmetric-client/src/main/java/org/jumpmind/symmetric/db/mssql/MsSqlSymmetricDialect.java
@@ -25,6 +25,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.sql.Types;
 
 import org.apache.commons.lang3.StringUtils;
 import org.jumpmind.db.model.Column;
@@ -73,17 +74,35 @@ public class MsSqlSymmetricDialect extends AbstractSymmetricDialect implements I
     public Database readSymmetricSchemaFromXml() {
         Database db = super.readSymmetricSchemaFromXml();
         if (parameterService.is(ParameterConstants.MSSQL_USE_NTYPES_FOR_SYNC)) {
-            Table table = db.findTable(TableConstants.getTableName(getTablePrefix(),
+            Table sym_table = db.findTable(TableConstants.getTableName(getTablePrefix(),
                     TableConstants.SYM_DATA));
-            setColumnToNtext(table.getColumnWithName("row_data"));
-            setColumnToNtext(table.getColumnWithName("old_data"));
-            setColumnToNtext(table.getColumnWithName("pk_data"));
+            setColumnToNtext(sym_table.getColumnWithName("row_data"));
+            setColumnToNtext(sym_table.getColumnWithName("old_data"));
+            setColumnToNtext(sym_table.getColumnWithName("pk_data"));
+        }
+        if (parameterService.is(ParameterConstants.MSSQL_USE_VARCHAR_FOR_LOB_IN_SYNC)) {
+            for (Table table : db.getTables()) {
+                for (Column column : table.getColumns()) {
+                    if (column.getMappedTypeCode() == Types.LONGNVARCHAR || column.getMappedTypeCode() == Types.LONGVARCHAR) {
+                        setColumnToVarChar(column, parameterService.is(ParameterConstants.MSSQL_USE_NTYPES_FOR_SYNC));
+                    }
+                }
+            }
         }
         return db;
     }
 
     protected void setColumnToNtext(Column column) {
         column.setMappedType(TypeMap.LONGNVARCHAR);
+    }
+
+    protected void setColumnToVarChar(Column column, boolean forceNtype) {
+        if (column.getMappedTypeCode() == Types.LONGNVARCHAR || (forceNtype && column.getMappedTypeCode() == Types.LONGVARCHAR)) {
+            column.setMappedType(TypeMap.NVARCHAR);
+        } else if (column.getMappedTypeCode() == Types.LONGVARCHAR) {
+            column.setMappedType(TypeMap.VARCHAR);
+        }
+        column.setSize("100000"); // This will ensure the size is converted to "max"
     }
 
     @Override

--- a/symmetric-client/src/main/java/org/jumpmind/symmetric/db/mssql/MsSqlSymmetricDialect.java
+++ b/symmetric-client/src/main/java/org/jumpmind/symmetric/db/mssql/MsSqlSymmetricDialect.java
@@ -74,11 +74,11 @@ public class MsSqlSymmetricDialect extends AbstractSymmetricDialect implements I
     public Database readSymmetricSchemaFromXml() {
         Database db = super.readSymmetricSchemaFromXml();
         if (parameterService.is(ParameterConstants.MSSQL_USE_NTYPES_FOR_SYNC)) {
-            Table sym_table = db.findTable(TableConstants.getTableName(getTablePrefix(),
+            Table symTable = db.findTable(TableConstants.getTableName(getTablePrefix(),
                     TableConstants.SYM_DATA));
-            setColumnToNtext(sym_table.getColumnWithName("row_data"));
-            setColumnToNtext(sym_table.getColumnWithName("old_data"));
-            setColumnToNtext(sym_table.getColumnWithName("pk_data"));
+            setColumnToNtext(symTable.getColumnWithName("row_data"));
+            setColumnToNtext(symTable.getColumnWithName("old_data"));
+            setColumnToNtext(symTable.getColumnWithName("pk_data"));
         }
         if (parameterService.is(ParameterConstants.MSSQL_USE_VARCHAR_FOR_LOB_IN_SYNC)) {
             for (Table table : db.getTables()) {

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/common/ParameterConstants.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/common/ParameterConstants.java
@@ -360,6 +360,7 @@ final public class ParameterConstants {
     public final static String BSH_EXTENSION_GLOBAL_SCRIPT = "bsh.extension.global.script";
     public final static String MSSQL_ROW_LEVEL_LOCKS_ONLY = "mssql.allow.only.row.level.locks.on.runtime.tables";
     public final static String MSSQL_USE_NTYPES_FOR_SYNC = "mssql.use.ntypes.for.sync";
+    public final static String MSSQL_USE_VARCHAR_FOR_LOB_IN_SYNC = "mssql.use.varchar.for.lob.in.sync";
     public final static String MSSQL_LOCK_ESCALATION_DISABLED = "mssql.lock.escalation.disabled";
     public final static String MSSQL_INCLUDE_CATALOG_IN_TRIGGERS = "mssql.include.catalog.in.triggers";
     public final static String MSSQL_TRIGGER_EXECUTE_AS = "mssql.trigger.execute.as";

--- a/symmetric-core/src/main/resources/symmetric-default.properties
+++ b/symmetric-core/src/main/resources/symmetric-default.properties
@@ -2612,6 +2612,14 @@ mssql.allow.only.row.level.locks.on.runtime.tables=true
 # Type: boolean
 mssql.use.ntypes.for.sync=false
 
+# Use varchar(max) or nvarchar(max) when a column in SymmetricDS tables is set to long
+# or nlong. This is for example necessary when using a _UTF8 of _SC collation.
+#
+# DatabaseOverridable: true
+# Tags: trigger, mssql
+# Type: boolean
+mssql.use.varchar.for.lob.in.sync=false
+
 # Specify the user the SymmetricDS triggers should execute as.  Possible values are
 # { CALLER | SELF | OWNER | 'user_name' }
 # DatabaseOverridable: true

--- a/symmetric-db/src/main/java/org/jumpmind/db/platform/mssql/MsSql2005DdlBuilder.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/platform/mssql/MsSql2005DdlBuilder.java
@@ -92,6 +92,8 @@ public class MsSql2005DdlBuilder extends MsSql2000DdlBuilder {
             sqlType = "VARBINARY(MAX)";
         } else if (column.getMappedTypeCode() == Types.VARCHAR && column.getSizeAsInt() > 8000) {
             sqlType = "VARCHAR(MAX)";
+        } else if (column.getMappedTypeCode() == Types.NVARCHAR && column.getSizeAsInt() > 8000) {
+            sqlType = "NVARCHAR(MAX)";
         } else if (column.getMappedTypeCode() == Types.DECIMAL && column.getSizeAsInt() > 38) {
             sqlType = String.format("DECIMAL(38,%d)", column.getScale());
         }


### PR DESCRIPTION
Fixes https://www.symmetricds.org/issues/view.php?id=5481. With this change the SymmetricDS tables can be created on MS SQL with _UTF8 of _SC collation by setting the `mssql.use.varchar.for.lob.in.sync` to `true`