### PR TITLE
0005483: Toggle to convert TEXT to VARCHAR in MS SQL

### DIFF
--- a/symmetric-db/src/main/java/org/jumpmind/db/platform/mssql/MsSql2005DdlBuilder.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/platform/mssql/MsSql2005DdlBuilder.java
@@ -98,10 +98,7 @@ public class MsSql2005DdlBuilder extends MsSql2000DdlBuilder {
             sqlType = String.format("DECIMAL(38,%d)", column.getScale());
         } else if (useVarcharForText && (column.getMappedTypeCode() == Types.LONGVARCHAR || column.getMappedTypeCode() == Types.LONGNVARCHAR || column
                 .getMappedTypeCode() == Types.CLOB)) {
-            sqlType = "";
-            if (column.getMappedTypeCode() == Types.LONGNVARCHAR) {
-                sqlType = "N";
-            }
+            sqlType = (column.getMappedTypeCode() == Types.LONGNVARCHAR) ? "N" : "";
             sqlType += "VARCHAR(MAX)";
         }
         return sqlType;

--- a/symmetric-db/src/main/java/org/jumpmind/db/platform/mssql/MsSql2005DdlBuilder.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/platform/mssql/MsSql2005DdlBuilder.java
@@ -88,8 +88,7 @@ public class MsSql2005DdlBuilder extends MsSql2000DdlBuilder {
 
     @Override
     public String getSqlType(Column column) {
-        Map<String, String> env = System.getenv();
-        boolean useVarcharForText = "y".equalsIgnoreCase(env.get("USE_VARCHAR_FOR_TEXT"));
+        boolean useVarcharForText = System.getProperty("mssql.use.varchar.for.lob", "false").equalsIgnoreCase("true");
         String sqlType = super.getSqlType(column);
         if (column.getMappedTypeCode() == Types.VARBINARY && column.getSizeAsInt() > 8000) {
             sqlType = "VARBINARY(MAX)";

--- a/symmetric-db/src/main/java/org/jumpmind/db/platform/mssql/MsSql2005DdlBuilder.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/platform/mssql/MsSql2005DdlBuilder.java
@@ -21,6 +21,7 @@
 package org.jumpmind.db.platform.mssql;
 
 import java.sql.Types;
+import java.util.Map;
 
 import org.jumpmind.db.model.Column;
 import org.jumpmind.db.model.Table;
@@ -87,6 +88,8 @@ public class MsSql2005DdlBuilder extends MsSql2000DdlBuilder {
 
     @Override
     public String getSqlType(Column column) {
+        Map<String, String> env = System.getenv();
+        boolean useVarcharForText = "y".equalsIgnoreCase(env.get("USE_VARCHAR_FOR_TEXT"));
         String sqlType = super.getSqlType(column);
         if (column.getMappedTypeCode() == Types.VARBINARY && column.getSizeAsInt() > 8000) {
             sqlType = "VARBINARY(MAX)";
@@ -94,6 +97,13 @@ public class MsSql2005DdlBuilder extends MsSql2000DdlBuilder {
             sqlType = "VARCHAR(MAX)";
         } else if (column.getMappedTypeCode() == Types.DECIMAL && column.getSizeAsInt() > 38) {
             sqlType = String.format("DECIMAL(38,%d)", column.getScale());
+        } else if (useVarcharForText && (column.getMappedTypeCode() == Types.LONGVARCHAR || column.getMappedTypeCode() == Types.LONGNVARCHAR || column
+                .getMappedTypeCode() == Types.CLOB)) {
+            sqlType = "";
+            if (column.getMappedTypeCode() == Types.LONGNVARCHAR) {
+                sqlType = "N";
+            }
+            sqlType += "VARCHAR(MAX)";
         }
         return sqlType;
     }


### PR DESCRIPTION
This PR will fix https://www.symmetricds.org/issues/view.php?id=5483.

When a column with the type of `long(n)varchar` is created it will be created in MS SQL as `(n)varchar(max)`. As this should not be the default action, I have created an environment variable which can activate this conversion. Maybe is there a better place to do this kind of type conversions?