### PR TITLE
0005525: allow cast to additional types in Postgres

### DIFF
--- a/symmetric-db/src/main/java/org/jumpmind/db/model/TypeMap.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/model/TypeMap.java
@@ -132,6 +132,9 @@ public abstract class TypeMap {
     public static final String JSONB = "JSONB";
     public static final String JSON = "JSON";
     public static final String INET = "INET";
+    public static final String CIDR = "CIDR";
+    public static final String MACADDR = "MACADDR";
+    public static final String MACADDR8 = "MACADDR8";
     /** Maps type names to the corresponding {@link java.sql.Types} constants. */
     private static HashMap<String, Integer> _typeNameToTypeCode = new HashMap<String, Integer>();
     /** Maps {@link java.sql.Types} type code constants to the corresponding type names. */

--- a/symmetric-db/src/main/java/org/jumpmind/db/platform/postgresql/PostgreSqlDmlStatement.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/platform/postgresql/PostgreSqlDmlStatement.java
@@ -163,6 +163,12 @@ public class PostgreSqlDmlStatement extends DmlStatement {
             typeToCast = "json";
         } else if (column.getJdbcTypeName() != null && column.getJdbcTypeName().toUpperCase().contains(TypeMap.INET)) {
             typeToCast = "inet";
+        } else if (column.getJdbcTypeName() != null && column.getJdbcTypeName().toUpperCase().contains(TypeMap.CIDR)) {
+            typeToCast = "cidr";
+        } else if (column.getJdbcTypeName() != null && column.getJdbcTypeName().toUpperCase().contains(TypeMap.MACADDR8)) {
+            typeToCast = "macaddr8";
+        } else if (column.getJdbcTypeName() != null && column.getJdbcTypeName().toUpperCase().contains(TypeMap.MACADDR)) {
+            typeToCast = "macaddr";
         }
         if (typeToCast != null && column.getMappedType() != null && column.getMappedType().equals(TypeMap.ARRAY)) {
             typeToCast = typeToCast + "[]";


### PR DESCRIPTION
This fix allows the use of the `cidr`, `macaddr` and `macaddr8` data types in Postgres. This resolves the issue as reported in https://www.symmetricds.org/issues/view.php?id=5525

Prior to code change:
```
[cluster-a] - AcknowledgeService - The outgoing batch cluster-b-463 failed: ERROR: column "col_cidr" is of type cidr but expression is of type character varying
  Hint: You will need to rewrite or cast the expression.
  Position: 69
```
```
[cluster-b] - ManageIncomingBatchListener - Failed to load batch cluster-a-463 org.jumpmind.db.sql.SqlException: ERROR: column "col_cidr" is of type cidr but expression is of type character varying
  Hint: You will need to rewrite or cast the expression.
  Position: 69
```

After code change, all 3 types replicate without error
```
[cluster-a] - PushService - Push data sent to cluster-b:cluster-b:cluster-b
[cluster-a] - PushService - Pushed data to node cluster-b:cluster-b:cluster-b. 1 data and 1 batches were processed. (table_cidr_type)
[cluster-a] - RouterService - Routed 1 data events in 21 ms
[cluster-a] - PushService - Push data sent to cluster-b:cluster-b:cluster-b
[cluster-a] - PushService - Pushed data to node cluster-b:cluster-b:cluster-b. 1 data and 1 batches were processed. (table_macaddr_type)
[cluster-a] - RouterService - Routed 1 data events in 32 ms
[cluster-a] - PushService - Push data sent to cluster-b:cluster-b:cluster-b
[cluster-a] - PushService - Pushed data to node cluster-b:cluster-b:cluster-b. 1 data and 1 batches were processed. (table_macaddr8_type)
```
```
[cluster-b] - DataLoaderService - 1 data and 1 batches loaded during push request from cluster-a:cluster-a:cluster-a
[cluster-b] - DataLoaderService - 1 data and 1 batches loaded during push request from cluster-a:cluster-a:cluster-a
[cluster-b] - DataLoaderService - 1 data and 1 batches loaded during push request from cluster-a:cluster-a:cluster-a
```