### PR TITLE
0006524: Fix admin sync-triggers command with no arguments

### DIFF
--- a/symmetric-client/src/main/java/org/jumpmind/symmetric/SymmetricAdmin.java
+++ b/symmetric-client/src/main/java/org/jumpmind/symmetric/SymmetricAdmin.java
@@ -713,7 +713,7 @@ public class SymmetricAdmin extends AbstractCommandLauncher {
         ITriggerRouterService triggerService = getSymmetricEngine().getTriggerRouterService();
         StringBuilder sqlBuffer = new StringBuilder();
         if (args.size() == 0) {
-            triggerService.syncTriggers(sqlBuffer, genAlways);
+            triggerService.syncTriggers(genAlways);
         } else {
             for (String tablename : args) {
                 Table table = platform.getTableFromCache(catalogName, schemaName, tablename, true);


### PR DESCRIPTION
Invoking the `./bin/symadmin sync-triggers` command with no arguments, doesn't properly update the database triggers. 

Possibly because of the following changes: https://github.com/JumpMind/symmetric-ds/commit/b74613d6fe3660c4cee230e3fbd35cb41e4d51cc

