### PR TITLE
Preserve NULL-able flag for columns referenced by a unique index

### DIFF
--- a/symmetric-db/src/main/java/org/jumpmind/db/model/Table.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/model/Table.java
@@ -1365,7 +1365,9 @@ public class Table implements Serializable, Cloneable, Comparable<Table> {
                     if (column != null) {
                         for (String pkColumnName : pkColumnNames) {
                             if (column.getName().equalsIgnoreCase(pkColumnName)) {
+                            	boolean required = column.isRequired();
                                 column.setPrimaryKey(true);
+                                column.setRequired(required);
                             }
                         }
                     }

--- a/symmetric-db/src/main/java/org/jumpmind/db/platform/AbstractDatabasePlatform.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/platform/AbstractDatabasePlatform.java
@@ -758,7 +758,7 @@ public abstract class AbstractDatabasePlatform implements IDatabasePlatform {
             for (IndexColumn indexColumn : indices[0].getColumns()) {
                 Column column = result.getColumnWithName(indexColumn.getName());
                 if (column != null) {
-                	boolean required = column.isRequired(); 
+                    boolean required = column.isRequired(); 
                     column.setPrimaryKey(true);
                     column.setRequired(required);
                 }

--- a/symmetric-db/src/main/java/org/jumpmind/db/platform/AbstractDatabasePlatform.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/platform/AbstractDatabasePlatform.java
@@ -758,7 +758,9 @@ public abstract class AbstractDatabasePlatform implements IDatabasePlatform {
             for (IndexColumn indexColumn : indices[0].getColumns()) {
                 Column column = result.getColumnWithName(indexColumn.getName());
                 if (column != null) {
+                	boolean required = column.isRequired(); 
                     column.setPrimaryKey(true);
+                    column.setRequired(required);
                 }
             }
         } else {


### PR DESCRIPTION
Preserve NULL-able flag for columns referenced by a unique index. Affects both DDL for new target table and data import tasks for an existing target table.