### PR TITLE
0006654: Info URL handler to use channel cache

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/IConfigurationService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/IConfigurationService.java
@@ -82,6 +82,8 @@ public interface IConfigurationService {
 
     public void deleteAllChannels();
 
+    public void deleteNodeChannelControl(String nodeId, String channelId);
+
     public List<NodeGroupChannelWindow> getNodeGroupChannelWindows(String nodeGroupId, String channelId);
 
     public Map<String, List<NodeGroupChannelWindow>> getNodeGroupChannelWindowsFromDb();

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/ConfigurationService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/ConfigurationService.java
@@ -439,6 +439,12 @@ public class ConfigurationService extends AbstractService implements IConfigurat
     }
 
     @Override
+    public void deleteNodeChannelControl(String nodeId, String channelId) {
+        sqlTemplate.update(getSql("deleteNodeChannelControlSql"), new Object[] { nodeId, channelId });
+        clearCache();
+    }
+
+    @Override
     public void deleteAllChannels() {
         sqlTemplate.update(getSql("deleteAllChannelsSql"));
         clearCache();

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/ConfigurationService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/ConfigurationService.java
@@ -99,8 +99,14 @@ public class ConfigurationService extends AbstractService implements IConfigurat
 
     @Override
     public boolean isBulkLoaderEnabled() {
-        List<Channel> channelList = sqlTemplate.query(getSql("selectChannelsSql", "whereBulkLoaderEnabledSql"), new ChannelMapper());
-        return channelList != null && !channelList.isEmpty();
+        boolean enabled = false;
+        for (Channel channel : getChannels(false).values()) {
+            if (channel.isReloadFlag() && channel.getDataLoaderType().equals("bulk")) {
+                enabled = true;
+                break;
+            }
+        }
+        return enabled;
     }
 
     @Override

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/ConfigurationServiceSqlMap.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/ConfigurationServiceSqlMap.java
@@ -78,8 +78,6 @@ public class ConfigurationServiceSqlMap extends AbstractSqlMap {
         putSql("orderChannelsBySql", "order by c.processing_order asc, c.channel_id");
         
         putSql("whereChannelIdLikeSql", "where channel_id like ?");
-        
-        putSql("whereBulkLoaderEnabledSql", "where data_loader_type='bulk' and reload_flag=1");
 
         putSql("selectNodeChannelsSql",
             "select c.channel_id, c.processing_order,       "

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/ConfigurationServiceSqlMap.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/ConfigurationServiceSqlMap.java
@@ -125,6 +125,8 @@ public class ConfigurationServiceSqlMap extends AbstractSqlMap {
 
         putSql("deleteNodeChannelSql", "delete from $(node_channel_ctl) where channel_id=?   ");
 
+        putSql("deleteNodeChannelControlSql", "delete from $(node_channel_ctl) where node_id=? and channel_id=?");
+
         putSql("selectNodeGroupChannelWindowSql",
                 "select node_group_id, channel_id, start_time, end_time, enabled                    "
               + "  from $(node_group_channel_wnd) where node_group_id=? and channel_id=?   ");


### PR DESCRIPTION
The info URL handler was modified to query the channels so it can report on whether bulk loading is enabled or not. The wizard uses this information so it can ask the user if they want to enable bulk loading. However, there was a report of a system taking up to 8 seconds to return the info URL to a load balancer running constant health checks. Instead, it should use the channel cache so the query is less often.