### PR TITLE
6677: Support include columns for indexes in SQL Server

### DIFF
--- a/symmetric-db/src/main/java/org/jumpmind/db/io/DatabaseXmlUtil.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/io/DatabaseXmlUtil.java
@@ -57,7 +57,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Map;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringEscapeUtils;
 import org.jumpmind.db.model.Column;
 import org.jumpmind.db.model.CompressionTypes;
@@ -376,6 +375,19 @@ public class DatabaseXmlUtil {
                             indexColumn.setColumn(table.getColumnWithName(indexColumn.getName()));
                             if (index != null) {
                                 index.addColumn(indexColumn);
+                            }
+                        } else if (name.equalsIgnoreCase("include-column")) {
+                            IndexColumn indexColumn = new IndexColumn();
+                            for (int i = 0; i < parser.getAttributeCount(); i++) {
+                                String attributeName = parser.getAttributeName(i);
+                                String attributeValue = parser.getAttributeValue(i);
+                                if (attributeName.equalsIgnoreCase("name")) {
+                                    indexColumn.setName(attributeValue);
+                                }
+                            }
+                            indexColumn.setColumn(table.getColumnWithName(indexColumn.getName()));
+                            if (index != null) {
+                                index.addIncludedColumn(indexColumn);
                             }
                         } else if (name.equalsIgnoreCase("platform-index")) {
                             PlatformIndex platformIndex = new PlatformIndex();
@@ -723,6 +735,7 @@ public class DatabaseXmlUtil {
                     for (IndexColumn column : index.getColumns()) {
                         output.write("\t\t\t<unique-column name=\"" + StringEscapeUtils.escapeXml10(column.getName()) + "\"/>\n");
                     }
+                    handleIncludeColumns(output, index);
                 } else {
                     output.write("\t\t<index name=\"" + StringEscapeUtils.escapeXml10(index.getName()) + "\">\n");
                     for (IndexColumn column : index.getColumns()) {
@@ -732,6 +745,7 @@ public class DatabaseXmlUtil {
                         }
                         output.write("/>\n");
                     }
+                    handleIncludeColumns(output, index);
                 }
                 if (index.getPlatformIndexes() != null && index.getPlatformIndexes().size() > 0) {
                     Map<String, PlatformIndex> platformIndexes = index.getPlatformIndexes();
@@ -815,5 +829,11 @@ public class DatabaseXmlUtil {
                     StringEscapeUtils.escapeXml10(fk.getOnDeleteAction().getForeignKeyActionName()) + "\"");
         }
         return sb.toString();
+    }
+    
+    private static void handleIncludeColumns(Writer output, IIndex index) throws IOException {
+        for (IndexColumn column : index.getIncludedColumns()) {
+            output.write("\t\t\t<include-column name=\"" + StringEscapeUtils.escapeXml10(column.getName()) + "\"/>\n");
+        }
     }
 }

--- a/symmetric-db/src/main/java/org/jumpmind/db/model/IIndex.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/model/IIndex.java
@@ -158,4 +158,14 @@ public interface IIndex extends Cloneable, Serializable {
     public Map<String, PlatformIndex> getPlatformIndexes();
 
     public PlatformIndex findPlatformIndex(PlatformIndex platformIndex);
+
+    public int getIncludedColumnCount();
+
+    public IndexColumn getIncludedColumn(int idx);
+
+    public IndexColumn[] getIncludedColumns();
+
+    public boolean hasIncludedColumn(Column column);
+
+    public void addIncludedColumn(IndexColumn column);
 }

--- a/symmetric-db/src/main/java/org/jumpmind/db/model/IndexImpBase.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/model/IndexImpBase.java
@@ -52,6 +52,7 @@ public abstract class IndexImpBase implements IIndex {
     protected String name;
     /** The columns making up the index. */
     protected ArrayList<IndexColumn> columns = new ArrayList<IndexColumn>();
+    protected ArrayList<IndexColumn> includedColumns = new ArrayList<IndexColumn>();
     protected Map<String, PlatformIndex> platformIndexes;
 
     public String getName() {
@@ -67,11 +68,11 @@ public abstract class IndexImpBase implements IIndex {
     }
 
     public IndexColumn getColumn(int idx) {
-        return (IndexColumn) columns.get(idx);
+        return columns.get(idx);
     }
 
     public IndexColumn[] getColumns() {
-        return (IndexColumn[]) columns.toArray(new IndexColumn[columns.size()]);
+        return columns.toArray(new IndexColumn[columns.size()]);
     }
 
     public boolean hasColumn(Column column) {
@@ -103,6 +104,41 @@ public abstract class IndexImpBase implements IIndex {
 
     public void removeColumn(int idx) {
         columns.remove(idx);
+    }
+
+    public int getIncludedColumnCount() {
+        return includedColumns.size();
+    }
+
+    public IndexColumn getIncludedColumn(int idx) {
+        return includedColumns.get(idx);
+    }
+
+    public IndexColumn[] getIncludedColumns() {
+        return includedColumns.toArray(new IndexColumn[includedColumns.size()]);
+    }
+
+    public boolean hasIncludedColumn(Column column) {
+        for (int idx = 0; idx < includedColumns.size(); idx++) {
+            IndexColumn curColumn = getIncludedColumn(idx);
+            if (column.getName().equals(curColumn.getName())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public void addIncludedColumn(IndexColumn column) {
+        if (column != null) {
+            for (int idx = 0; idx < includedColumns.size(); idx++) {
+                IndexColumn curColumn = getIncludedColumn(idx);
+                if (curColumn.getOrdinalPosition() > column.getOrdinalPosition()) {
+                    includedColumns.add(idx, column);
+                    return;
+                }
+            }
+            includedColumns.add(column);
+        }
     }
 
     public abstract Object clone() throws CloneNotSupportedException;

--- a/symmetric-db/src/main/java/org/jumpmind/db/model/NonUniqueIndex.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/model/NonUniqueIndex.java
@@ -67,6 +67,7 @@ public class NonUniqueIndex extends IndexImpBase {
         NonUniqueIndex result = new NonUniqueIndex();
         result.name = name;
         result.columns = (ArrayList<IndexColumn>) columns.clone();
+        result.includedColumns = (ArrayList<IndexColumn>) includedColumns.clone();
         clonePlatformIndexes(result);
         return result;
     }
@@ -77,6 +78,7 @@ public class NonUniqueIndex extends IndexImpBase {
             NonUniqueIndex other = (NonUniqueIndex) obj;
             return new EqualsBuilder().append(name, other.name).append(columns, other.columns)
                     .append(platformIndexes, other.platformIndexes)
+                    .append(includedColumns, other.includedColumns)
                     .isEquals();
         } else {
             return false;

--- a/symmetric-db/src/main/java/org/jumpmind/db/model/UniqueIndex.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/model/UniqueIndex.java
@@ -67,6 +67,7 @@ public class UniqueIndex extends IndexImpBase {
         UniqueIndex result = new UniqueIndex();
         result.name = name;
         result.columns = (ArrayList<IndexColumn>) columns.clone();
+        result.includedColumns = (ArrayList<IndexColumn>) includedColumns.clone();
         clonePlatformIndexes(result);
         return result;
     }
@@ -76,6 +77,7 @@ public class UniqueIndex extends IndexImpBase {
             UniqueIndex other = (UniqueIndex) obj;
             return new EqualsBuilder().append(name, other.name).append(columns, other.columns)
                     .append(platformIndexes, other.platformIndexes)
+                    .append(includedColumns, other.includedColumns)
                     .isEquals();
         } else {
             return false;

--- a/symmetric-db/src/main/java/org/jumpmind/db/platform/mssql/MsSql2005DdlBuilder.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/platform/mssql/MsSql2005DdlBuilder.java
@@ -24,6 +24,8 @@ import java.sql.Types;
 
 import org.apache.commons.lang3.StringUtils;
 import org.jumpmind.db.model.Column;
+import org.jumpmind.db.model.IIndex;
+import org.jumpmind.db.model.IndexColumn;
 import org.jumpmind.db.model.PlatformColumn;
 import org.jumpmind.db.model.Table;
 import org.jumpmind.db.model.TypeMap;
@@ -228,6 +230,23 @@ public class MsSql2005DdlBuilder extends MsSql2000DdlBuilder {
                 !(databaseInfo.isNullAsDefaultValueRequired() && databaseInfo.hasNullDefault(column.getMappedTypeCode()))) {
             ddl.append(" ");
             writeColumnNullableStmt(ddl);
+        }
+    }
+
+    @Override
+    protected void writeExternalIndexCreate(Table table, IIndex index, StringBuilder ddl) {
+        super.writeExternalIndexCreate(table, index, ddl);
+        if (index.getIncludedColumns() != null && index.getIncludedColumns().length > 0) {
+            ddl.append(" INCLUDE (");
+            IndexColumn[] includedColumns = index.getIncludedColumns();
+            for (int i = 0; i < includedColumns.length; i++) {
+                IndexColumn includedColumn = includedColumns[i];
+                if (i > 0) {
+                    ddl.append(", ");
+                }
+                ddl.append(includedColumn.getName());
+            }
+            ddl.append(")");
         }
     }
 }


### PR DESCRIPTION
Add the ability to replicate the INCLUDE columns for indexes in SQL Server.

Also support changes to indexes when synching DDL to allow the drop and create of indexes when the indexes are different between the source and the target.