### PR TITLE
0006721: Data loader incorrect SQL error when no columns on target table

### DIFF
--- a/symmetric-io/src/main/java/org/jumpmind/symmetric/io/data/writer/DefaultDatabaseWriter.java
+++ b/symmetric-io/src/main/java/org/jumpmind/symmetric/io/data/writer/DefaultDatabaseWriter.java
@@ -249,7 +249,7 @@ public class DefaultDatabaseWriter extends AbstractDatabaseWriter {
         if (isCteExpression()) {
             retSql = getPlatform().getDdlBuilder().getDatabaseInfo().getCteExpression()
                     + " " + sql;
-            retSql = currentDmlStatement.updateCteExpression(retSql, batch.getSourceNodeId());
+            retSql = DmlStatement.updateCteExpression(retSql, batch.getSourceNodeId());
         }
         return retSql;
     }
@@ -269,6 +269,7 @@ public class DefaultDatabaseWriter extends AbstractDatabaseWriter {
             }
             statistics.get(batch).startTimer(DataWriterStatisticConstants.LOADMILLIS);
             if (requireNewStatement(DmlType.INSERT, data, false, true, null)) {
+                checkTargetTableHasColumns();
                 lastUseConflictDetection = true;
                 currentDmlStatement = getPlatform().createDmlStatement(DmlType.INSERT, targetTable, writerSettings.getTextColumnExpression());
                 replaceCteExpression();
@@ -616,6 +617,7 @@ public class DefaultDatabaseWriter extends AbstractDatabaseWriter {
                     }
                 }
             } else {
+                checkTargetTableHasColumns();
                 if (log.isDebugEnabled()) {
                     log.debug("Not running update for table {} with pk of {}.  There was no change to apply",
                             targetTable.getFullyQualifiedTableName(), data.getCsvData(CsvData.PK_DATA));
@@ -628,6 +630,13 @@ public class DefaultDatabaseWriter extends AbstractDatabaseWriter {
             throw ex;
         } finally {
             statistics.get(batch).stopTimer(DataWriterStatisticConstants.LOADMILLIS);
+        }
+    }
+
+    protected void checkTargetTableHasColumns() {
+        if (targetTable.getColumnCount() == 0) {
+            throw new IllegalStateException("There are no columns defined for table " + targetTable.getFullyQualifiedTableName() +
+                    " that match with " + sourceTable.getColumnCount() + " columns in the batch");
         }
     }
 


### PR DESCRIPTION
If source and target table names match but the column names do not, the dataloader will execute invalid SQL that causes a syntax error. Instead, we should log an illegal state exception explaining that no column names matched. This happened to a user whose intention was to transform column names, but the transform was not setup correctly, and the resulting error message was confusing.  Insert and update needed a check, but delete already had a check to complain about no primary key columns.