### PR TITLE
0006787: Prevented ConcurrentModificationException while deploying engines in parallel

### DIFF
--- a/symmetric-server/src/main/java/org/jumpmind/symmetric/web/SymmetricEngineHolder.java
+++ b/symmetric-server/src/main/java/org/jumpmind/symmetric/web/SymmetricEngineHolder.java
@@ -246,53 +246,55 @@ public class SymmetricEngineHolder {
             String registrationUrl = properties.getProperty(ParameterConstants.REGISTRATION_URL);
             if (StringUtils.isNotBlank(registrationUrl)) {
                 Collection<ServerSymmetricEngine> all = getEngines().values();
-                for (ISymmetricEngine currentEngine : all) {
-                    if (currentEngine.getParameterService().getSyncUrl().equals(registrationUrl)) {
-                        String serverNodeGroupId = currentEngine.getParameterService().getNodeGroupId();
-                        String clientNodeGroupId = properties.getProperty(ParameterConstants.NODE_GROUP_ID);
-                        String externalId = properties.getProperty(ParameterConstants.EXTERNAL_ID);
-                        IConfigurationService configurationService = currentEngine.getConfigurationService();
-                        ITriggerRouterService triggerRouterService = currentEngine.getTriggerRouterService();
-                        List<NodeGroup> groups = configurationService.getNodeGroups();
-                        boolean foundGroup = false;
-                        for (NodeGroup nodeGroup : groups) {
-                            if (nodeGroup.getNodeGroupId().equals(clientNodeGroupId)) {
-                                foundGroup = true;
-                            }
-                        }
-                        if (!foundGroup) {
-                            configurationService.saveNodeGroup(new NodeGroup(clientNodeGroupId));
-                            NodeGroupLink serverToClientLink = new NodeGroupLink(serverNodeGroupId, clientNodeGroupId, NodeGroupLinkAction.W);
-                            configurationService.saveNodeGroupLink(serverToClientLink);
-                            NodeGroupLink clientToServerLink = new NodeGroupLink(clientNodeGroupId, serverNodeGroupId, NodeGroupLinkAction.P);
-                            configurationService.saveNodeGroupLink(clientToServerLink);
-                            Router serverToClientRouter = new Router("", serverToClientLink);
-                            serverToClientRouter.setRouterId(serverToClientRouter.createDefaultName());
-                            Router clientToServerRouter = new Router("", clientToServerLink);
-                            clientToServerRouter.setRouterId(clientToServerRouter.createDefaultName());
-                            triggerRouterService.saveRouter(serverToClientRouter);
-                            triggerRouterService.saveRouter(clientToServerRouter);
-                            triggerRouterService.syncTriggers();
-                        } else {
-                            boolean foundLink = false;
-                            List<NodeGroupLink> links = configurationService.getNodeGroupLinksFor(serverNodeGroupId, false);
-                            for (NodeGroupLink nodeGroupLink : links) {
-                                if (nodeGroupLink.getTargetNodeGroupId().equals(clientNodeGroupId)) {
-                                    foundLink = true;
+                synchronized (getEngines()) {
+                    for (ISymmetricEngine currentEngine : all) {
+                        if (currentEngine.getParameterService().getSyncUrl().equals(registrationUrl)) {
+                            String serverNodeGroupId = currentEngine.getParameterService().getNodeGroupId();
+                            String clientNodeGroupId = properties.getProperty(ParameterConstants.NODE_GROUP_ID);
+                            String externalId = properties.getProperty(ParameterConstants.EXTERNAL_ID);
+                            IConfigurationService configurationService = currentEngine.getConfigurationService();
+                            ITriggerRouterService triggerRouterService = currentEngine.getTriggerRouterService();
+                            List<NodeGroup> groups = configurationService.getNodeGroups();
+                            boolean foundGroup = false;
+                            for (NodeGroup nodeGroup : groups) {
+                                if (nodeGroup.getNodeGroupId().equals(clientNodeGroupId)) {
+                                    foundGroup = true;
                                 }
                             }
-                            if (!foundLink) {
-                                configurationService.saveNodeGroupLink(new NodeGroupLink(serverNodeGroupId, clientNodeGroupId, NodeGroupLinkAction.W));
+                            if (!foundGroup) {
+                                configurationService.saveNodeGroup(new NodeGroup(clientNodeGroupId));
+                                NodeGroupLink serverToClientLink = new NodeGroupLink(serverNodeGroupId, clientNodeGroupId, NodeGroupLinkAction.W);
+                                configurationService.saveNodeGroupLink(serverToClientLink);
+                                NodeGroupLink clientToServerLink = new NodeGroupLink(clientNodeGroupId, serverNodeGroupId, NodeGroupLinkAction.P);
+                                configurationService.saveNodeGroupLink(clientToServerLink);
+                                Router serverToClientRouter = new Router("", serverToClientLink);
+                                serverToClientRouter.setRouterId(serverToClientRouter.createDefaultName());
+                                Router clientToServerRouter = new Router("", clientToServerLink);
+                                clientToServerRouter.setRouterId(clientToServerRouter.createDefaultName());
+                                triggerRouterService.saveRouter(serverToClientRouter);
+                                triggerRouterService.saveRouter(clientToServerRouter);
                                 triggerRouterService.syncTriggers();
+                            } else {
+                                boolean foundLink = false;
+                                List<NodeGroupLink> links = configurationService.getNodeGroupLinksFor(serverNodeGroupId, false);
+                                for (NodeGroupLink nodeGroupLink : links) {
+                                    if (nodeGroupLink.getTargetNodeGroupId().equals(clientNodeGroupId)) {
+                                        foundLink = true;
+                                    }
+                                }
+                                if (!foundLink) {
+                                    configurationService.saveNodeGroupLink(new NodeGroupLink(serverNodeGroupId, clientNodeGroupId, NodeGroupLinkAction.W));
+                                    triggerRouterService.syncTriggers();
+                                }
                             }
-                        }
-                        IRegistrationService registrationService = currentEngine.getRegistrationService();
-                        if (!registrationService.isAutoRegistration() && !registrationService.isRegistrationOpen(clientNodeGroupId, externalId)) {
-                            Node node = new Node(properties);
-                            if (TableConstants.getTables("").contains(TableConstants.SYM_CONSOLE_USER)) {
-                                node.setDeploymentType(Constants.DEPLOYMENT_TYPE_PROFESSIONAL);
+                            IRegistrationService registrationService = currentEngine.getRegistrationService();
+                            if (!registrationService.isAutoRegistration() && !registrationService.isRegistrationOpen(clientNodeGroupId, externalId)) {
+                                Node node = new Node(properties);
+                                if (TableConstants.getTables("").contains(TableConstants.SYM_CONSOLE_USER)) {
+                                    node.setDeploymentType(Constants.DEPLOYMENT_TYPE_PROFESSIONAL);
+                                }
+                                registrationService.openRegistration(node);
                             }
-                            registrationService.openRegistration(node);
                         }
                     }
                 }

--- a/symmetric-server/src/main/java/org/jumpmind/symmetric/web/SymmetricEngineHolder.java
+++ b/symmetric-server/src/main/java/org/jumpmind/symmetric/web/SymmetricEngineHolder.java
@@ -25,6 +25,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -245,56 +246,54 @@ public class SymmetricEngineHolder {
         try {
             String registrationUrl = properties.getProperty(ParameterConstants.REGISTRATION_URL);
             if (StringUtils.isNotBlank(registrationUrl)) {
-                Collection<ServerSymmetricEngine> all = getEngines().values();
-                synchronized (getEngines()) {
-                    for (ISymmetricEngine currentEngine : all) {
-                        if (currentEngine.getParameterService().getSyncUrl().equals(registrationUrl)) {
-                            String serverNodeGroupId = currentEngine.getParameterService().getNodeGroupId();
-                            String clientNodeGroupId = properties.getProperty(ParameterConstants.NODE_GROUP_ID);
-                            String externalId = properties.getProperty(ParameterConstants.EXTERNAL_ID);
-                            IConfigurationService configurationService = currentEngine.getConfigurationService();
-                            ITriggerRouterService triggerRouterService = currentEngine.getTriggerRouterService();
-                            List<NodeGroup> groups = configurationService.getNodeGroups();
-                            boolean foundGroup = false;
-                            for (NodeGroup nodeGroup : groups) {
-                                if (nodeGroup.getNodeGroupId().equals(clientNodeGroupId)) {
-                                    foundGroup = true;
+                Collection<ServerSymmetricEngine> all = new ArrayList<ServerSymmetricEngine>(getEngines().values());
+                for (ISymmetricEngine currentEngine : all) {
+                    if (currentEngine.getParameterService().getSyncUrl().equals(registrationUrl)) {
+                        String serverNodeGroupId = currentEngine.getParameterService().getNodeGroupId();
+                        String clientNodeGroupId = properties.getProperty(ParameterConstants.NODE_GROUP_ID);
+                        String externalId = properties.getProperty(ParameterConstants.EXTERNAL_ID);
+                        IConfigurationService configurationService = currentEngine.getConfigurationService();
+                        ITriggerRouterService triggerRouterService = currentEngine.getTriggerRouterService();
+                        List<NodeGroup> groups = configurationService.getNodeGroups();
+                        boolean foundGroup = false;
+                        for (NodeGroup nodeGroup : groups) {
+                            if (nodeGroup.getNodeGroupId().equals(clientNodeGroupId)) {
+                                foundGroup = true;
+                            }
+                        }
+                        if (!foundGroup) {
+                            configurationService.saveNodeGroup(new NodeGroup(clientNodeGroupId));
+                            NodeGroupLink serverToClientLink = new NodeGroupLink(serverNodeGroupId, clientNodeGroupId, NodeGroupLinkAction.W);
+                            configurationService.saveNodeGroupLink(serverToClientLink);
+                            NodeGroupLink clientToServerLink = new NodeGroupLink(clientNodeGroupId, serverNodeGroupId, NodeGroupLinkAction.P);
+                            configurationService.saveNodeGroupLink(clientToServerLink);
+                            Router serverToClientRouter = new Router("", serverToClientLink);
+                            serverToClientRouter.setRouterId(serverToClientRouter.createDefaultName());
+                            Router clientToServerRouter = new Router("", clientToServerLink);
+                            clientToServerRouter.setRouterId(clientToServerRouter.createDefaultName());
+                            triggerRouterService.saveRouter(serverToClientRouter);
+                            triggerRouterService.saveRouter(clientToServerRouter);
+                            triggerRouterService.syncTriggers();
+                        } else {
+                            boolean foundLink = false;
+                            List<NodeGroupLink> links = configurationService.getNodeGroupLinksFor(serverNodeGroupId, false);
+                            for (NodeGroupLink nodeGroupLink : links) {
+                                if (nodeGroupLink.getTargetNodeGroupId().equals(clientNodeGroupId)) {
+                                    foundLink = true;
                                 }
                             }
-                            if (!foundGroup) {
-                                configurationService.saveNodeGroup(new NodeGroup(clientNodeGroupId));
-                                NodeGroupLink serverToClientLink = new NodeGroupLink(serverNodeGroupId, clientNodeGroupId, NodeGroupLinkAction.W);
-                                configurationService.saveNodeGroupLink(serverToClientLink);
-                                NodeGroupLink clientToServerLink = new NodeGroupLink(clientNodeGroupId, serverNodeGroupId, NodeGroupLinkAction.P);
-                                configurationService.saveNodeGroupLink(clientToServerLink);
-                                Router serverToClientRouter = new Router("", serverToClientLink);
-                                serverToClientRouter.setRouterId(serverToClientRouter.createDefaultName());
-                                Router clientToServerRouter = new Router("", clientToServerLink);
-                                clientToServerRouter.setRouterId(clientToServerRouter.createDefaultName());
-                                triggerRouterService.saveRouter(serverToClientRouter);
-                                triggerRouterService.saveRouter(clientToServerRouter);
+                            if (!foundLink) {
+                                configurationService.saveNodeGroupLink(new NodeGroupLink(serverNodeGroupId, clientNodeGroupId, NodeGroupLinkAction.W));
                                 triggerRouterService.syncTriggers();
-                            } else {
-                                boolean foundLink = false;
-                                List<NodeGroupLink> links = configurationService.getNodeGroupLinksFor(serverNodeGroupId, false);
-                                for (NodeGroupLink nodeGroupLink : links) {
-                                    if (nodeGroupLink.getTargetNodeGroupId().equals(clientNodeGroupId)) {
-                                        foundLink = true;
-                                    }
-                                }
-                                if (!foundLink) {
-                                    configurationService.saveNodeGroupLink(new NodeGroupLink(serverNodeGroupId, clientNodeGroupId, NodeGroupLinkAction.W));
-                                    triggerRouterService.syncTriggers();
-                                }
                             }
-                            IRegistrationService registrationService = currentEngine.getRegistrationService();
-                            if (!registrationService.isAutoRegistration() && !registrationService.isRegistrationOpen(clientNodeGroupId, externalId)) {
-                                Node node = new Node(properties);
-                                if (TableConstants.getTables("").contains(TableConstants.SYM_CONSOLE_USER)) {
-                                    node.setDeploymentType(Constants.DEPLOYMENT_TYPE_PROFESSIONAL);
-                                }
-                                registrationService.openRegistration(node);
+                        }
+                        IRegistrationService registrationService = currentEngine.getRegistrationService();
+                        if (!registrationService.isAutoRegistration() && !registrationService.isRegistrationOpen(clientNodeGroupId, externalId)) {
+                            Node node = new Node(properties);
+                            if (TableConstants.getTables("").contains(TableConstants.SYM_CONSOLE_USER)) {
+                                node.setDeploymentType(Constants.DEPLOYMENT_TYPE_PROFESSIONAL);
                             }
+                            registrationService.openRegistration(node);
                         }
                     }
                 }


### PR DESCRIPTION
I made this change to prevent the following `ConcurrentModificationException`:

```
Exception in thread "symmetric-engine-deployment-1" java.util.ConcurrentModificationException
      at java.base/java.util.HashMap$HashIterator.nextNode(HashMap.java:1597)
      at java.base/java.util.HashMap$ValueIterator.next(HashMap.java:1625)
      at org.jumpmind.symmetric.web.SymmetricEngineHolder.install(SymmetricEngineHolder.java:249)
      [symmetric-pro code omitted from stack trace]
```

The `engines` map being traversed comes from `Collections.synchronizedMap()`, but wrapping the map using this method does not prevent this exception. It turns out that according to this method's [Javadoc](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/Collections.html#synchronizedMap(java.util.Map)), whenever you traverse the map, you have to add a `synchronized` block.

There are many sets and maps in `SymmetricEngineHolder` that come from similar `Collections` methods that do not follow this pattern when they are traversed, so this seems like a wider issue. Maybe it would be good to create another issue to add more `synchronized` blocks.

If I shouldn't make this change, let me know and I can find another way around the `ConcurrentModificationException`. The `for` loop within the `install()` method is actually unnecessary when called during deployment, so I could make a change so that it avoids going into this loop instead.