### PR TITLE
0006757: ExtractDataReader support from target platform

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/extract/ExtractDataReaderFactory.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/extract/ExtractDataReaderFactory.java
@@ -38,10 +38,12 @@ public class ExtractDataReaderFactory implements IExtractDataReaderFactory {
         this.engine = engine;
     }
 
-    public ExtractDataReader getReader(IDatabasePlatform platform, IExtractDataReaderSource source, Node sourceNode, Node targetNode) {
+    @Override
+    public ExtractDataReader getReader(IDatabasePlatform platform, IExtractDataReaderSource source, Node sourceNode, Node targetNode,
+            IDatabasePlatform targetPlatform) {
         ISymmetricDialect symmetricDialect = engine.getSymmetricDialect();
         boolean isUsingUnitypes = symmetricDialect.getParameterService().is(ParameterConstants.DBDIALECT_SYBASE_ASE_CONVERT_UNITYPES_FOR_SYNC);
         List<IExtractDataFilter> filters = engine.getExtensionService().getExtensionPointList(IExtractDataFilter.class);
-        return new ExtractDataReader(platform, source, filters, isUsingUnitypes);
+        return new ExtractDataReader(platform, source, filters, isUsingUnitypes, targetPlatform);
     }
 }

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/extract/IExtractDataReaderFactory.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/extract/IExtractDataReaderFactory.java
@@ -26,5 +26,6 @@ import org.jumpmind.symmetric.io.data.reader.IExtractDataReaderSource;
 import org.jumpmind.symmetric.model.Node;
 
 public interface IExtractDataReaderFactory {
-    public ExtractDataReader getReader(IDatabasePlatform platform, IExtractDataReaderSource source, Node sourceNode, Node targetNode);
+    public ExtractDataReader getReader(IDatabasePlatform platform, IExtractDataReaderSource source,
+            Node sourceNode, Node targetNode, IDatabasePlatform targetPlatform);
 }

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/DataExtractorService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/DataExtractorService.java
@@ -218,6 +218,7 @@ public class DataExtractorService extends AbstractService implements IDataExtrac
     /**
      * Extract the SymmetricDS configuration for the passed in {@link Node}.
      */
+    @Override
     public void extractConfigurationStandalone(Node targetNode, Writer writer, String... tablesToExclude) {
         Node sourceNode = nodeService.findIdentity();
         if (targetNode != null && sourceNode != null) {
@@ -282,7 +283,7 @@ public class DataExtractorService extends AbstractService implements IDataExtrac
             }
             SelectFromTableSource source = new SelectFromTableSource(engine, batch, initialLoadEvents);
             source.setConfiguration(true);
-            ExtractDataReader dataReader = new ExtractDataReader(symmetricDialect.getPlatform(), source);
+            ExtractDataReader dataReader = new ExtractDataReader(symmetricDialect.getPlatform(), source, symmetricDialect.getTargetPlatform());
             ProtocolDataWriter dataWriter = new ProtocolDataWriter(nodeService.findIdentityNodeId(), writer, targetNode.requires13Compatiblity(), false, false);
             List<TransformTableNodeGroupLink> transformsList = transformService.getConfigExtractTransforms(nodeGroupLink);
             TransformTable[] transforms = transformsList.toArray(new TransformTable[transformsList.size()]);
@@ -348,6 +349,7 @@ public class DataExtractorService extends AbstractService implements IDataExtrac
         return batches.getBatches();
     }
 
+    @Override
     public List<OutgoingBatchWithPayload> extractToPayload(ProcessInfo processInfo,
             Node targetNode, PayloadType payloadType, boolean useJdbcTimestampFormat,
             boolean useUpsertStatements, boolean useDelimiterIdentifiers) {
@@ -386,11 +388,13 @@ public class DataExtractorService extends AbstractService implements IDataExtrac
         return Collections.emptyList();
     }
 
+    @Override
     public List<OutgoingBatch> extract(ProcessInfo extractInfo, Node targetNode,
             IOutgoingTransport transport) {
         return extract(extractInfo, targetNode, null, transport);
     }
 
+    @Override
     public List<OutgoingBatch> extract(ProcessInfo extractInfo, Node targetNode, String queue,
             IOutgoingTransport transport) {
         /*
@@ -484,6 +488,7 @@ public class DataExtractorService extends AbstractService implements IDataExtrac
     /**
      * This method will extract an outgoing batch, but will not update the outgoing batch status
      */
+    @Override
     public boolean extractOnlyOutgoingBatch(String nodeId, long batchId, Writer writer) {
         boolean extracted = false;
         Node targetNode = null;
@@ -1008,6 +1013,7 @@ public class DataExtractorService extends AbstractService implements IDataExtrac
         return lock;
     }
 
+    @Override
     public StagingFileLock acquireStagingFileLock(OutgoingBatch batch) {
         boolean stagingFileAcquired = false;
         StagingFileLock fileLock = null;
@@ -1088,7 +1094,7 @@ public class DataExtractorService extends AbstractService implements IDataExtrac
                 new Class[] { ISymmetricEngine.class, OutgoingBatch.class, Node.class, Node.class, ProcessInfo.class, boolean.class });
         IExtractDataReaderFactory factory = AppUtils.newInstance(IExtractDataReaderFactory.class, ExtractDataReaderFactory.class,
                 new Object[] { engine }, new Class[] { ISymmetricEngine.class });
-        return factory.getReader(platform, source, sourceNode, targetNode);
+        return factory.getReader(platform, source, sourceNode, targetNode, engine.getSymmetricDialect().getTargetPlatform());
     }
 
     protected Statistics getExtractStats(IDataWriter writer, OutgoingBatch currentBatch) {
@@ -1520,6 +1526,7 @@ public class DataExtractorService extends AbstractService implements IDataExtrac
                 String.valueOf(batch.getExtractDeleteRowCount()), String.valueOf(batch.getFailedDataId()) }, ',');
     }
 
+    @Override
     public boolean extractBatchRange(Writer writer, String nodeId, long startBatchId,
             long endBatchId) {
         boolean foundBatch = false;
@@ -1548,6 +1555,7 @@ public class DataExtractorService extends AbstractService implements IDataExtrac
         return foundBatch;
     }
 
+    @Override
     public boolean extractBatchRange(Writer writer, String nodeId, Date startBatchTime,
             Date endBatchTime, String... channelIds) {
         boolean foundBatch = false;
@@ -1590,6 +1598,7 @@ public class DataExtractorService extends AbstractService implements IDataExtrac
         return transformExtractWriter;
     }
 
+    @Override
     public RemoteNodeStatuses queueWork(boolean force) {
         final RemoteNodeStatuses statuses = new RemoteNodeStatuses(configurationService.getChannels(false));
         Node identity = nodeService.findIdentity();
@@ -1713,6 +1722,7 @@ public class DataExtractorService extends AbstractService implements IDataExtrac
         }
     }
 
+    @Override
     public ExtractRequest requestExtractRequest(ISqlTransaction transaction, String nodeId, String queue,
             TriggerRouter triggerRouter, long startBatchId, long endBatchId, long loadId, String table, long rows, long parentRequestId) {
         long requestId = 0;
@@ -1755,6 +1765,7 @@ public class DataExtractorService extends AbstractService implements IDataExtrac
     /**
      * This is a callback method used by the NodeCommunicationService that extracts an initial load in the background.
      */
+    @Override
     public void execute(NodeCommunication nodeCommunication, RemoteNodeStatus status) {
         if (!isApplicable(nodeCommunication)) {
             log.debug("{} failed isApplicable check and will not run.", this);
@@ -1954,6 +1965,7 @@ public class DataExtractorService extends AbstractService implements IDataExtrac
         }
     }
 
+    @Override
     public void releaseMissedExtractRequests() {
         List<Long> requestIds = sqlTemplateDirty.query(getSql("selectExtractChildRequestIdsMissed"), new LongMapper(), Status.NE.name(), Status.OK.name(),
                 engine.getNodeId(), engine.getNodeId());
@@ -2020,6 +2032,7 @@ public class DataExtractorService extends AbstractService implements IDataExtrac
     }
 
     class ExtractRequestMapper implements ISqlRowMapper<ExtractRequest> {
+        @Override
         public ExtractRequest mapRow(Row row) {
             ExtractRequest request = new ExtractRequest();
             request.setNodeId(row.getString("node_id"));

--- a/symmetric-io/src/main/java/org/jumpmind/symmetric/io/data/reader/ExtractDataReader.java
+++ b/symmetric-io/src/main/java/org/jumpmind/symmetric/io/data/reader/ExtractDataReader.java
@@ -85,7 +85,7 @@ public class ExtractDataReader implements IDataReader {
     public ExtractDataReader(IDatabasePlatform platform, List<IExtractDataReaderSource> sources, IDatabasePlatform targetPlatform) {
         this.sourcesToUse = new ArrayList<IExtractDataReaderSource>(sources);
         this.platform = platform;
-        this.targetPlatform = platform;
+        this.targetPlatform = targetPlatform;
         isSybaseASE = platform.getName().equals(DatabaseNamesConstants.ASE);
     }
 

--- a/symmetric-io/src/main/java/org/jumpmind/symmetric/io/data/reader/ExtractDataReader.java
+++ b/symmetric-io/src/main/java/org/jumpmind/symmetric/io/data/reader/ExtractDataReader.java
@@ -52,6 +52,7 @@ public class ExtractDataReader implements IDataReader {
     public static final String DATA_CONTEXT_CURRENT_CSV_DATA = "csvData";
     protected Map<Batch, Statistics> statistics = new HashMap<Batch, Statistics>();
     protected IDatabasePlatform platform;
+    protected IDatabasePlatform targetPlatform;
     protected List<IExtractDataReaderSource> sourcesToUse;
     protected IExtractDataReaderSource currentSource;
     protected List<IExtractDataFilter> filters;
@@ -62,25 +63,29 @@ public class ExtractDataReader implements IDataReader {
     protected boolean isSybaseASE;
     protected boolean isUsingUnitypes;
 
-    public ExtractDataReader(IDatabasePlatform platform, IExtractDataReaderSource source) {
+    public ExtractDataReader(IDatabasePlatform platform, IExtractDataReaderSource source, IDatabasePlatform targetPlatform) {
         this.sourcesToUse = new ArrayList<IExtractDataReaderSource>();
         this.sourcesToUse.add(source);
         this.platform = platform;
+        this.targetPlatform = platform;
         this.isSybaseASE = platform.getName().equals(DatabaseNamesConstants.ASE);
     }
 
-    public ExtractDataReader(IDatabasePlatform platform, IExtractDataReaderSource source, List<IExtractDataFilter> filters, boolean isUsingUnitypes) {
+    public ExtractDataReader(IDatabasePlatform platform, IExtractDataReaderSource source, List<IExtractDataFilter> filters,
+            boolean isUsingUnitypes, IDatabasePlatform targetPlatform) {
         this.sourcesToUse = new ArrayList<IExtractDataReaderSource>();
         this.sourcesToUse.add(source);
         this.platform = platform;
+        this.targetPlatform = targetPlatform;
         this.filters = filters;
         this.isUsingUnitypes = isUsingUnitypes;
         this.isSybaseASE = platform.getName().equals(DatabaseNamesConstants.ASE);
     }
 
-    public ExtractDataReader(IDatabasePlatform platform, List<IExtractDataReaderSource> sources) {
+    public ExtractDataReader(IDatabasePlatform platform, List<IExtractDataReaderSource> sources, IDatabasePlatform targetPlatform) {
         this.sourcesToUse = new ArrayList<IExtractDataReaderSource>(sources);
         this.platform = platform;
+        this.targetPlatform = platform;
         isSybaseASE = platform.getName().equals(DatabaseNamesConstants.ASE);
     }
 
@@ -216,7 +221,7 @@ public class ExtractDataReader implements IDataReader {
                 Map<String, Object> columnDataMap = CollectionUtils
                         .toMap(columnNames, objectValues);
                 Column[] pkColumns = table.getPrimaryKeyColumns();
-                ISqlTemplate sqlTemplate = platform.getSqlTemplate();
+                ISqlTemplate sqlTemplate = targetPlatform.getSqlTemplate();
                 Object[] args = new Object[pkColumns.length];
                 for (int i = 0; i < pkColumns.length; i++) {
                     args[i] = columnDataMap.get(pkColumns[i].getName());

--- a/symmetric-io/src/main/java/org/jumpmind/symmetric/io/data/reader/ExtractDataReader.java
+++ b/symmetric-io/src/main/java/org/jumpmind/symmetric/io/data/reader/ExtractDataReader.java
@@ -67,7 +67,7 @@ public class ExtractDataReader implements IDataReader {
         this.sourcesToUse = new ArrayList<IExtractDataReaderSource>();
         this.sourcesToUse.add(source);
         this.platform = platform;
-        this.targetPlatform = platform;
+        this.targetPlatform = targetPlatform;
         this.isSybaseASE = platform.getName().equals(DatabaseNamesConstants.ASE);
     }
 


### PR DESCRIPTION
Log based implementations that use the stream lob setting will fail to extract data during CDC as the ExtractDataReader always uses the platform (which in the case of a log miner setup is H2).   So it fails to find the user table in H2 when it should be looking in the user database.