### PR TITLE
0006826: Add a batch.outgoing.tosend.offline.count to runtime-stats in the Support Snapshot

### DIFF
--- a/symmetric-client/src/main/java/org/jumpmind/symmetric/util/SnapshotUtil.java
+++ b/symmetric-client/src/main/java/org/jumpmind/symmetric/util/SnapshotUtil.java
@@ -661,6 +661,9 @@ public class SnapshotUtil {
                     df.format(engine.getOutgoingBatchService().countOutgoingBatchesInError()));
             runtimeProperties.setProperty("batch.outgoing.tosend.count",
                     df.format(engine.getOutgoingBatchService().countOutgoingBatchesUnsent()));
+            runtimeProperties.setProperty("batch.outgoing.tosend.offline.count",
+                    df.format(engine.getOutgoingBatchService().countOutgoingBatchesUnsentOfflineNodes(
+                            ParameterConstants.OFFLINE_NODE_DETECTION_PERIOD_MINUTES)));
             runtimeProperties.setProperty("batch.incoming.errors.count",
                     df.format(engine.getIncomingBatchService().countIncomingBatchesInError()));
             List<DataGap> gaps = engine.getDataService().findDataGapsUnchecked();

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/IOutgoingBatchService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/IOutgoingBatchService.java
@@ -108,6 +108,8 @@ public interface IOutgoingBatchService {
 
     public int countOutgoingBatchesUnsent();
 
+    public int countOutgoingBatchesUnsentOfflineNodes(String minsBeforeOfflineParam);
+
     public int[] countOutgoingNonSystemBatchesRowsUnsent();
 
     public int countOutgoingBatchesInError(String channelId);

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/OutgoingBatchService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/OutgoingBatchService.java
@@ -61,6 +61,7 @@ import org.jumpmind.symmetric.service.IConfigurationService;
 import org.jumpmind.symmetric.service.IExtensionService;
 import org.jumpmind.symmetric.service.INodeService;
 import org.jumpmind.symmetric.service.IOutgoingBatchService;
+import org.jumpmind.symmetric.service.IParameterService;
 import org.jumpmind.symmetric.service.ISequenceService;
 import org.jumpmind.symmetric.util.QueueThread;
 import org.jumpmind.util.AppUtils;
@@ -76,9 +77,11 @@ public class OutgoingBatchService extends AbstractService implements IOutgoingBa
     private IClusterService clusterService;
     private IExtensionService extensionService;
     private ICacheManager cacheManager;
+    private IParameterService parameterService;
 
     public OutgoingBatchService(ISymmetricEngine engine) {
         super(engine.getParameterService(), engine.getSymmetricDialect());
+        this.parameterService = engine.getParameterService();
         this.nodeService = engine.getNodeService();
         this.configurationService = engine.getConfigurationService();
         this.sequenceService = engine.getSequenceService();
@@ -420,6 +423,19 @@ public class OutgoingBatchService extends AbstractService implements IOutgoingBa
 
     public int countOutgoingBatchesUnsent() {
         return sqlTemplateDirty.queryForInt(getSql("countOutgoingBatchesUnsentSql"));
+    }
+
+    @Override
+    public int countOutgoingBatchesUnsentOfflineNodes(String minsBeforeOfflineParam) {
+        int unsentBatchCount = 0;
+        int minutesBeforeOffline = parameterService.getInt(minsBeforeOfflineParam);
+        if (minutesBeforeOffline < 0) {
+            return unsentBatchCount;
+        }
+        for (String offlineNodeId : nodeService.findOfflineNodeIds(minutesBeforeOffline)) {
+            unsentBatchCount += countUnsentBatchesByTargetNode(offlineNodeId, true);
+        }
+        return unsentBatchCount;
     }
 
     public int[] countOutgoingNonSystemBatchesRowsUnsent() {


### PR DESCRIPTION
Issue: https://issues.symmetricds.org/view.php?id=6826

Note: This PR is related to issue 6831, they should be merged in at the same time. (https://github.com/JumpMind/symmetric-pro/pull/278)

Questions:

1. Is ParameterConstants.OFFLINE_NODE_DETECTION_PERIOD_MINUTES the right parameter to use in this case to detect an offline node?