### PR TITLE
0006876: Prevented SQL Server DDL reader from removing too many outer parentheses from a default value

### DIFF
--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/mssql/MsSqlDdlReader.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/mssql/MsSqlDdlReader.java
@@ -337,7 +337,11 @@ public class MsSqlDdlReader extends AbstractJdbcDdlReader {
         // two sets of parentheses
         if (defaultValue != null) {
             while (defaultValue.startsWith("(") && defaultValue.endsWith(")")) {
-                defaultValue = defaultValue.substring(1, defaultValue.length() - 1);
+                String substring = defaultValue.substring(1, defaultValue.length() - 1);
+                if (substring.indexOf("(") > substring.indexOf(")") || substring.lastIndexOf("(") > substring.lastIndexOf(")")) {
+                    break;
+                }
+                defaultValue = substring;
             }
             if (column.getMappedTypeCode() == Types.TIMESTAMP) {
                 // Sql Server maintains the default values for DATE/TIME jdbc


### PR DESCRIPTION
I added a check that prevents a default value from being left with a leading `)` or a trailing `(`.

This is likely a wider issue because the same approach for removing outer parentheses is used in 14 other places. Let me know if I should look into this further.