### PR TITLE
0006877: Prevented SQL Server DDL reader from attempting to unescape single quotes within default values

### DIFF
--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/mssql/MsSqlDdlReader.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/mssql/MsSqlDdlReader.java
@@ -364,10 +364,10 @@ public class MsSqlDdlReader extends AbstractJdbcDdlReader {
                 if ((column.getScale() == 0) && defaultValue.endsWith(".")) {
                     defaultValue = defaultValue.substring(0, defaultValue.length() - 1);
                 }
-            } else if (TypeMap.isTextType( column.getMappedTypeCode())) {
+            } else if (TypeMap.isTextType(column.getMappedTypeCode())) {
                 String unescapedValue = unescapeTextValue(defaultValue, column);
                 if (log.isTraceEnabled()) {
-                    log.trace("Unescaped default value fro column={}, Original={}, Result={}", column.getName(), defaultValue, unescapedValue);
+                    log.trace("Unescaped default value for column={}, Original={}, Result={}", column.getName(), defaultValue, unescapedValue);
                 }
                 defaultValue = unescapedValue;
             }

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/mssql/MsSqlDdlReader.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/mssql/MsSqlDdlReader.java
@@ -364,10 +364,32 @@ public class MsSqlDdlReader extends AbstractJdbcDdlReader {
                 if ((column.getScale() == 0) && defaultValue.endsWith(".")) {
                     defaultValue = defaultValue.substring(0, defaultValue.length() - 1);
                 }
-            } else if (TypeMap.isTextType(column.getMappedTypeCode()) && defaultValue.startsWith("N'") && defaultValue.endsWith("'")) {
-                defaultValue = defaultValue.substring(2, defaultValue.length() - 1);
+            } else if (TypeMap.isTextType( column.getMappedTypeCode())) {
+                String unescapedValue = unescapeTextValue(defaultValue, column);
+                if (log.isTraceEnabled()) {
+                    log.trace("Unescaped default value fro column={}, Original={}, Result={}", column.getName(), defaultValue, unescapedValue);
+                }
+                defaultValue = unescapedValue;
             }
             column.setDefaultValue(defaultValue);
+        }
+    }
+
+    /**
+     * Removes outer quotes and un-escapes Transact-SQL text value. Might need additional parsing of each quoted string item in the future.
+     */
+    protected String unescapeTextValue(String defaultValue, Column column) {
+        if (defaultValue.endsWith("'") && (defaultValue.startsWith("N'") || defaultValue.startsWith("'"))) {
+            int newStartPos = 0;
+            int newEndPos = defaultValue.length() - 1;
+            if (defaultValue.startsWith("N'")) {
+                newStartPos = 2;
+            } else {
+                newStartPos = 1;
+            }
+            return unescape(defaultValue.substring(newStartPos, newEndPos), "'", "''");
+        } else {
+            return defaultValue;
         }
     }
 

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/mssql/MsSqlDdlReader.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/mssql/MsSqlDdlReader.java
@@ -364,11 +364,8 @@ public class MsSqlDdlReader extends AbstractJdbcDdlReader {
                 if ((column.getScale() == 0) && defaultValue.endsWith(".")) {
                     defaultValue = defaultValue.substring(0, defaultValue.length() - 1);
                 }
-            } else if (TypeMap.isTextType(column.getMappedTypeCode())) {
-                if (defaultValue.startsWith("N'") && defaultValue.endsWith("'")) {
-                    defaultValue = defaultValue.substring(2, defaultValue.length() - 1);
-                }
-                defaultValue = unescape(defaultValue, "'", "''");
+            } else if (TypeMap.isTextType(column.getMappedTypeCode()) && defaultValue.startsWith("N'") && defaultValue.endsWith("'")) {
+                defaultValue = defaultValue.substring(2, defaultValue.length() - 1);
             }
             column.setDefaultValue(defaultValue);
         }

--- a/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/mssql/MsSql2008DdlReaderTest.java
+++ b/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/mssql/MsSql2008DdlReaderTest.java
@@ -151,6 +151,22 @@ class MsSql2008DdlReaderTest {
     }
 
     @ParameterizedTest
+    @DisplayName("Parse Default Values")
+    @CsvSource(
+            value = { "'default'|default|" + Types.VARCHAR, "N'default'|default|" + Types.NVARCHAR,
+                    "coalesce([column_0]+' ','')|coalesce([column_0]+' ','')|" + Types.LONGVARCHAR, },
+            delimiter = '|')
+    void testParseDefaultValue(String originalDefault, String parsedDefault, int mappedTypeCode) throws Exception {
+        MockDbDataSource mockDataSource = new MockDbDataSource(MsSqlDatabasePlatform_VERSION10);
+        MsSqlDdlReader testReader = createMsSqlDdlReader(mockDataSource);
+        Column column = new Column();
+        column.setDefaultValue(originalDefault);
+        column.setMappedTypeCode(mappedTypeCode);
+        testReader.parseDefaultValue(column);
+        assertEquals(parsedDefault, column.getDefaultValue());
+    }
+
+    @ParameterizedTest
     @Disabled
     @CsvSource({ "INSERT,1,0,0", "UPDATE,0,1,0", "DELETE,0,0,1", })
     void testGetTriggers(String triggerTypeParam, String isInsert, String isUpdate, String isDelete) throws Exception {

--- a/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/mssql/MsSql2008DdlReaderTest.java
+++ b/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/mssql/MsSql2008DdlReaderTest.java
@@ -166,6 +166,51 @@ class MsSql2008DdlReaderTest {
         assertEquals(parsedDefault, column.getDefaultValue());
     }
 
+    @Test
+    @DisplayName("Parse Default Value for VARCHAR with unescaping")
+    void testParseDefaultVarcharValue() throws Exception {
+        MockDbDataSource mockDataSource = new MockDbDataSource(MsSqlDatabasePlatform_VERSION10);
+        String originalDefault = "'John''s'";
+        String expectedDefault = "John's";
+        int mappedTypeCode = Types.VARCHAR;
+        MsSqlDdlReader testReader = createMsSqlDdlReader(mockDataSource);
+        Column column = new Column();
+        column.setDefaultValue(originalDefault);
+        column.setMappedTypeCode(mappedTypeCode);
+        String result = testReader.unescapeTextValue(originalDefault, column);
+        assertEquals(expectedDefault, result);
+    }
+
+    @Test
+    @DisplayName("Parse Default Value for NVARCHAR with unescaping")
+    void testParseDefaultNVarcharValue() throws Exception {
+        MockDbDataSource mockDataSource = new MockDbDataSource(MsSqlDatabasePlatform_VERSION10);
+        String originalDefault = "N'John''s'";
+        String expectedDefault = "John's";
+        int mappedTypeCode = Types.NVARCHAR;
+        MsSqlDdlReader testReader = createMsSqlDdlReader(mockDataSource);
+        Column column = new Column();
+        column.setDefaultValue(originalDefault);
+        column.setMappedTypeCode(mappedTypeCode);
+        String result = testReader.unescapeTextValue(originalDefault, column);
+        assertEquals(expectedDefault, result);
+    }
+
+    @Test
+    @DisplayName("Parse Default Value for LONGVARCHAR no unescaping required")
+    void testParseDefaultLongVarcharValue() throws Exception {
+        MockDbDataSource mockDataSource = new MockDbDataSource(MsSqlDatabasePlatform_VERSION10);
+        String originalDefault = "coalesce([Description]+' ','')";
+        String expectedDefault = "coalesce([Description]+' ','')";
+        int mappedTypeCode = Types.NVARCHAR;
+        MsSqlDdlReader testReader = createMsSqlDdlReader(mockDataSource);
+        Column column = new Column();
+        column.setDefaultValue(originalDefault);
+        column.setMappedTypeCode(mappedTypeCode);
+        String result = testReader.unescapeTextValue(originalDefault, column);
+        assertEquals(expectedDefault, result);
+    }
+
     @ParameterizedTest
     @Disabled
     @CsvSource({ "INSERT,1,0,0", "UPDATE,0,1,0", "DELETE,0,0,1", })


### PR DESCRIPTION
Calling `unescape()` here can cause certain default values to become invalid. I could not find a reason why `unescape()` should be called here, since the default values come straight from the database. The unit tests for `MsSqlDdlReader` still pass with this change in place. Let me know if there's something I'm missing here.

This is likely a wider issue because `unescape()` is called by 13 other `IDdlReader`s with the same `"'"` and `"''"` arguments. Let me know if I should look into this further.