### PR TITLE
0006862: Remove trailing slash from sync URL

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/AbstractParameterService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/AbstractParameterService.java
@@ -194,7 +194,7 @@ abstract public class AbstractParameterService {
             String value = getString(ParameterConstants.SYNC_URL);
             value = SymmetricUtils.substituteScripts(value, getReplacementValues());
             if (value != null) {
-                value = value.trim();
+                value = value.trim().replaceAll("[/\\\\]+$", "");
             }
             syncUrl = value;
             if (log.isDebugEnabled()) {


### PR DESCRIPTION
Issue: https://issues.symmetricds.org/view.php?id=6862

This change prevents issues with starting up when a user changes their sync URL in the engine file to have a trailing '/' or '\'. 

If the user adds a trailing slash in the deploy wizard however, this does not resolve that. I can add a way to resolve that issue though by adjusting the code in EndpointScreen.java though. Let me know if I should do so!