### PR TITLE
0006939: Changed log messages from info level to warn level and documented Too Many Form Keys insight

### DIFF
--- a/symmetric-assemble/src/asciidoc/configuration/monitors.ad
+++ b/symmetric-assemble/src/asciidoc/configuration/monitors.ad
@@ -91,6 +91,8 @@ be compared to a threshold value.
 
 |unknownCa|Number of nodes that have recently experienced a "PKIX path building failed" error due to an unknown certificate authority. The duration in the past during which this insight checks for errors is determined by the purge.log.summary.retention.minutes parameter, which defaults to 60 minutes.|✔
 
+|formKeys|Value of 0, 1, or 2 indicating whether acknowledgments are failing during a pull due to too many form keys. A value of 0 indicates that there were no failures. A value of 1 indicates that there were failures and SymmetricDS was able to temporarily resolve them. A value of 2 indicates that there were failures and SymmetricDS was unable to resolve them.|✔
+
 |===
 
 Expression:: An expression used by the monitor to set options specific to the monitor type. For batchError monitors, setting the expression to

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/transport/http/HttpTransportManager.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/transport/http/HttpTransportManager.java
@@ -136,10 +136,10 @@ public class HttpTransportManager extends AbstractTransportManager implements IT
                         } else {
                             backOffPostCount++;
                             if (maxFormKeys > FORM_KEYS_PER_BATCH) {
-                                log.info("Ack received a {} response from node {}. The form key limit will be reduced from {} to {} during the next attempt.",
+                                log.warn("Ack received a {} response from node {}. The form key limit will be reduced from {} to {} during the next attempt.",
                                         statusCode, remote.getNodeId(), maxFormKeys, Math.max(maxFormKeys / 2, FORM_KEYS_PER_BATCH));
                             } else {
-                                log.info("Ack received a {} response from node {}. A form key limit of 50000 will take effect during the next attempt.",
+                                log.warn("Ack received a {} response from node {}. A form key limit of 50000 will take effect during the next attempt.",
                                         statusCode, remote.getNodeId());
                             }
                         }

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/transport/http/HttpTransportManager.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/transport/http/HttpTransportManager.java
@@ -60,6 +60,7 @@ import org.slf4j.LoggerFactory;
  */
 public class HttpTransportManager extends AbstractTransportManager implements ITransportManager {
     private static final Logger log = LoggerFactory.getLogger(HttpTransportManager.class);
+    public static final int DEFAULT_MAX_FORM_KEYS = 100000;
     protected ISymmetricEngine engine;
     protected Map<String, String> sessionIdByUri = new HashMap<String, String>();
     protected boolean useHeaderSecurityToken;
@@ -119,7 +120,7 @@ public class HttpTransportManager extends AbstractTransportManager implements IT
         if (list != null && list.size() > 0) {
             int maxFormKeys = engine.getParameterService().getInt(ParameterConstants.TRANSPORT_MAX_FORM_KEYS);
             if (backOffPostCount > 0 && maxFormKeys <= 0) {
-                maxFormKeys = 100000;
+                maxFormKeys = DEFAULT_MAX_FORM_KEYS;
             }
             for (int i = 0; i < backOffPostCount && maxFormKeys > 1; i++) {
                 maxFormKeys /= 2;
@@ -139,8 +140,8 @@ public class HttpTransportManager extends AbstractTransportManager implements IT
                                 log.warn("Ack received a {} response from node {}. The form key limit will be reduced from {} to {} during the next attempt.",
                                         statusCode, remote.getNodeId(), maxFormKeys, Math.max(maxFormKeys / 2, FORM_KEYS_PER_BATCH));
                             } else {
-                                log.warn("Ack received a {} response from node {}. A form key limit of 50000 will take effect during the next attempt.",
-                                        statusCode, remote.getNodeId());
+                                log.warn("Ack received a {} response from node {}. A form key limit of {} will take effect during the next attempt.",
+                                        statusCode, remote.getNodeId(), DEFAULT_MAX_FORM_KEYS / 2);
                             }
                         }
                     }


### PR DESCRIPTION
I had to change these log messages to `warn` level because `LogSummaryAppender` doesn't track `info`-level log messages.