### PR TITLE
0006947: Mapped the MySQL INT UNSIGNED data type to BIGINT

### DIFF
--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/mysql/MySqlDdlReader.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/mysql/MySqlDdlReader.java
@@ -160,6 +160,8 @@ public class MySqlDdlReader extends AbstractJdbcDdlReader {
         if ("YEAR".equals(typeName)) {
             // it is safe to map a YEAR to INTEGER
             return Types.INTEGER;
+        } else if ("INT UNSIGNED".equals(typeName)) {
+            return Types.BIGINT;
         } else if (typeName != null && typeName.endsWith("TEXT")) {
             String catalog = (String) values.get("TABLE_CAT");
             String tableName = (String) values.get("TABLE_NAME");


### PR DESCRIPTION
I reproduced the issue and confirmed that my change maps `INT UNSIGNED` to `BIGINT` in the XML and SQL:

```
2025-06-16 12:31:15,421 INFO [] [SqlRunner] [sql-runner-251] [server] Executing by no_user: create table unsigned_test (id int primary key, test int(10) unsigned)
...
2025-06-16 12:44:26,684 INFO [client] [DefaultDatabaseWriter] [client-dataloader-8] Incoming batch server-19 on channel config contains the following table definition: <?xml version="1.0"?>
<!DOCTYPE database SYSTEM "http://db.apache.org/torque/dtd/database">
<database name="dataextractor">
	<table name="unsigned_test">
		<column name="id" primaryKey="true" primaryKeySeq="1" required="true" type="INTEGER" size="10">
			<platform-column name="mysql" type="INT" size="10"/>
		</column>
		<column name="test" type="BIGINT" size="10">
			<platform-column name="mysql" type="INT UNSIGNED" size="10"/>
		</column>
	</table>
</database>
2025-06-16 12:44:26,689 INFO [client] [ModelComparator] [client-dataloader-8] Table unsigned_test needs to be added
2025-06-16 12:44:26,690 INFO [client] [PostgreSql95DatabasePlatform] [client-dataloader-8] Running alter sql:
CREATE TABLE "public"."unsigned_test"(
    "id" INTEGER NOT NULL,
    "test" BIGINT,
    PRIMARY KEY ("id")
);
```