### PR TITLE
0006980: Made the registration server set its own sym_node_security row's registration_enabled flag to 0 if it's 1 during startup

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/AbstractSymmetricEngine.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/AbstractSymmetricEngine.java
@@ -506,23 +506,26 @@ abstract public class AbstractSymmetricEngine implements ISymmetricEngine {
             stagingManager.clean(0);
         }
         node = nodeService.findIdentity();
-        if (node == null && parameterService.isRegistrationServer()
-                && parameterService.is(ParameterConstants.AUTO_INSERT_REG_SVR_IF_NOT_FOUND, false)) {
-            log.info("Inserting rows for node, security, identity and group for registration server");
-            String nodeId = parameterService.getExternalId();
-            node = new Node(parameterService, symmetricDialect, platform.getName());
-            node.setNodeId(node.getExternalId());
-            nodeService.save(node);
-            nodeService.insertNodeIdentity(nodeId);
-            node = nodeService.findIdentity();
-            nodeService.insertNodeGroup(node.getNodeGroupId(), null);
-            NodeSecurity nodeSecurity = nodeService.findOrCreateNodeSecurity(nodeId);
-            nodeSecurity.setInitialLoadTime(new Date());
-            nodeSecurity.setInitialLoadEndTime(new Date());
-            nodeSecurity.setRegistrationTime(new Date());
-            nodeSecurity.setInitialLoadEnabled(false);
-            nodeSecurity.setRegistrationEnabled(false);
-            nodeService.updateNodeSecurity(nodeSecurity);
+        if (parameterService.isRegistrationServer()) {
+            if (node == null && parameterService.is(ParameterConstants.AUTO_INSERT_REG_SVR_IF_NOT_FOUND, false)) {
+                log.info("Inserting rows for node, security, identity and group for registration server");
+                String nodeId = parameterService.getExternalId();
+                node = new Node(parameterService, symmetricDialect, platform.getName());
+                node.setNodeId(node.getExternalId());
+                nodeService.save(node);
+                nodeService.insertNodeIdentity(nodeId);
+                node = nodeService.findIdentity();
+                nodeService.insertNodeGroup(node.getNodeGroupId(), null);
+                NodeSecurity nodeSecurity = nodeService.findOrCreateNodeSecurity(nodeId);
+                nodeSecurity.setInitialLoadTime(new Date());
+                nodeSecurity.setInitialLoadEndTime(new Date());
+                nodeSecurity.setRegistrationTime(new Date());
+                nodeSecurity.setInitialLoadEnabled(false);
+                nodeSecurity.setRegistrationEnabled(false);
+                nodeService.updateNodeSecurity(nodeSecurity);
+            } else if (node != null) {
+                disableRegistrationIfNecessary(node.getNodeId());
+            }
         }
     }
 
@@ -616,6 +619,16 @@ abstract public class AbstractSymmetricEngine implements ISymmetricEngine {
             }
         }
         return loaded;
+    }
+
+    protected void disableRegistrationIfNecessary(String registrationServerNodeId) {
+        NodeSecurity nodeSecurity = nodeService.findNodeSecurity(registrationServerNodeId);
+        if (nodeSecurity != null && nodeSecurity.isRegistrationEnabled()) {
+            log.info("Node {} is a registration server and its registration_enabled flag in {} is set to 1. Setting it back to 0.",
+                    registrationServerNodeId, TableConstants.getTableName(getTablePrefix(), TableConstants.SYM_NODE_SECURITY));
+            nodeSecurity.setRegistrationEnabled(false);
+            nodeService.updateNodeSecurity(nodeSecurity);
+        }
     }
 
     public synchronized boolean start() {

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/PullService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/PullService.java
@@ -101,7 +101,7 @@ public class PullService extends AbstractOfflineDetectorService implements IPull
                                             .getCreatedAtNodeId());
                                 }
                             }
-                            if (availableThreads > 0 && meetsMinimumTime && !m2mLockout && nodeSecurity != null && !nodeSecurity.isRegistrationEnabled()) {
+                            if (availableThreads > 0 && meetsMinimumTime && !m2mLockout && isAllowedToPull(nodeSecurity, identity.getNodeId())) {
                                 if (nodeCommunicationService.execute(nodeCommunication, statuses, this)) {
                                     availableThreads--;
                                 }
@@ -134,6 +134,11 @@ public class PullService extends AbstractOfflineDetectorService implements IPull
             }
         }
         return filteredNodes;
+    }
+
+    protected boolean isAllowedToPull(NodeSecurity nodeSecurity, String currentNodeId) {
+        return nodeSecurity != null
+                && (!nodeSecurity.isRegistrationEnabled() || !currentNodeId.equals(nodeSecurity.getCreatedAtNodeId()));
     }
 
     public void execute(NodeCommunication nodeCommunication, RemoteNodeStatus status) {

--- a/symmetric-core/src/test/java/org/jumpmind/symmetric/service/impl/PullServiceTest.java
+++ b/symmetric-core/src/test/java/org/jumpmind/symmetric/service/impl/PullServiceTest.java
@@ -1,0 +1,48 @@
+package org.jumpmind.symmetric.service.impl;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.jumpmind.db.platform.IDatabasePlatform;
+import org.jumpmind.symmetric.ISymmetricEngine;
+import org.jumpmind.symmetric.db.ISymmetricDialect;
+import org.jumpmind.symmetric.model.NodeSecurity;
+import org.jumpmind.symmetric.service.IParameterService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class PullServiceTest {
+    protected PullService pullService;
+
+    @BeforeEach
+    public void setUp() {
+        ISymmetricEngine engine = mock(ISymmetricEngine.class);
+        IParameterService parameterService = mock(IParameterService.class);
+        ISymmetricDialect symmetricDialect = mock(ISymmetricDialect.class);
+        IDatabasePlatform databasePlatform = mock(IDatabasePlatform.class);
+        when(engine.getParameterService()).thenReturn(parameterService);
+        when(engine.getSymmetricDialect()).thenReturn(symmetricDialect);
+        when(symmetricDialect.getPlatform()).thenReturn(databasePlatform);
+        pullService = new PullService(engine);
+    }
+
+    @Test
+    public void testIsAllowedToPull() {
+        NodeSecurity nodeSecurity = null;
+        assertFalse(pullService.isAllowedToPull(nodeSecurity, "current_node"));
+        nodeSecurity = new NodeSecurity();
+        nodeSecurity.setRegistrationEnabled(false);
+        assertTrue(pullService.isAllowedToPull(nodeSecurity, "current_node"));
+        nodeSecurity.setRegistrationEnabled(true);
+        nodeSecurity.setCreatedAtNodeId(null);
+        assertTrue(pullService.isAllowedToPull(nodeSecurity, "current_node"));
+        nodeSecurity.setCreatedAtNodeId("");
+        assertTrue(pullService.isAllowedToPull(nodeSecurity, "current_node"));
+        nodeSecurity.setCreatedAtNodeId("parent_node");
+        assertTrue(pullService.isAllowedToPull(nodeSecurity, "current_node"));
+        nodeSecurity.setCreatedAtNodeId("current_node");
+        assertFalse(pullService.isAllowedToPull(nodeSecurity, "current_node"));
+    }
+}


### PR DESCRIPTION
This issue's target version is 3.16.5, so this PR shouldn't be merged until after 3.16.4 has been released.

To begin with, the only changes I made were to `AbstractSymmetricEngine`. However, I found that when the registration server updates its own `sym_node_security` row's `registration_enabled` flag to 0, the client node doesn't pull the change because the flag is still set to 1 in its database.

When we discussed this issue, we decided to only prevent pulling from a node with `registration_enabled=1` if it was created at the current node or if the `created_at_node_id` is blank. However, this didn't resolve the issue because the registration server's `created_at_node_id` is blank. To resolve the issue, I decided not to check if the `created_at_node_id` is blank. Let me know if this needs changed.
