### PR TITLE
0006991: Added a monitor that detects a backlog of PostgreSQL Write-Ahead Logging (WAL) changes that aren't mined yet

### DIFF
--- a/symmetric-assemble/src/asciidoc/configuration/monitors.ad
+++ b/symmetric-assemble/src/asciidoc/configuration/monitors.ad
@@ -49,6 +49,8 @@ be compared to a threshold value.
 
 |licenseRows|Percentage from 0 to 100 of rows used out of the maximum number of rows allowed by the license.|
 
+|postgresWal|Size in MB of the backlog of PostgreSQL Write-Ahead Logging (WAL) changes that haven't yet been mined by the PostgreSQL log miner.|
+
 |jvm64Bit|Value of 0 or 1 indicating whether or not the operating system is 64-bit and the JVM is 32-bit.|✔
 
 |jvmCrash|Number of Java crash files found that were created or modified in the last 24 hours.|✔

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/common/MonitorConstants.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/common/MonitorConstants.java
@@ -62,6 +62,7 @@ public class MonitorConstants {
     public static final String STRANDED_OR_EXPIRED_DATA = "strandedOrExpiredData";
     public static final String UNKNOWN_CA = "unknownCa";
     public static final String INCOMPATIBLE_DATETIME = "incompatibleDatetime";
+    public static final String POSTGRES_WAL = "postgresWal";
 
     public static Map<String, String> getMonitorTypesByVersion() {
         Map<String, String> map = new HashMap<String, String>();
@@ -78,6 +79,9 @@ public class MonitorConstants {
         }
         for (String name : new String[] { INCOMPATIBLE_DATETIME }) {
             map.put(name, "3.16.2");
+        }
+        for (String name : new String[] { POSTGRES_WAL }) {
+            map.put(name, "3.16.5");
         }
         return map;
     }


### PR DESCRIPTION
This issue's target version is 3.16.5, so this PR shouldn't be merged until after 3.16.4 has been released.