### PR TITLE
0006990: Set the Postgres DatabaseInfo's triggersCreateOrReplaceSupported property to true

### DIFF
--- a/symmetric-client/src/main/java/org/jumpmind/symmetric/db/postgresql/PostgreSqlSymmetricDialect.java
+++ b/symmetric-client/src/main/java/org/jumpmind/symmetric/db/postgresql/PostgreSqlSymmetricDialect.java
@@ -58,9 +58,9 @@ public class PostgreSqlSymmetricDialect extends AbstractSymmetricDialect impleme
 
     public PostgreSqlSymmetricDialect(IParameterService parameterService, IDatabasePlatform platform) {
         super(parameterService, platform);
+        versionSupportsReplaceTriggers = databaseMajorVersion >= 14;
         this.triggerTemplate = new PostgreSqlTriggerTemplate(this);
         this.supportsDdlTriggers = databaseMajorVersion > 9 || (databaseMajorVersion == 9 && databaseMinorVersion >= 3);
-        versionSupportsReplaceTriggers = databaseMajorVersion >= 14;
         if (parameterService.is(ParameterConstants.ROUTING_GAPS_USE_TRANSACTION_VIEW)) {
             try {
                 getEarliestTransactionStartTime();
@@ -71,6 +71,7 @@ public class PostgreSqlSymmetricDialect extends AbstractSymmetricDialect impleme
             }
         }
         platform.getDatabaseInfo().setGeneratedColumnsSupported(databaseMajorVersion >= 12);
+        platform.getDatabaseInfo().setTriggersCreateOrReplaceSupported(versionSupportsReplaceTriggers);
         sharedTriggersDisabledFunction = this.parameterService.getTablePrefix() + "_triggers_disabled";
         sharedNodeDisabledFunction = this.parameterService.getTablePrefix() + "_node_disabled";
         sharedReadLargeObjectFunction = this.parameterService.getTablePrefix() + "_largeobject";


### PR DESCRIPTION
The issue description says to set the property in the DDL builder. I tried that but ran into some issues because the `databaseMajorVersion` comes from the SQL template, which is initialized after the DDL builder in the `AbstractJdbcDatabasePlatform` constructor.

I noticed that `PostgreSqlSymmetricDialect` already has a `versionSupportsReplaceTriggers` variable, so I set the property in its constructor instead. I had to move `versionSupportsReplaceTriggers` above the trigger template because it needs to be set before the `PostgreSqlTriggerTemplate` constructor calls `getCreateTriggerCommandBeginning()`.