### PR TITLE
0006922: Removed DDL trigger when uninstalling a node

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/AbstractSymmetricEngine.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/AbstractSymmetricEngine.java
@@ -848,10 +848,8 @@ abstract public class AbstractSymmetricEngine implements ISymmetricEngine {
             }
             processInfo.incrementCurrentDataCount();
             if (platform.readTableFromDatabase(null, null, TableConstants.getTableName(prefix, TableConstants.SYM_LOCK)) != null) {
-                if (parameterService.is(ParameterConstants.TRIGGER_CAPTURE_DDL_CHANGES)) {
-                    parameterService.saveParameter(parameterService.getExternalId(), parameterService.getNodeGroupId(),
-                            ParameterConstants.TRIGGER_CAPTURE_DDL_CHANGES, false, Constants.SYSTEM_USER);
-                }
+                disableParameter(ParameterConstants.TRIGGER_CAPTURE_DDL_CHANGES);
+                disableParameter(ParameterConstants.POSTGRES_TRIGGER_CAPTURE_TRUNCATE);
                 // this should remove all triggers because we have removed all the trigger configuration
                 triggerRouterService.syncTriggers(true);
             }
@@ -879,6 +877,13 @@ abstract public class AbstractSymmetricEngine implements ISymmetricEngine {
         parameterService.setDatabaseHasBeenInitialized(false);
         processInfo.setCurrentDataCount(totalStepCount);
         log.info("Finished uninstalling SymmetricDS database objects from the database");
+    }
+
+    private void disableParameter(String parameter) {
+        if (parameterService.is(parameter)) {
+            parameterService.saveParameter(parameterService.getExternalId(), parameterService.getNodeGroupId(),
+                    parameter, false, Constants.SYSTEM_USER);
+        }
     }
 
     private static ISqlResultsListener generateDropTablesListener(ProcessInfo processInfo, int dropTablesWeight,

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/AbstractSymmetricEngine.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/AbstractSymmetricEngine.java
@@ -848,6 +848,10 @@ abstract public class AbstractSymmetricEngine implements ISymmetricEngine {
             }
             processInfo.incrementCurrentDataCount();
             if (platform.readTableFromDatabase(null, null, TableConstants.getTableName(prefix, TableConstants.SYM_LOCK)) != null) {
+                if (parameterService.is(ParameterConstants.TRIGGER_CAPTURE_DDL_CHANGES)) {
+                    parameterService.saveParameter(parameterService.getExternalId(), parameterService.getNodeGroupId(),
+                            ParameterConstants.TRIGGER_CAPTURE_DDL_CHANGES, false, Constants.SYSTEM_USER);
+                }
                 // this should remove all triggers because we have removed all the trigger configuration
                 triggerRouterService.syncTriggers(true);
             }


### PR DESCRIPTION
Even though `trigger.capture.ddl.changes` is a startup parameter, setting it to false in `sym_parameter` still takes effect and overrides the engine file. Then, when syncing triggers, `TriggerRouterService.updateOrCreateDdlTriggers()` removes the DDL trigger.