### PR TITLE
Improvement/0006994 fail build on test failure

### DIFF
--- a/symmetric-assemble/common.gradle
+++ b/symmetric-assemble/common.gradle
@@ -256,7 +256,6 @@ subprojects { subproject ->
     }
 
     def integrationTest = tasks.register("integrationTest", Test) {
-        ignoreFailures true
         minHeapSize = "128m"
         maxHeapSize = "512m"
         forkEvery=1

--- a/symmetric-assemble/common.gradle
+++ b/symmetric-assemble/common.gradle
@@ -247,7 +247,6 @@ subprojects { subproject ->
     }
     
     test {
-        ignoreFailures = true
         minHeapSize = "128m"
         maxHeapSize = "512m"
         useJUnitPlatform {


### PR DESCRIPTION
Before:
Unit test fails -> ./gradle build passes
integration test fails -> ./gradle integrationTest passes

After:
Unit test fails -> ./gradle build fails
integration test fails -> ./gradle integrationTest fails

The change impacts both PRO and open source projects. 
When open source unit test fails, PRO build fails. 
But not vice versa. 

