### PR TITLE
0007000: Cached the lists of table names in each catalog/schema in the DDL reader

### DIFF
--- a/symmetric-db/src/main/java/org/jumpmind/db/platform/AbstractDatabasePlatform.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/platform/AbstractDatabasePlatform.java
@@ -409,6 +409,10 @@ public abstract class AbstractDatabasePlatform implements IDatabasePlatform {
 
     @Override
     public void resetCachedTableModel() {
+        resetCachedTableModel(true);
+    }
+
+    protected void resetCachedTableModel(boolean clearTableNameCache) {
         this.tableCache = Collections.synchronizedMap(new HashMap<String, Table>());
         lastTimeCachedModelClearedInMs = System.currentTimeMillis();
     }
@@ -421,7 +425,7 @@ public abstract class AbstractDatabasePlatform implements IDatabasePlatform {
     @Override
     public Table getTableFromCache(String catalogName, String schemaName, String tableName, boolean forceReread) {
         if (System.currentTimeMillis() - lastTimeCachedModelClearedInMs > clearCacheModelTimeoutInMs) {
-            resetCachedTableModel();
+            resetCachedTableModel(false);
         }
         Map<String, Table> model = tableCache;
         String key = Table.getFullyQualifiedTableName(catalogName, schemaName, tableName);

--- a/symmetric-jdbc/src/main/java/org/jumpmind/cache/ObjectDefinitionCache.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/cache/ObjectDefinitionCache.java
@@ -75,8 +75,10 @@ public class ObjectDefinitionCache {
     }
 
     public void clearTableNameCache() {
-        tableNameCache.clear();
-        tableNameCacheTime = System.currentTimeMillis();
+        synchronized (tableNameCacheLock) {
+            tableNameCache.clear();
+            tableNameCacheTime = System.currentTimeMillis();
+        }
     }
 
     private class TableNameCacheKey {

--- a/symmetric-jdbc/src/main/java/org/jumpmind/cache/ObjectDefinitionCache.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/cache/ObjectDefinitionCache.java
@@ -1,0 +1,132 @@
+/**
+ * Licensed to JumpMind Inc under one or more contributor
+ * license agreements.  See the NOTICE file distributed
+ * with this work for additional information regarding
+ * copyright ownership.  JumpMind Inc licenses this file
+ * to you under the GNU General Public License, version 3.0 (GPLv3)
+ * (the "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3.0 (GPLv3) along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jumpmind.cache;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.jumpmind.db.platform.AbstractJdbcDdlReader;
+
+public class ObjectDefinitionCache {
+    private AbstractJdbcDdlReader ddlReader;
+    private Object tableNameCacheLock = new Object();
+    volatile private Map<TableNameCacheKey, List<String>> tableNameCache = new HashMap<TableNameCacheKey, List<String>>();
+    volatile private long tableNameCacheTime;
+
+    public ObjectDefinitionCache(AbstractJdbcDdlReader ddlReader) {
+        this.ddlReader = ddlReader;
+    }
+
+    public List<String> getTableNames(String catalog, String schema, String[] tableTypes) {
+        TableNameCacheKey cacheKey = new TableNameCacheKey(catalog, schema, tableTypes);
+        long cacheTimeoutInMs = ddlReader.getPlatform().getClearCacheModelTimeoutInMs();
+        List<String> tableNames;
+        synchronized (tableNameCacheLock) {
+            boolean timedOut = System.currentTimeMillis() - tableNameCacheTime >= cacheTimeoutInMs;
+            tableNames = tableNameCache.get(cacheKey);
+            if (timedOut || tableNames == null) {
+                if (timedOut) {
+                    clearTableNameCache();
+                }
+                tableNames = ddlReader.getTableNamesFromDatabase(catalog, schema, tableTypes);
+                tableNameCache.put(cacheKey, tableNames);
+            }
+        }
+        return tableNames;
+    }
+
+    public void clearTableNameCache() {
+        tableNameCache.clear();
+        tableNameCacheTime = System.currentTimeMillis();
+    }
+
+    private class TableNameCacheKey {
+        private String catalog;
+        private String schema;
+        private String[] tableTypes;
+
+        public TableNameCacheKey(String catalog, String schema, String[] tableTypes) {
+            this.catalog = catalog;
+            this.schema = schema;
+            this.tableTypes = tableTypes;
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + ((catalog == null) ? 0 : catalog.hashCode());
+            result = prime * result + ((schema == null) ? 0 : schema.hashCode());
+            result = prime * result + Arrays.hashCode(tableTypes);
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (!(obj instanceof TableNameCacheKey)) {
+                return false;
+            }
+            TableNameCacheKey other = (TableNameCacheKey) obj;
+            if (catalog == null) {
+                if (other.catalog != null) {
+                    return false;
+                }
+            } else if (!catalog.equals(other.catalog)) {
+                return false;
+            }
+            if (schema == null) {
+                if (other.schema != null) {
+                    return false;
+                }
+            } else if (!schema.equals(other.schema)) {
+                return false;
+            }
+            if (!Arrays.equals(tableTypes, other.tableTypes)) {
+                return false;
+            }
+            return true;
+        }
+    }
+}

--- a/symmetric-jdbc/src/main/java/org/jumpmind/cache/ObjectDefinitionCache.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/cache/ObjectDefinitionCache.java
@@ -44,6 +44,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.jumpmind.db.model.CatalogSchema;
 import org.jumpmind.db.platform.AbstractJdbcDdlReader;
 
 public class ObjectDefinitionCache {
@@ -56,8 +57,8 @@ public class ObjectDefinitionCache {
         this.ddlReader = ddlReader;
     }
 
-    public List<String> getTableNames(String catalog, String schema, String[] tableTypes) {
-        TableNameCacheKey cacheKey = new TableNameCacheKey(catalog, schema, tableTypes);
+    public List<String> getTableNames(CatalogSchema catalogSchema, String[] tableTypes) {
+        TableNameCacheKey cacheKey = new TableNameCacheKey(catalogSchema, tableTypes);
         long cacheTimeoutInMs = ddlReader.getPlatform().getClearCacheModelTimeoutInMs();
         List<String> tableNames;
         synchronized (tableNameCacheLock) {
@@ -67,7 +68,7 @@ public class ObjectDefinitionCache {
                 if (timedOut) {
                     clearTableNameCache();
                 }
-                tableNames = ddlReader.getTableNamesFromDatabase(catalog, schema, tableTypes);
+                tableNames = ddlReader.getTableNamesFromDatabase(catalogSchema.getCatalog(), catalogSchema.getSchema(), tableTypes);
                 tableNameCache.put(cacheKey, tableNames);
             }
         }
@@ -82,13 +83,11 @@ public class ObjectDefinitionCache {
     }
 
     private class TableNameCacheKey {
-        private String catalog;
-        private String schema;
+        private CatalogSchema catalogSchema;
         private String[] tableTypes;
 
-        public TableNameCacheKey(String catalog, String schema, String[] tableTypes) {
-            this.catalog = catalog;
-            this.schema = schema;
+        public TableNameCacheKey(CatalogSchema catalogSchema, String[] tableTypes) {
+            this.catalogSchema = catalogSchema;
             this.tableTypes = tableTypes;
         }
 
@@ -96,8 +95,7 @@ public class ObjectDefinitionCache {
         public int hashCode() {
             final int prime = 31;
             int result = 1;
-            result = prime * result + ((catalog == null) ? 0 : catalog.hashCode());
-            result = prime * result + ((schema == null) ? 0 : schema.hashCode());
+            result = prime * result + ((catalogSchema == null) ? 0 : catalogSchema.hashCode());
             result = prime * result + Arrays.hashCode(tableTypes);
             return result;
         }
@@ -111,18 +109,11 @@ public class ObjectDefinitionCache {
                 return false;
             }
             TableNameCacheKey other = (TableNameCacheKey) obj;
-            if (catalog == null) {
-                if (other.catalog != null) {
+            if (catalogSchema == null) {
+                if (other.catalogSchema != null) {
                     return false;
                 }
-            } else if (!catalog.equals(other.catalog)) {
-                return false;
-            }
-            if (schema == null) {
-                if (other.schema != null) {
-                    return false;
-                }
-            } else if (!schema.equals(other.schema)) {
+            } else if (!catalogSchema.equals(other.catalogSchema)) {
                 return false;
             }
             if (!Arrays.equals(tableTypes, other.tableTypes)) {

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/AbstractJdbcDatabasePlatform.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/AbstractJdbcDatabasePlatform.java
@@ -83,4 +83,12 @@ abstract public class AbstractJdbcDatabasePlatform extends AbstractDatabasePlatf
             }
         }
     }
+
+    @Override
+    protected void resetCachedTableModel(boolean clearTableNameCache) {
+        super.resetCachedTableModel(clearTableNameCache);
+        if (clearTableNameCache && ddlReader instanceof AbstractJdbcDdlReader jdbcDdlReader) {
+            jdbcDdlReader.clearTableNameCache();
+        }
+    }
 }

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/AbstractJdbcDdlReader.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/AbstractJdbcDdlReader.java
@@ -66,6 +66,7 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.jumpmind.cache.ObjectDefinitionCache;
+import org.jumpmind.db.model.CatalogSchema;
 import org.jumpmind.db.model.Column;
 import org.jumpmind.db.model.Database;
 import org.jumpmind.db.model.ForeignKey;
@@ -1561,7 +1562,7 @@ public abstract class AbstractJdbcDdlReader implements IDdlReader {
 
     public List<String> getTableNames(final String catalog, final String schema,
             final String[] tableTypes) {
-        return objectDefinitionCache.getTableNames(catalog, schema, tableTypes);
+        return objectDefinitionCache.getTableNames(new CatalogSchema(catalog, schema), tableTypes);
     }
 
     public List<String> getTableNamesFromDatabase(final String catalog, final String schema,

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/AbstractJdbcDdlReader.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/AbstractJdbcDdlReader.java
@@ -65,6 +65,7 @@ import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
+import org.jumpmind.cache.ObjectDefinitionCache;
 import org.jumpmind.db.model.Column;
 import org.jumpmind.db.model.Database;
 import org.jumpmind.db.model.ForeignKey;
@@ -112,6 +113,8 @@ public abstract class AbstractJdbcDdlReader implements IDdlReader {
     private final List<MetaDataColumnDescriptor> _columnsForIndex;
     /* The platform that this model reader belongs to. */
     protected IDatabasePlatform platform;
+    /* The cache containing definitions of database objects. */
+    protected ObjectDefinitionCache objectDefinitionCache = new ObjectDefinitionCache(this);
     /*
      * Contains default column sizes (minimum sizes that a JDBC-compliant db must support).
      */
@@ -1558,6 +1561,11 @@ public abstract class AbstractJdbcDdlReader implements IDdlReader {
 
     public List<String> getTableNames(final String catalog, final String schema,
             final String[] tableTypes) {
+        return objectDefinitionCache.getTableNames(catalog, schema, tableTypes);
+    }
+
+    public List<String> getTableNamesFromDatabase(final String catalog, final String schema,
+            final String[] tableTypes) {
         JdbcSqlTemplate sqlTemplate = (JdbcSqlTemplate) platform.getSqlTemplateDirty();
         List<String> list = sqlTemplate.execute(new IConnectionCallback<List<String>>() {
             public List<String> execute(Connection connection) throws SQLException {
@@ -1580,6 +1588,10 @@ public abstract class AbstractJdbcDdlReader implements IDdlReader {
             }
         });
         return list;
+    }
+
+    public void clearTableNameCache() {
+        objectDefinitionCache.clearTableNameCache();
     }
 
     public List<String> getColumnNames(final String catalog, final String schema, final String tableName) {

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/mssql/MsSqlDdlReader.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/mssql/MsSqlDdlReader.java
@@ -398,7 +398,7 @@ public class MsSqlDdlReader extends AbstractJdbcDdlReader {
     }
 
     @Override
-    public List<String> getTableNames(final String catalog, final String schema,
+    public List<String> getTableNamesFromDatabase(final String catalog, final String schema,
             final String[] tableTypes) {
         StringBuilder sql = new StringBuilder("select \"TABLE_NAME\" from ");
         if (isNotBlank(catalog)) {

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/oracle/OracleDdlReader.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/oracle/OracleDdlReader.java
@@ -454,7 +454,7 @@ public class OracleDdlReader extends AbstractJdbcDdlReader {
         return String.format("%s", tableName).replaceAll("\\_", "/_");
     }
 
-    public List<String> getTableNames(final String catalog, final String schema,
+    public List<String> getTableNamesFromDatabase(final String catalog, final String schema,
             final String[] tableTypes) {
         List<String> tableNames = new ArrayList<String>();
         JdbcSqlTemplate sqlTemplate = (JdbcSqlTemplate) platform.getSqlTemplate();

--- a/symmetric-jdbc/src/test/java/org/jumpmind/cache/ObjectDefinitionCacheTest.java
+++ b/symmetric-jdbc/src/test/java/org/jumpmind/cache/ObjectDefinitionCacheTest.java
@@ -1,0 +1,69 @@
+/**
+ * Licensed to JumpMind Inc under one or more contributor
+ * license agreements.  See the NOTICE file distributed
+ * with this work for additional information regarding
+ * copyright ownership.  JumpMind Inc licenses this file
+ * to you under the GNU General Public License, version 3.0 (GPLv3)
+ * (the "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3.0 (GPLv3) along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jumpmind.cache;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.jumpmind.db.platform.AbstractJdbcDdlReader;
+import org.jumpmind.db.platform.IDatabasePlatform;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class ObjectDefinitionCacheTest {
+    private AbstractJdbcDdlReader ddlReader;
+    private IDatabasePlatform platform;
+
+    @BeforeEach
+    public void setup() {
+        ddlReader = mock(AbstractJdbcDdlReader.class);
+        platform = mock(IDatabasePlatform.class);
+        when(ddlReader.getPlatform()).thenReturn(platform);
+    }
+
+    @Test
+    public void tableNameCacheTest() {
+        ObjectDefinitionCache cache = new ObjectDefinitionCache(ddlReader);
+        when(ddlReader.getTableNamesFromDatabase("catalog", "schema", null)).thenReturn(Arrays.asList("table0"));
+        when(platform.getClearCacheModelTimeoutInMs()).thenReturn(3600000l);
+        List<String> tableNames = cache.getTableNames("catalog", "schema", null);
+        assertEquals(1, tableNames.size());
+        when(ddlReader.getTableNamesFromDatabase("catalog", "schema", null)).thenReturn(Arrays.asList("table0", "table1"));
+        tableNames = cache.getTableNames("catalog", "schema", null);
+        assertEquals(1, tableNames.size());
+        cache.clearTableNameCache();
+        tableNames = cache.getTableNames("catalog", "schema", null);
+        assertEquals(2, tableNames.size());
+        when(platform.getClearCacheModelTimeoutInMs()).thenReturn(5l);
+        when(ddlReader.getTableNamesFromDatabase("catalog", "schema", null)).thenReturn(Arrays.asList("table0"));
+        try {
+            Thread.sleep(10l);
+        } catch (InterruptedException e) {
+        }
+        tableNames = cache.getTableNames("catalog", "schema", null);
+        assertEquals(1, tableNames.size());
+        assertEquals("table0", tableNames.get(0));
+    }
+}

--- a/symmetric-jdbc/src/test/java/org/jumpmind/cache/ObjectDefinitionCacheTest.java
+++ b/symmetric-jdbc/src/test/java/org/jumpmind/cache/ObjectDefinitionCacheTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.when;
 import java.util.Arrays;
 import java.util.List;
 
+import org.jumpmind.db.model.CatalogSchema;
 import org.jumpmind.db.platform.AbstractJdbcDdlReader;
 import org.jumpmind.db.platform.IDatabasePlatform;
 import org.junit.jupiter.api.BeforeEach;
@@ -48,13 +49,14 @@ public class ObjectDefinitionCacheTest {
         ObjectDefinitionCache cache = new ObjectDefinitionCache(ddlReader);
         when(ddlReader.getTableNamesFromDatabase("catalog", "schema", null)).thenReturn(Arrays.asList("table0"));
         when(platform.getClearCacheModelTimeoutInMs()).thenReturn(3600000l);
-        List<String> tableNames = cache.getTableNames("catalog", "schema", null);
+        CatalogSchema catalogSchema = new CatalogSchema("catalog", "schema");
+        List<String> tableNames = cache.getTableNames(catalogSchema, null);
         assertEquals(1, tableNames.size());
         when(ddlReader.getTableNamesFromDatabase("catalog", "schema", null)).thenReturn(Arrays.asList("table0", "table1"));
-        tableNames = cache.getTableNames("catalog", "schema", null);
+        tableNames = cache.getTableNames(catalogSchema, null);
         assertEquals(1, tableNames.size());
         cache.clearTableNameCache();
-        tableNames = cache.getTableNames("catalog", "schema", null);
+        tableNames = cache.getTableNames(catalogSchema, null);
         assertEquals(2, tableNames.size());
         when(platform.getClearCacheModelTimeoutInMs()).thenReturn(5l);
         when(ddlReader.getTableNamesFromDatabase("catalog", "schema", null)).thenReturn(Arrays.asList("table0"));
@@ -62,7 +64,7 @@ public class ObjectDefinitionCacheTest {
             Thread.sleep(10l);
         } catch (InterruptedException e) {
         }
-        tableNames = cache.getTableNames("catalog", "schema", null);
+        tableNames = cache.getTableNames(catalogSchema, null);
         assertEquals(1, tableNames.size());
         assertEquals("table0", tableNames.get(0));
     }


### PR DESCRIPTION
I created new `org.jumpmind.cache` packages in `symmetric-jdbc` for `ObjectDefinitionCache` and `ObjectDefinitionCacheTest`. Let me know if there's a better place for these classes.