### PR TITLE
0007008: Allowed other threads to access the node channel cache while it's being refreshed

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/cache/ConfigurationCache.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/cache/ConfigurationCache.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Semaphore;
 
 import org.jumpmind.symmetric.ISymmetricEngine;
 import org.jumpmind.symmetric.common.ParameterConstants;
@@ -35,11 +36,14 @@ import org.jumpmind.symmetric.model.NodeGroupChannelWindow;
 import org.jumpmind.symmetric.model.NodeGroupLink;
 import org.jumpmind.symmetric.service.IConfigurationService;
 import org.jumpmind.symmetric.service.IParameterService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ConfigurationCache {
+    private final Logger log = LoggerFactory.getLogger(ConfigurationCache.class);
     private IParameterService parameterService;
     private IConfigurationService configurationService;
-    private Object configurationCacheLock = new Object();
+    private Semaphore configurationCacheLock = new Semaphore(1);
     volatile private Map<String, List<NodeChannel>> nodeChannelCache;
     volatile private Map<String, Channel> channelsCache;
     volatile private Collection<String> queuesCache;
@@ -56,24 +60,59 @@ public class ConfigurationCache {
     }
 
     public List<NodeChannel> getNodeChannels(String nodeId) {
+        if (nodeId == null) {
+            return new ArrayList<NodeChannel>(0);
+        }
+        checkNodeChannelCache(nodeId);
+        if (nodeChannelCache != null) {
+            return nodeChannelCache.getOrDefault(nodeId, new ArrayList<NodeChannel>(0));
+        }
+        return new ArrayList<NodeChannel>(0);
+    }
+
+    protected void checkNodeChannelCache(String nodeId) {
         long channelCacheTimeoutInMs = parameterService.getLong(ParameterConstants.CACHE_TIMEOUT_CHANNEL_IN_MS);
-        List<NodeChannel> nodeChannels;
-        synchronized (configurationCacheLock) {
-            nodeChannels = nodeChannelCache != null ? nodeChannelCache.get(nodeId) : null;
-            if (System.currentTimeMillis() - nodeChannelCacheTime >= channelCacheTimeoutInMs || nodeChannels == null) {
-                if (System.currentTimeMillis() - nodeChannelCacheTime >= channelCacheTimeoutInMs || nodeChannelCache == null) {
-                    nodeChannelCache = new HashMap<String, List<NodeChannel>>();
-                    nodeChannelCacheTime = System.currentTimeMillis();
+        List<NodeChannel> nodeChannels = nodeChannelCache != null ? nodeChannelCache.get(nodeId) : null;
+        if (System.currentTimeMillis() - nodeChannelCacheTime >= channelCacheTimeoutInMs || nodeChannelCache == null || nodeChannels == null) {
+            if (nodeChannelCache == null || nodeChannels == null) {
+                try {
+                    configurationCacheLock.acquire();
+                    try {
+                        boolean refreshCache = System.currentTimeMillis() - nodeChannelCacheTime >= channelCacheTimeoutInMs
+                                || nodeChannelCache == null;
+                        nodeChannels = nodeChannelCache != null ? nodeChannelCache.get(nodeId) : null;
+                        if (refreshCache || nodeChannels == null) {
+                            populateNodeChannelCache(nodeId, refreshCache, channelCacheTimeoutInMs);
+                        }
+                    } finally {
+                        configurationCacheLock.release();
+                    }
+                } catch (InterruptedException e) {
+                    log.error("Failed to retrieve node channels", e);
                 }
-                if (nodeId != null) {
-                    nodeChannels = configurationService.getNodeChannelsFromDb(nodeId);
-                    nodeChannelCache.put(nodeId, nodeChannels);
-                } else {
-                    nodeChannels = new ArrayList<NodeChannel>(0);
+            } else if (configurationCacheLock.tryAcquire()) {
+                try {
+                    populateNodeChannelCache(nodeId, true, channelCacheTimeoutInMs);
+                } finally {
+                    configurationCacheLock.release();
                 }
             }
         }
-        return nodeChannels;
+    }
+
+    protected void populateNodeChannelCache(String nodeId, boolean refreshCache, long channelCacheTimeoutInMs) {
+        long ts = System.currentTimeMillis();
+        List<NodeChannel> nodeChannels = configurationService.getNodeChannelsFromDb(nodeId);
+        if (refreshCache) {
+            nodeChannelCache = new HashMap<String, List<NodeChannel>>();
+            nodeChannelCacheTime = System.currentTimeMillis();
+        }
+        nodeChannelCache.put(nodeId, nodeChannels);
+        long queryTime = System.currentTimeMillis() - ts;
+        if (queryTime > channelCacheTimeoutInMs) {
+            log.warn("Query time of {} ms exceeded cache time of {} ms for node channels. "
+                    + " This means the query may run on the database constantly.", queryTime, channelCacheTimeoutInMs);
+        }
     }
 
     public long getNodeChannelCacheTime() {
@@ -82,81 +121,180 @@ public class ConfigurationCache {
 
     public Map<String, Channel> getChannels(boolean refreshCache) {
         checkChannelCache(refreshCache);
-        return channelsCache;
+        if (channelsCache != null) {
+            return channelsCache;
+        }
+        return new HashMap<String, Channel>(0);
     }
 
     public Collection<String> getQueues(boolean refreshCache) {
         checkChannelCache(refreshCache);
-        return queuesCache;
+        if (queuesCache != null) {
+            return queuesCache;
+        }
+        return new ArrayList<String>(0);
     }
 
     protected void checkChannelCache(boolean refreshCache) {
         long channelCacheTimeoutInMs = parameterService.getLong(ParameterConstants.CACHE_TIMEOUT_CHANNEL_IN_MS, 60000);
         if (System.currentTimeMillis() - channelCacheTime >= channelCacheTimeoutInMs || channelsCache == null || refreshCache) {
-            synchronized (configurationCacheLock) {
-                if (System.currentTimeMillis() - channelCacheTime >= channelCacheTimeoutInMs || channelsCache == null || refreshCache) {
-                    channelsCache = configurationService.getChannelsFromDb();
-                    Collection<String> queues = new HashSet<String>();
-                    for (Channel channel : channelsCache.values()) {
-                        queues.add(channel.getQueue());
+            if (channelsCache == null) {
+                try {
+                    configurationCacheLock.acquire();
+                    try {
+                        if (System.currentTimeMillis() - channelCacheTime >= channelCacheTimeoutInMs || channelsCache == null || refreshCache) {
+                            populateChannelCache(channelCacheTimeoutInMs);
+                        }
+                    } finally {
+                        configurationCacheLock.release();
                     }
-                    queuesCache = queues;
-                    channelCacheTime = System.currentTimeMillis();
+                } catch (InterruptedException e) {
+                    log.error("Failed to retrieve channels", e);
+                }
+            } else if (configurationCacheLock.tryAcquire()) {
+                try {
+                    populateChannelCache(channelCacheTimeoutInMs);
+                } finally {
+                    configurationCacheLock.release();
                 }
             }
+        }
+    }
+
+    protected void populateChannelCache(long channelCacheTimeoutInMs) {
+        long ts = System.currentTimeMillis();
+        channelsCache = configurationService.getChannelsFromDb();
+        Collection<String> queues = new HashSet<String>();
+        for (Channel channel : channelsCache.values()) {
+            queues.add(channel.getQueue());
+        }
+        queuesCache = queues;
+        channelCacheTime = System.currentTimeMillis();
+        long queryTime = channelCacheTime - ts;
+        if (queryTime > channelCacheTimeoutInMs) {
+            log.warn("Query time of {} ms exceeded cache time of {} ms for channels. "
+                    + " This means the query may run on the database constantly.", queryTime, channelCacheTimeoutInMs);
         }
     }
 
     public List<NodeGroupLink> getNodeGroupLinks(boolean refreshCache) {
+        checkNodeGroupLinkCache(refreshCache);
+        if (nodeGroupLinksCache != null) {
+            return nodeGroupLinksCache;
+        }
+        return new ArrayList<NodeGroupLink>(0);
+    }
+
+    protected void checkNodeGroupLinkCache(boolean refreshCache) {
         long cacheTimeoutInMs = parameterService
                 .getLong(ParameterConstants.CACHE_TIMEOUT_NODE_GROUP_LINK_IN_MS);
-        if (System.currentTimeMillis() - nodeGroupLinkCacheTime >= cacheTimeoutInMs
-                || nodeGroupLinksCache == null || refreshCache) {
-            synchronized (configurationCacheLock) {
-                if (System.currentTimeMillis() - nodeGroupLinkCacheTime >= cacheTimeoutInMs
-                        || nodeGroupLinksCache == null || refreshCache) {
-                    nodeGroupLinksCache = configurationService.getNodeGroupLinksFromDb();
-                    nodeGroupLinkCacheTime = System.currentTimeMillis();
+        if (System.currentTimeMillis() - nodeGroupLinkCacheTime >= cacheTimeoutInMs || nodeGroupLinksCache == null || refreshCache) {
+            if (nodeGroupLinksCache == null) {
+                try {
+                    configurationCacheLock.acquire();
+                    try {
+                        if (System.currentTimeMillis() - nodeGroupLinkCacheTime >= cacheTimeoutInMs
+                                || nodeGroupLinksCache == null || refreshCache) {
+                            populateNodeGroupLinkCache(cacheTimeoutInMs);
+                        }
+                    } finally {
+                        configurationCacheLock.release();
+                    }
+                } catch (InterruptedException e) {
+                    log.error("Failed to retrieve node group links", e);
+                }
+            } else if (configurationCacheLock.tryAcquire()) {
+                try {
+                    populateNodeGroupLinkCache(cacheTimeoutInMs);
+                } finally {
+                    configurationCacheLock.release();
                 }
             }
         }
-        return nodeGroupLinksCache;
+    }
+
+    protected void populateNodeGroupLinkCache(long cacheTimeoutInMs) {
+        long ts = System.currentTimeMillis();
+        nodeGroupLinksCache = configurationService.getNodeGroupLinksFromDb();
+        nodeGroupLinkCacheTime = System.currentTimeMillis();
+        long queryTime = nodeGroupLinkCacheTime - ts;
+        if (queryTime > cacheTimeoutInMs) {
+            log.warn("Query time of {} ms exceeded cache time of {} ms for node group links. "
+                    + " This means the query may run on the database constantly.", queryTime, cacheTimeoutInMs);
+        }
     }
 
     public Map<String, List<NodeGroupChannelWindow>> getNodeGroupChannelWindows() {
+        checkNodeGroupChannelWindowCache();
+        if (channelWindowsByChannelCache != null) {
+            return channelWindowsByChannelCache;
+        }
+        return new HashMap<String, List<NodeGroupChannelWindow>>(0);
+    }
+
+    protected void checkNodeGroupChannelWindowCache() {
         long channelCacheTimeoutInMs = parameterService.getLong(ParameterConstants.CACHE_TIMEOUT_CHANNEL_IN_MS, 60000);
         if (System.currentTimeMillis() - channelWindowsByChannelCacheTime >= channelCacheTimeoutInMs || channelWindowsByChannelCache == null) {
-            synchronized (configurationCacheLock) {
-                if (System.currentTimeMillis() - channelWindowsByChannelCacheTime >= channelCacheTimeoutInMs || channelWindowsByChannelCache == null) {
-                    channelWindowsByChannelCache = configurationService.getNodeGroupChannelWindowsFromDb();
-                    channelWindowsByChannelCacheTime = System.currentTimeMillis();
+            if (channelWindowsByChannelCache == null) {
+                try {
+                    configurationCacheLock.acquire();
+                    try {
+                        if (System.currentTimeMillis() - channelWindowsByChannelCacheTime >= channelCacheTimeoutInMs
+                                || channelWindowsByChannelCache == null) {
+                            populateNodeGroupChannelWindowCache(channelCacheTimeoutInMs);
+                        }
+                    } finally {
+                        configurationCacheLock.release();
+                    }
+                } catch (InterruptedException e) {
+                    log.error("Failed to retrieve node group channel windows", e);
+                }
+            } else if (configurationCacheLock.tryAcquire()) {
+                try {
+                    populateNodeGroupChannelWindowCache(channelCacheTimeoutInMs);
+                } finally {
+                    configurationCacheLock.release();
                 }
             }
         }
-        return channelWindowsByChannelCache;
+    }
+
+    protected void populateNodeGroupChannelWindowCache(long channelCacheTimeoutInMs) {
+        long ts = System.currentTimeMillis();
+        channelWindowsByChannelCache = configurationService.getNodeGroupChannelWindowsFromDb();
+        channelWindowsByChannelCacheTime = System.currentTimeMillis();
+        long queryTime = channelWindowsByChannelCacheTime - ts;
+        if (queryTime > channelCacheTimeoutInMs) {
+            log.warn("Query time of {} ms exceeded cache time of {} ms for node group channel windows. "
+                    + " This means the query may run on the database constantly.", queryTime, channelCacheTimeoutInMs);
+        }
     }
 
     public void flushNodeChannels() {
-        synchronized (configurationCacheLock) {
+        if (configurationCacheLock.tryAcquire()) {
             nodeChannelCacheTime = 0l;
+            configurationCacheLock.release();
         }
     }
 
     public void flushChannels() {
-        synchronized (configurationCacheLock) {
+        if (configurationCacheLock.tryAcquire()) {
             channelCacheTime = 0l;
+            configurationCacheLock.release();
         }
     }
 
     public void flushNodeGroupLinks() {
-        synchronized (configurationCacheLock) {
+        if (configurationCacheLock.tryAcquire()) {
             nodeGroupLinkCacheTime = 0l;
+            configurationCacheLock.release();
         }
     }
 
     public void flushNodeGroupChannelWindows() {
-        synchronized (configurationCacheLock) {
+        if (configurationCacheLock.tryAcquire()) {
             channelWindowsByChannelCacheTime = 0l;
+            configurationCacheLock.release();
         }
     }
 }

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/cache/ConfigurationCache.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/cache/ConfigurationCache.java
@@ -41,7 +41,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ConfigurationCache {
-    private final Logger log = LoggerFactory.getLogger(ConfigurationCache.class);
+    private static final Logger log = LoggerFactory.getLogger(ConfigurationCache.class);
     private IParameterService parameterService;
     private IConfigurationService configurationService;
     private Semaphore configurationCacheLock = new Semaphore(1);
@@ -106,14 +106,14 @@ public class ConfigurationCache {
     }
 
     protected void populateNodeChannelCache(String nodeId, boolean refreshCache, long channelCacheTimeoutInMs) throws SqlException {
-        long ts = System.currentTimeMillis();
+        long startTime = System.currentTimeMillis();
         List<NodeChannel> nodeChannels = configurationService.getNodeChannelsFromDb(nodeId);
         if (refreshCache) {
             nodeChannelCache = new HashMap<String, List<NodeChannel>>();
             nodeChannelCacheTime = System.currentTimeMillis();
         }
         nodeChannelCache.put(nodeId, nodeChannels);
-        long queryTime = System.currentTimeMillis() - ts;
+        long queryTime = System.currentTimeMillis() - startTime;
         if (queryTime > channelCacheTimeoutInMs) {
             log.warn("Query time of {} ms exceeded cache time of {} ms for node channels. "
                     + " This means the query may run on the database constantly.", queryTime, channelCacheTimeoutInMs);
@@ -171,7 +171,7 @@ public class ConfigurationCache {
     }
 
     protected void populateChannelCache(long channelCacheTimeoutInMs) throws SqlException {
-        long ts = System.currentTimeMillis();
+        long startTime = System.currentTimeMillis();
         channelsCache = configurationService.getChannelsFromDb();
         Collection<String> queues = new HashSet<String>();
         for (Channel channel : channelsCache.values()) {
@@ -179,7 +179,7 @@ public class ConfigurationCache {
         }
         queuesCache = queues;
         channelCacheTime = System.currentTimeMillis();
-        long queryTime = channelCacheTime - ts;
+        long queryTime = channelCacheTime - startTime;
         if (queryTime > channelCacheTimeoutInMs) {
             log.warn("Query time of {} ms exceeded cache time of {} ms for channels. "
                     + " This means the query may run on the database constantly.", queryTime, channelCacheTimeoutInMs);
@@ -227,10 +227,10 @@ public class ConfigurationCache {
     }
 
     protected void populateNodeGroupLinkCache(long cacheTimeoutInMs) throws SqlException {
-        long ts = System.currentTimeMillis();
+        long startTime = System.currentTimeMillis();
         nodeGroupLinksCache = configurationService.getNodeGroupLinksFromDb();
         nodeGroupLinkCacheTime = System.currentTimeMillis();
-        long queryTime = nodeGroupLinkCacheTime - ts;
+        long queryTime = nodeGroupLinkCacheTime - startTime;
         if (queryTime > cacheTimeoutInMs) {
             log.warn("Query time of {} ms exceeded cache time of {} ms for node group links. "
                     + " This means the query may run on the database constantly.", queryTime, cacheTimeoutInMs);
@@ -277,10 +277,10 @@ public class ConfigurationCache {
     }
 
     protected void populateNodeGroupChannelWindowCache(long channelCacheTimeoutInMs) throws SqlException {
-        long ts = System.currentTimeMillis();
+        long startTime = System.currentTimeMillis();
         channelWindowsByChannelCache = configurationService.getNodeGroupChannelWindowsFromDb();
         channelWindowsByChannelCacheTime = System.currentTimeMillis();
-        long queryTime = channelWindowsByChannelCacheTime - ts;
+        long queryTime = channelWindowsByChannelCacheTime - startTime;
         if (queryTime > channelCacheTimeoutInMs) {
             log.warn("Query time of {} ms exceeded cache time of {} ms for node group channel windows. "
                     + " This means the query may run on the database constantly.", queryTime, channelCacheTimeoutInMs);

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/cache/ConfigurationCache.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/cache/ConfigurationCache.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Semaphore;
 
+import org.jumpmind.db.sql.SqlException;
 import org.jumpmind.symmetric.ISymmetricEngine;
 import org.jumpmind.symmetric.common.ParameterConstants;
 import org.jumpmind.symmetric.model.Channel;
@@ -84,6 +85,8 @@ public class ConfigurationCache {
                         if (refreshCache || nodeChannels == null) {
                             populateNodeChannelCache(nodeId, refreshCache, channelCacheTimeoutInMs);
                         }
+                    } catch (SqlException e) {
+                        log.error("Failed to retrieve node channels", e);
                     } finally {
                         configurationCacheLock.release();
                     }
@@ -93,6 +96,8 @@ public class ConfigurationCache {
             } else if (configurationCacheLock.tryAcquire()) {
                 try {
                     populateNodeChannelCache(nodeId, true, channelCacheTimeoutInMs);
+                } catch (SqlException e) {
+                    log.error("Failed to retrieve node channels", e);
                 } finally {
                     configurationCacheLock.release();
                 }
@@ -100,7 +105,7 @@ public class ConfigurationCache {
         }
     }
 
-    protected void populateNodeChannelCache(String nodeId, boolean refreshCache, long channelCacheTimeoutInMs) {
+    protected void populateNodeChannelCache(String nodeId, boolean refreshCache, long channelCacheTimeoutInMs) throws SqlException {
         long ts = System.currentTimeMillis();
         List<NodeChannel> nodeChannels = configurationService.getNodeChannelsFromDb(nodeId);
         if (refreshCache) {
@@ -145,6 +150,8 @@ public class ConfigurationCache {
                         if (System.currentTimeMillis() - channelCacheTime >= channelCacheTimeoutInMs || channelsCache == null || refreshCache) {
                             populateChannelCache(channelCacheTimeoutInMs);
                         }
+                    } catch (SqlException e) {
+                        log.error("Failed to retrieve channels", e);
                     } finally {
                         configurationCacheLock.release();
                     }
@@ -154,6 +161,8 @@ public class ConfigurationCache {
             } else if (configurationCacheLock.tryAcquire()) {
                 try {
                     populateChannelCache(channelCacheTimeoutInMs);
+                } catch (SqlException e) {
+                    log.error("Failed to retrieve channels", e);
                 } finally {
                     configurationCacheLock.release();
                 }
@@ -161,7 +170,7 @@ public class ConfigurationCache {
         }
     }
 
-    protected void populateChannelCache(long channelCacheTimeoutInMs) {
+    protected void populateChannelCache(long channelCacheTimeoutInMs) throws SqlException {
         long ts = System.currentTimeMillis();
         channelsCache = configurationService.getChannelsFromDb();
         Collection<String> queues = new HashSet<String>();
@@ -189,7 +198,7 @@ public class ConfigurationCache {
         long cacheTimeoutInMs = parameterService
                 .getLong(ParameterConstants.CACHE_TIMEOUT_NODE_GROUP_LINK_IN_MS);
         if (System.currentTimeMillis() - nodeGroupLinkCacheTime >= cacheTimeoutInMs || nodeGroupLinksCache == null || refreshCache) {
-            if (nodeGroupLinksCache == null) {
+            if (nodeGroupLinksCache == null || refreshCache) {
                 try {
                     configurationCacheLock.acquire();
                     try {
@@ -197,6 +206,8 @@ public class ConfigurationCache {
                                 || nodeGroupLinksCache == null || refreshCache) {
                             populateNodeGroupLinkCache(cacheTimeoutInMs);
                         }
+                    } catch (SqlException e) {
+                        log.error("Failed to retrieve node group links", e);
                     } finally {
                         configurationCacheLock.release();
                     }
@@ -206,6 +217,8 @@ public class ConfigurationCache {
             } else if (configurationCacheLock.tryAcquire()) {
                 try {
                     populateNodeGroupLinkCache(cacheTimeoutInMs);
+                } catch (SqlException e) {
+                    log.error("Failed to retrieve node group links", e);
                 } finally {
                     configurationCacheLock.release();
                 }
@@ -213,7 +226,7 @@ public class ConfigurationCache {
         }
     }
 
-    protected void populateNodeGroupLinkCache(long cacheTimeoutInMs) {
+    protected void populateNodeGroupLinkCache(long cacheTimeoutInMs) throws SqlException {
         long ts = System.currentTimeMillis();
         nodeGroupLinksCache = configurationService.getNodeGroupLinksFromDb();
         nodeGroupLinkCacheTime = System.currentTimeMillis();
@@ -243,6 +256,8 @@ public class ConfigurationCache {
                                 || channelWindowsByChannelCache == null) {
                             populateNodeGroupChannelWindowCache(channelCacheTimeoutInMs);
                         }
+                    } catch (SqlException e) {
+                        log.error("Failed to retrieve node group channel windows", e);
                     } finally {
                         configurationCacheLock.release();
                     }
@@ -252,6 +267,8 @@ public class ConfigurationCache {
             } else if (configurationCacheLock.tryAcquire()) {
                 try {
                     populateNodeGroupChannelWindowCache(channelCacheTimeoutInMs);
+                } catch (SqlException e) {
+                    log.error("Failed to retrieve node group channel windows", e);
                 } finally {
                     configurationCacheLock.release();
                 }
@@ -259,7 +276,7 @@ public class ConfigurationCache {
         }
     }
 
-    protected void populateNodeGroupChannelWindowCache(long channelCacheTimeoutInMs) {
+    protected void populateNodeGroupChannelWindowCache(long channelCacheTimeoutInMs) throws SqlException {
         long ts = System.currentTimeMillis();
         channelWindowsByChannelCache = configurationService.getNodeGroupChannelWindowsFromDb();
         channelWindowsByChannelCacheTime = System.currentTimeMillis();


### PR DESCRIPTION
I used `OutgoingBatchCache` as an example when making this change. One difference is that if the cache is null, `acquire()` is called in order to wait for the lock and avoid returning a null or empty result. This should only happen shortly after startup.

Because every cache within `ConfigurationCache` shares the `configurationCacheLock`, I also made similar changes to the channel, queue, node group link, and node group channel window caches.

Once this PR is approved, I'll backport the changes to 3.15 to resolve issue 7007.