### PR TITLE
0007033: Prevented leading ZWNBSP character from getting lost when replicating unitype data from Sybase ASE

### DIFF
--- a/symmetric-io/src/main/java/org/jumpmind/symmetric/io/data/reader/ExtractDataReader.java
+++ b/symmetric-io/src/main/java/org/jumpmind/symmetric/io/data/reader/ExtractDataReader.java
@@ -294,9 +294,7 @@ public class ExtractDataReader implements IDataReader {
                     if (index >= 0 && rowData[index] != null) {
                         try {
                             String baseString = rowData[index];
-                            if (!baseString.startsWith("fffe")) {
-                                baseString = "fffe" + baseString;
-                            }
+                            baseString = "fffe" + baseString;
                             byte[] utf16Bytes = Hex.decodeHex(baseString);
                             String utf16Str = new String(utf16Bytes, "UTF-16");
                             String utf8Str = new String(utf16Str.getBytes("UTF-8"), "UTF-8");


### PR DESCRIPTION
Once this is merged, I'll make the same change on the 3.16 branch to fix issue 7034.