### PR TITLE
0007035: Caught IllegalArgumentException when sorting process info

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/statistic/StatisticManager.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/statistic/StatisticManager.java
@@ -125,7 +125,11 @@ public class StatisticManager implements IStatisticManager {
 
     public List<ProcessInfo> getProcessInfos() {
         List<ProcessInfo> list = new ArrayList<ProcessInfo>(processInfos.values());
-        Collections.sort(list);
+        try {
+            Collections.sort(list);
+        } catch (IllegalArgumentException e) {
+            log.warn("Failed to sort process infos", e);
+        }
         return list;
     }
 

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/statistic/StatisticManager.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/statistic/StatisticManager.java
@@ -129,6 +129,12 @@ public class StatisticManager implements IStatisticManager {
             Collections.sort(list);
         } catch (IllegalArgumentException e) {
             log.warn("Failed to sort process infos", e);
+            List<ProcessInfo> deepCopyList = new ArrayList<ProcessInfo>();
+            for (ProcessInfo processInfo : list) {
+                deepCopyList.add(processInfo.copy());
+            }
+            list = deepCopyList;
+            Collections.sort(list);
         }
         return list;
     }


### PR DESCRIPTION
See the [issue tracker](https://issues.symmetricds.org/view.php?id=7035) for the `IllegalArgumentException` and its stack trace.

I didn't notice anything wrong with `ProcessInfo.compareTo()`, so I wrote a quick test to `sort()` a `List` containing `ProcessInfo`s with various `status`es and `startTime`s and found that I couldn't reproduce the error. I concluded that the `IllegalArgumentException` was occurring because one or more of the `ProcessInfo`s had their `status` modified during the `sort()`.

I looked through the callers of `StatisticManager.getProcessInfos()` and I didn't notice any that would experience any major issues if the `List` was out of order, so I decided to just catch the `IllegalArgumentException` and return the unsorted `List`.

Some other options for the `catch` block would be to return a sorted deep copy of `processInfos.values()` instead of the unsorted shallow copy, or to try calling `sort()` again. Let me know if either of those would be better.