### PR TITLE
0007056: Fixed NullPointerException when updating create time stats

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/statistic/ChannelStats.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/statistic/ChannelStats.java
@@ -302,7 +302,7 @@ public class ChannelStats extends AbstractNodeHostStats {
     }
 
     public void updateDataMinCreateTime(Date dataMinCreateTime) {
-        if (this.dataMinCreateTime == null || this.dataMinCreateTime.after(dataMinCreateTime)) {
+        if (dataMinCreateTime != null && (this.dataMinCreateTime == null || this.dataMinCreateTime.after(dataMinCreateTime))) {
             this.dataMinCreateTime = dataMinCreateTime;
         }
     }
@@ -316,7 +316,7 @@ public class ChannelStats extends AbstractNodeHostStats {
     }
 
     public void updateDataMaxCreateTime(Date dataMaxCreateTime) {
-        if (this.dataMaxCreateTime == null || this.dataMaxCreateTime.before(dataMaxCreateTime)) {
+        if (dataMaxCreateTime != null && (this.dataMaxCreateTime == null || this.dataMaxCreateTime.before(dataMaxCreateTime))) {
             this.dataMaxCreateTime = dataMaxCreateTime;
         }
     }


### PR DESCRIPTION
The main PR for this issue has already been merged. This fix is for a `NullPointerException` that I noticed when working on a different 3.17 issue.