### PR TITLE
0007061: Fixed $(sourceExternalId) and $(targetExternalId) variables not getting replaced when included in a router's target catalog or schema

### DIFF
--- a/symmetric-io/src/main/java/org/jumpmind/symmetric/io/data/reader/ExtractDataReader.java
+++ b/symmetric-io/src/main/java/org/jumpmind/symmetric/io/data/reader/ExtractDataReader.java
@@ -133,10 +133,14 @@ public class ExtractDataReader implements IDataReader {
     protected String substituteVariables(String sourceString) {
         if (sourceString != null && sourceString.indexOf("$(") != -1) {
             sourceString = FormatUtils.replace("sourceNodeId", (String) dataContext.get("sourceNodeId"), sourceString);
-            sourceString = FormatUtils.replace("sourceNodeExternalId", (String) dataContext.get("sourceNodeExternalId"), sourceString);
+            String sourceNodeExternalId = (String) dataContext.get("sourceNodeExternalId");
+            sourceString = FormatUtils.replace("sourceNodeExternalId", sourceNodeExternalId, sourceString);
+            sourceString = FormatUtils.replace("sourceExternalId", sourceNodeExternalId, sourceString);
             sourceString = FormatUtils.replace("sourceNodeGroupId", (String) dataContext.get("sourceNodeGroupId"), sourceString);
             sourceString = FormatUtils.replace("targetNodeId", (String) dataContext.get("targetNodeId"), sourceString);
-            sourceString = FormatUtils.replace("targetNodeExternalId", (String) dataContext.get("targetNodeExternalId"), sourceString);
+            String targetNodeExternalId = (String) dataContext.get("targetNodeExternalId");
+            sourceString = FormatUtils.replace("targetNodeExternalId", targetNodeExternalId, sourceString);
+            sourceString = FormatUtils.replace("targetExternalId", targetNodeExternalId, sourceString);
             sourceString = FormatUtils.replace("targetNodeGroupId", (String) dataContext.get("targetNodeGroupId"), sourceString);
         }
         return sourceString;


### PR DESCRIPTION
I looked through the history of `ExtractDataReader` and it looks like the `substituteVariables()` method has never replaced these variables since it was added in 3.7.0. Here is the commit:

https://github.com/jumpmindinc/symmetric-ds/commit/503a394f460f0e5bbe6ddc86badef5ba46908a46

They do get replaced as expected in `ColumnsAccordingToTriggerHistory` where it calls `SymmetricUtils.replaceNodeVariables()`.