### PR TITLE
0006935: Added a conflict count to sym_extract_request

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/model/ExtractRequest.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/model/ExtractRequest.java
@@ -48,6 +48,7 @@ public class ExtractRequest implements Serializable {
     private long extractedRows;
     private long transferredRows;
     private long loadedRows;
+    private long conflictedRows;
     private long lastTransferredBatchId;
     private long lastLoadedBatchId;
     private long extractedMillis;
@@ -205,6 +206,14 @@ public class ExtractRequest implements Serializable {
 
     public void setLoadedRows(long loadedRows) {
         this.loadedRows = loadedRows;
+    }
+
+    public long getConflictedRows() {
+        return conflictedRows;
+    }
+
+    public void setConflictedRows(long conflictedRows) {
+        this.conflictedRows = conflictedRows;
     }
 
     public long getLastTransferredBatchId() {

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/DataExtractorService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/DataExtractorService.java
@@ -1501,8 +1501,8 @@ public class DataExtractorService extends AbstractService implements IDataExtrac
         if (platform.supportsParametersInSelect()) {
             transaction.prepareAndExecute(getSql("updateExtractRequestLoadTime"), outgoingBatch.getBatchId(), new Date(),
                     outgoingBatch.getReloadRowCount() > 0 ? outgoingBatch.getDataRowCount() : 0,
-                    outgoingBatch.getLoadMillis(), outgoingBatch.getBatchId(), new Date(), outgoingBatch.isBulkLoaderFlag() == true ? outgoingBatch
-                            .getLoadRowCount() : 0, outgoingBatch.getBatchId(),
+                    outgoingBatch.getLoadMillis(), outgoingBatch.getBatchId(), outgoingBatch.getConflictWinCount() + outgoingBatch.getConflictLoseCount(),
+                    new Date(), outgoingBatch.isBulkLoaderFlag() == true ? outgoingBatch.getLoadRowCount() : 0, outgoingBatch.getBatchId(),
                     outgoingBatch.getBatchId(), outgoingBatch.getNodeId(), outgoingBatch.getLoadId(), engine.getNodeId());
         } else {
             String sql = getSql("updateExtractRequestLoadTimeNoParamsInSelect");
@@ -1510,6 +1510,7 @@ public class DataExtractorService extends AbstractService implements IDataExtrac
             sql = FormatUtils.replace("rowCount",
                     String.valueOf(outgoingBatch.getReloadRowCount() > 0 ? outgoingBatch.getDataRowCount() : 0), sql);
             sql = FormatUtils.replace("loadMillis", String.valueOf(outgoingBatch.getLoadMillis()), sql);
+            sql = FormatUtils.replace("conflictedRows", String.valueOf(outgoingBatch.getConflictWinCount() + outgoingBatch.getConflictLoseCount()), sql);
             sql = FormatUtils.replace("bulkRowsLoaded",
                     String.valueOf(outgoingBatch.isBulkLoaderFlag() == true ? (outgoingBatch.getReloadRowCount() > 0 ? outgoingBatch.getDataRowCount() : 0)
                             : 0), sql);
@@ -2253,6 +2254,7 @@ public class DataExtractorService extends AbstractService implements IDataExtrac
             request.setTransferredRows(row.getLong("transferred_rows"));
             request.setLastTransferredBatchId(row.getLong("last_transferred_batch_id"));
             request.setLoadedRows(row.getLong("loaded_rows"));
+            request.setConflictedRows(row.getLong("conflicted_rows"));
             request.setLastLoadedBatchId(row.getLong("last_loaded_batch_id"));
             request.setTransferredMillis(row.getLong("transferred_millis"));
             request.setLoadedMillis(row.getLong("loaded_millis"));

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/DataExtractorServiceSqlMap.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/DataExtractorServiceSqlMap.java
@@ -64,12 +64,14 @@ public class DataExtractorServiceSqlMap extends AbstractSqlMap {
         
         putSql("updateExtractRequestLoadTime", "update $(extract_request) set loaded_time = (case when end_batch_id = ? then ? when 1 = 0 then last_update_time else null end), "
                 + " loaded_rows = loaded_rows + ?, loaded_millis = loaded_millis + ?, last_loaded_batch_id = ?, "
+                + " conflicted_rows = conflicted_rows + ?, "
                 + " last_update_time=?, "
                 + " bulk_rows_loaded = bulk_rows_loaded + ?"
                 + " where start_batch_id <= ? and end_batch_id >= ? and node_id=? and load_id=? and source_node_id = ? and loaded_time is null");
         
         putSql("updateExtractRequestLoadTimeNoParamsInSelect", "update $(extract_request) set loaded_time = (case when end_batch_id = $(batchId) then current_timestamp when 1 = 0 then last_update_time else null end), "
                 + " loaded_rows = loaded_rows + $(rowCount), loaded_millis = loaded_millis + $(loadMillis), last_loaded_batch_id = ?, "
+                + " conflicted_rows = conflicted_rows + $(conflictedRows), "
                 + " last_update_time=?, "
                 + " bulk_rows_loaded = bulk_rows_loaded + $(bulkRowsLoaded) "
                 + " where start_batch_id <= ? and end_batch_id >= ? and node_id=? and load_id=? and source_node_id = ? and loaded_time is null");

--- a/symmetric-core/src/main/resources/symmetric-schema.xml
+++ b/symmetric-core/src/main/resources/symmetric-schema.xml
@@ -152,6 +152,7 @@
        	<column name="loaded_millis" type="BIGINT" required="true" default="0" description="The time spent loading this table" />
        	<column name="last_loaded_batch_id" type="BIGINT" required="false" description="The last batch id that was successfully loaded on the target" />
        	<column name="total_rows" type="BIGINT" required="false" description="The rows in this table to be extracted" />
+       	<column name="conflicted_rows" type="BIGINT" required="true" default="0" description="The rows in this table that went into conflict when loaded to the target" />
        	<column name="loaded_time" type="TIMESTAMP"  description="Timestamp when this table was loaded." />
         <column name="parent_request_id" type="BIGINT" required="true" default="0" description="Parent request_id that will actually handle the extract for this request." />
         <column name="extract_thread_id" type="INTEGER" required="false" description="Thread number within dynamic queue assigned for extraction" />


### PR DESCRIPTION
I chose to name the new column `conflicted_rows` because `sym_extract_request` already has 4 other columns that contain a row count and have names that end with `_rows`. Let me know if it needs changed. Some other possibilities are `rows_in_conflict`, `conflict_count`, or `conflicts`.