### PR TITLE
0007067: Added a byte count to sym_extract_request

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/model/ExtractRequest.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/model/ExtractRequest.java
@@ -44,6 +44,7 @@ public class ExtractRequest implements Serializable {
     private String queue;
     private long loadId;
     private String tableName;
+    private long byteCount;
     private long rows;
     private long extractedRows;
     private long transferredRows;
@@ -182,6 +183,14 @@ public class ExtractRequest implements Serializable {
 
     public void setTableName(String tableName) {
         this.tableName = tableName;
+    }
+
+    public long getByteCount() {
+        return byteCount;
+    }
+
+    public void setByteCount(long byteCount) {
+        this.byteCount = byteCount;
     }
 
     public long getRows() {

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/DataExtractorService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/DataExtractorService.java
@@ -1536,10 +1536,11 @@ public class DataExtractorService extends AbstractService implements IDataExtrac
         try {
             transaction = sqlTemplate.startSqlTransaction();
             if (platform.supportsParametersInSelect()) {
-                transaction.prepareAndExecute(getSql("updateExtractRequestTransferred"), batch.getBatchId(), batch.getDataRowCount(), transferMillis,
-                        batch.getBatchId(), batch.getBatchId(), batch.getNodeId(), batch.getLoadId(), batch.getBatchId(), engine.getNodeId());
+                transaction.prepareAndExecute(getSql("updateExtractRequestTransferred"), batch.getByteCount(), batch.getBatchId(), batch.getDataRowCount(),
+                        transferMillis, batch.getBatchId(), batch.getBatchId(), batch.getNodeId(), batch.getLoadId(), batch.getBatchId(), engine.getNodeId());
             } else {
                 String sql = getSql("updateExtractRequestTransferredNoParamsInSelect");
+                sql = FormatUtils.replace("byteCount", String.valueOf(batch.getByteCount()), sql);
                 sql = FormatUtils.replace("rowCount", String.valueOf(batch.getDataRowCount()), sql);
                 transaction.prepareAndExecute(sql, batch.getBatchId(), transferMillis, batch.getBatchId(),
                         batch.getBatchId(), batch.getNodeId(), batch.getLoadId(), batch.getBatchId(), engine.getNodeId());
@@ -2250,6 +2251,7 @@ public class DataExtractorService extends AbstractService implements IDataExtrac
             request.setQueue(row.getString("queue"));
             request.setLoadId(row.getLong("load_id"));
             request.setTableName(row.getString("table_name"));
+            request.setByteCount(row.getLong("byte_count"));
             request.setRows(row.getLong("total_rows"));
             request.setTransferredRows(row.getLong("transferred_rows"));
             request.setLastTransferredBatchId(row.getLong("last_transferred_batch_id"));

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/DataExtractorServiceSqlMap.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/DataExtractorServiceSqlMap.java
@@ -76,10 +76,10 @@ public class DataExtractorServiceSqlMap extends AbstractSqlMap {
                 + " bulk_rows_loaded = bulk_rows_loaded + $(bulkRowsLoaded) "
                 + " where start_batch_id <= ? and end_batch_id >= ? and node_id=? and load_id=? and source_node_id = ? and loaded_time is null");
         
-        putSql("updateExtractRequestTransferred", "update $(extract_request) set last_transferred_batch_id=?, transferred_rows = transferred_rows + ?, transferred_millis = ?"
+        putSql("updateExtractRequestTransferred", "update $(extract_request) set byte_count = byte_count + ?, last_transferred_batch_id=?, transferred_rows = transferred_rows + ?, transferred_millis = ?"
                 + " where start_batch_id <= ? and end_batch_id >= ? and node_id=? and load_id=? and (last_transferred_batch_id is null or last_transferred_batch_id < ?) and source_node_id = ?");
 
-        putSql("updateExtractRequestTransferredNoParamsInSelect", "update $(extract_request) set last_transferred_batch_id=?, transferred_rows = transferred_rows + $(rowCount), transferred_millis = ?"
+        putSql("updateExtractRequestTransferredNoParamsInSelect", "update $(extract_request) set byte_count = byte_count + $(byteCount), last_transferred_batch_id=?, transferred_rows = transferred_rows + $(rowCount), transferred_millis = ?"
                 + " where start_batch_id <= ? and end_batch_id >= ? and node_id=? and load_id=? and (last_transferred_batch_id is null or last_transferred_batch_id < ?) and source_node_id = ?");
 
         putSql("updateExtractRequestsThreadsSql", "update $(extract_request) set extract_thread_id = ?, load_thread_id = ? where request_id = ?");

--- a/symmetric-core/src/main/resources/symmetric-schema.xml
+++ b/symmetric-core/src/main/resources/symmetric-schema.xml
@@ -143,6 +143,7 @@
         <column name="router_id" type="VARCHAR" size="50" required="true" description="Unique description of the router associated with the extract request." />
         <column name="load_id" type="BIGINT" required="false" description="The load id associated with the extract request." />
         <column name="table_name" type="VARCHAR" size="255" required="false" description="The table name for this extract request" />
+        <column name="byte_count" type="BIGINT" required="true" default="0" description="The number of bytes that were transferred to the target for this table" />
         <column name="extracted_rows" type="BIGINT" required="true" default="0" description="The rows in this table that have been extracted to target" />
         <column name="extracted_millis" type="BIGINT" required="true" default="0" description="The time spent extracting this table" />
         <column name="transferred_rows" type="BIGINT" required="true" default="0" description="The rows in this table that have been transferred to target" />


### PR DESCRIPTION
This issue originally stated that the new column should represent the "size of data _loaded_". However, the new `sym_extract_request.byte_count` column represents the number of bytes that were _sent_, because that's what's available in the `sym_outgoing_batch.byte_count` column. Let me know if this needs changed, and if so, let me know if you have any ideas on how to get the number of bytes that were _loaded_.