### PR TITLE
0007070: Recorded the number of gaps and unrouted rows to sym_node_host_stats

### DIFF
--- a/symmetric-client/src/main/java/org/jumpmind/symmetric/ClientSymmetricEngine.java
+++ b/symmetric-client/src/main/java/org/jumpmind/symmetric/ClientSymmetricEngine.java
@@ -435,8 +435,7 @@ public class ClientSymmetricEngine extends AbstractSymmetricEngine {
                 throw new RuntimeException(e);
             }
         }
-        return new StatisticManager(parameterService, nodeService,
-                configurationService, statisticService, clusterService);
+        return new StatisticManager(this);
     }
 
     protected static void waitForAvailableDatabase(DataSource dataSource) {

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/DataService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/DataService.java
@@ -3146,7 +3146,9 @@ public class DataService extends AbstractService implements IDataService {
 
     @Override
     public long countDataGaps() {
-        return sqlTemplate.queryForLong(getSql("countDataGapsSql"));
+        long dataGapCount = sqlTemplate.queryForLong(getSql("countDataGapsSql"));
+        engine.getStatisticManager().setDataGapCount(dataGapCount);
+        return dataGapCount;
     }
 
     @Override
@@ -3160,13 +3162,17 @@ public class DataService extends AbstractService implements IDataService {
     }
 
     protected List<DataGap> findDataGaps(boolean isExpired) {
-        return sqlTemplate.query(getSql("findDataGapsSql"), new ISqlRowMapper<DataGap>() {
+        List<DataGap> dataGapList = sqlTemplate.query(getSql("findDataGapsSql"), new ISqlRowMapper<DataGap>() {
             @Override
             public DataGap mapRow(Row rs) {
                 return new DataGap(rs.getLong("start_id"), rs.getLong("end_id"), rs
                         .getDateTime("create_time"));
             }
         }, isExpired ? 1 : 0);
+        if (!isExpired) {
+            engine.getStatisticManager().setDataGapCount(dataGapList.size());
+        }
+        return dataGapList;
     }
 
     @Override

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/DataService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/DataService.java
@@ -3169,7 +3169,7 @@ public class DataService extends AbstractService implements IDataService {
                         .getDateTime("create_time"));
             }
         }, isExpired ? 1 : 0);
-        if (!isExpired) {
+        if (!isExpired && engine.getStatisticManager() != null) {
             engine.getStatisticManager().setDataGapCount(dataGapList.size());
         }
         return dataGapList;

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/RouterService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/RouterService.java
@@ -1245,12 +1245,9 @@ public class RouterService extends AbstractService implements IRouterService, IN
         if (maxDataIdAlreadyRouted == 0) {
             return 0;
         }
-        long leftToRoute = (engine.getDataService().findMaxDataId() - maxDataIdAlreadyRouted) + 1;
-        if (leftToRoute > 0) {
-            return leftToRoute;
-        } else {
-            return 0;
-        }
+        long leftToRoute = Math.max((engine.getDataService().findMaxDataId() - maxDataIdAlreadyRouted) + 1, 0);
+        engine.getStatisticManager().setDataUnroutedCount(leftToRoute);
+        return leftToRoute;
     }
 
     public List<String> getAvailableBatchAlgorithms() {

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/StatisticService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/StatisticService.java
@@ -124,12 +124,14 @@ public class StatisticService extends AbstractService implements IStatisticServi
                         stats.getPurgedStrandedDataEventRows(), stats.getPurgedExpiredDataRows(),
                         stats.getTriggersCreatedCount(),
                         stats.getTriggersRebuiltCount(), stats.getTriggersRemovedCount(),
-                        stats.getTotalNodesPullTime(), stats.getTotalNodesPushTime() },
+                        stats.getTotalNodesPullTime(), stats.getTotalNodesPushTime(),
+                        stats.getDataGapCount(), stats.getDataUnroutedCount() },
                 new int[] { Types.VARCHAR, Types.VARCHAR, Types.TIMESTAMP, Types.TIMESTAMP,
                         Types.BIGINT, Types.BIGINT, Types.BIGINT, Types.BIGINT, Types.BIGINT,
                         Types.BIGINT, Types.BIGINT, Types.BIGINT, Types.BIGINT, Types.BIGINT,
                         Types.BIGINT, Types.BIGINT, Types.BIGINT, Types.BIGINT, Types.BIGINT,
-                        Types.BIGINT, Types.BIGINT, Types.BIGINT, Types.BIGINT });
+                        Types.BIGINT, Types.BIGINT, Types.BIGINT, Types.BIGINT, Types.BIGINT,
+                        Types.BIGINT });
     }
 
     public List<HostStats> getHostStatsForPeriod(Date start, Date end, String nodeId) {
@@ -225,6 +227,8 @@ public class StatisticService extends AbstractService implements IStatisticServi
             stats.setTriggersRemovedCount(rs.getLong("triggers_removed_count"));
             stats.setTotalNodesPullTime(rs.getLong("total_nodes_pull_time"));
             stats.setTotalNodesPushTime(rs.getLong("total_nodes_push_time"));
+            stats.setDataGapCount(rs.getLong("data_gap_count"));
+            stats.setDataUnroutedCount(rs.getLong("data_unrouted_count"));
             return stats;
         }
     }

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/StatisticServiceSqlMap.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/StatisticServiceSqlMap.java
@@ -86,9 +86,9 @@ public class StatisticServiceSqlMap extends AbstractSqlMap {
                 "  purged_data_event_rows,purged_batch_outgoing_rows,purged_batch_incoming_rows,   " +
                 "  purged_stranded_data_rows, purged_stranded_event_rows, purged_expired_data_rows," +
                 "  triggers_created_count,triggers_rebuilt_count,triggers_removed_count,           " +
-                "  total_nodes_pull_time, total_nodes_push_time                                    " +
+                "  total_nodes_pull_time, total_nodes_push_time,data_gap_count,data_unrouted_count " +
                 "  )                                                                               " +
-                "  values(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)                           ");
+                "  values(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)                       ");
         putSql("selectHostStatsSql", "" +
                 "select node_id, host_name, start_time, end_time,                                   " +
                 "  restarted,nodes_pulled,nodes_pushed,nodes_rejected,                              " +
@@ -96,7 +96,7 @@ public class StatisticServiceSqlMap extends AbstractSqlMap {
                 "  purged_data_event_rows,purged_batch_outgoing_rows,purged_batch_incoming_rows,    " +
                 "  purged_stranded_data_rows, purged_stranded_event_rows, purged_expired_data_rows, " +
                 "  triggers_created_count,triggers_rebuilt_count,triggers_removed_count,            " +
-                "  total_nodes_pull_time, total_nodes_push_time                                     " +
+                "  total_nodes_pull_time, total_nodes_push_time,data_gap_count,data_unrouted_count  " +
                 "  from $(node_host_stats)                                                    " +
                 "  where  start_time >= ? and end_time <= ? and node_id=? order by start_time asc   ");
         putSql("insertJobStatsSql", "" +

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/statistic/HostStats.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/statistic/HostStats.java
@@ -42,6 +42,8 @@ public class HostStats extends AbstractNodeHostStats {
     private long triggersCreatedCount;
     private long triggersRebuiltCount;
     private long triggersRemovedCount;
+    private Long dataGapCount;
+    private Long dataUnroutedCount;
 
     public HostStats() {
     }
@@ -75,13 +77,6 @@ public class HostStats extends AbstractNodeHostStats {
         triggersCreatedCount += stats.getTriggersCreatedCount();
         triggersRebuiltCount += stats.getTriggersRebuiltCount();
         triggersRemovedCount += stats.getTriggersRemovedCount();
-    }
-
-    public boolean isNonZero() {
-        return restarted > 0 || nodesPulled > 0 || totalNodesPullTime > 0 || nodesPushed > 0 || totalNodesPushTime > 0 || nodesRejected > 0
-                || nodesRegistered > 0 || nodesLoaded > 0 || nodesDisabled > 0 || purgedDataRows > 0 || purgedDataEventRows > 0 || purgedBatchOutgoingRows > 0
-                || purgedBatchIncomingRows > 0 || purgedStrandedDataRows > 0 || purgedStrandedDataEventRows > 0 || purgedExpiredDataRows > 0
-                || triggersCreatedCount > 0 || triggersRebuiltCount > 0 || triggersRemovedCount > 0;
     }
 
     public long getRestarted() {
@@ -310,5 +305,21 @@ public class HostStats extends AbstractNodeHostStats {
 
     public void incrementPurgedExpiredDataRows(long value) {
         this.purgedExpiredDataRows += value;
+    }
+
+    public Long getDataGapCount() {
+        return dataGapCount;
+    }
+
+    public void setDataGapCount(long dataGapCount) {
+        this.dataGapCount = dataGapCount;
+    }
+
+    public Long getDataUnroutedCount() {
+        return dataUnroutedCount;
+    }
+
+    public void setDataUnroutedCount(long dataUnroutedCount) {
+        this.dataUnroutedCount = dataUnroutedCount;
     }
 }

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/statistic/IStatisticManager.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/statistic/IStatisticManager.java
@@ -137,6 +137,10 @@ public interface IStatisticManager {
 
     public void incrementTriggersCreatedCount(long count);
 
+    public void setDataGapCount(long count);
+
+    public void setDataUnroutedCount(long count);
+
     public void incrementTableRows(Map<String, Map<String, Long>> tableCounts, boolean loaded);
 
     public Map<String, ChannelStats> getWorkingChannelStats();

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/statistic/StatisticManager.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/statistic/StatisticManager.java
@@ -35,6 +35,7 @@ import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Semaphore;
 
+import org.jumpmind.symmetric.ISymmetricEngine;
 import org.jumpmind.symmetric.common.Constants;
 import org.jumpmind.symmetric.common.ParameterConstants;
 import org.jumpmind.symmetric.model.DataGap;
@@ -46,6 +47,7 @@ import org.jumpmind.symmetric.model.ProcessInfo.ProcessStatus;
 import org.jumpmind.symmetric.model.ProcessInfoKey;
 import org.jumpmind.symmetric.service.IClusterService;
 import org.jumpmind.symmetric.service.IConfigurationService;
+import org.jumpmind.symmetric.service.IDataService;
 import org.jumpmind.symmetric.service.INodeService;
 import org.jumpmind.symmetric.service.IParameterService;
 import org.jumpmind.symmetric.service.IStatisticService;
@@ -63,11 +65,13 @@ public class StatisticManager implements IStatisticManager {
     private List<JobStats> jobStats = new ArrayList<JobStats>();
     private HostStats hostStats;
     private ConcurrentHashMap<Long, RouterStats> routerStatsByBatch = new ConcurrentHashMap<Long, RouterStats>();
+    protected ISymmetricEngine engine;
     protected INodeService nodeService;
     protected IStatisticService statisticService;
     protected IParameterService parameterService;
     protected IConfigurationService configurationService;
     protected IClusterService clusterService;
+    protected IDataService dataService;
     protected Semaphore channelStatsLock = new Semaphore(NUMBER_OF_PERMITS, true);
     protected Semaphore hostStatsLock = new Semaphore(NUMBER_OF_PERMITS, true);
     protected Semaphore jobStatsLock = new Semaphore(NUMBER_OF_PERMITS, true);
@@ -76,14 +80,14 @@ public class StatisticManager implements IStatisticManager {
     protected Map<ProcessInfoKey, ProcessInfo> processInfosThatHaveDoneWork = new ConcurrentHashMap<ProcessInfoKey, ProcessInfo>();
     private Map<Date, Map<String, ChannelStats>> baseChannelStatsInMemory = new LinkedHashMap<Date, Map<String, ChannelStats>>();
 
-    public StatisticManager(IParameterService parameterService, INodeService nodeService,
-            IConfigurationService configurationService, IStatisticService statisticsService,
-            IClusterService clusterService) {
-        this.parameterService = parameterService;
-        this.nodeService = nodeService;
-        this.configurationService = configurationService;
-        this.statisticService = statisticsService;
-        this.clusterService = clusterService;
+    public StatisticManager(ISymmetricEngine engine) {
+        this.engine = engine;
+        parameterService = engine.getParameterService();
+        nodeService = engine.getNodeService();
+        configurationService = engine.getConfigurationService();
+        statisticService = engine.getStatisticService();
+        clusterService = engine.getClusterService();
+        dataService = engine.getDataService();
         init();
     }
 
@@ -559,6 +563,28 @@ public class StatisticManager implements IStatisticManager {
         }
     }
 
+    @Override
+    public void setDataGapCount(long count) {
+        if (hostStatsLock.tryAcquire()) {
+            try {
+                getHostStats().setDataGapCount(count);
+            } finally {
+                hostStatsLock.release();
+            }
+        }
+    }
+
+    @Override
+    public void setDataUnroutedCount(long count) {
+        if (hostStatsLock.tryAcquire()) {
+            try {
+                getHostStats().setDataUnroutedCount(count);
+            } finally {
+                hostStatsLock.release();
+            }
+        }
+    }
+
     protected void saveAdditionalStats(Date endTime, ChannelStats stats) {
         if (baseChannelStatsInMemory.get(endTime) == null) {
             baseChannelStatsInMemory.put(endTime, new HashMap<String, ChannelStats>());
@@ -614,12 +640,18 @@ public class StatisticManager implements IStatisticManager {
         if (hostStats != null) {
             hostStatsLock.acquireUninterruptibly(NUMBER_OF_PERMITS);
             try {
-                if (recordStatistics && hostStats.isNonZero()) {
+                if (recordStatistics) {
                     if (hostStats.getNodeId().equals(UNKNOWN)) {
                         Node node = nodeService.getCachedIdentity();
                         if (node != null) {
                             hostStats.setNodeId(node.getNodeId());
                         }
+                    }
+                    if (hostStats.getDataGapCount() == null) {
+                        hostStats.setDataGapCount(dataService.countDataGaps());
+                    }
+                    if (hostStats.getDataUnroutedCount() == null && engine.getRouterService() != null) {
+                        hostStats.setDataUnroutedCount(engine.getRouterService().getUnroutedDataCount());
                     }
                     hostStats.setEndTime(new Date());
                     statisticService.save(hostStats);

--- a/symmetric-core/src/main/resources/symmetric-schema.xml
+++ b/symmetric-core/src/main/resources/symmetric-schema.xml
@@ -587,6 +587,8 @@
         <column name="triggers_created_count" type="BIGINT" description="" />
         <column name="triggers_rebuilt_count" type="BIGINT" description="" />
         <column name="triggers_removed_count" type="BIGINT" description="" />
+        <column name="data_gap_count" type="BIGINT" description="Number of non-expired data gaps during this period." />
+        <column name="data_unrouted_count" type="BIGINT" description="Estimated number of unrouted data rows during this period." />
         <index name="idx_nd_hst_sts">
             <index-column name="node_id"/>
             <index-column name="start_time"/>

--- a/symmetric-core/src/test/java/org/jumpmind/symmetric/statistic/MockStatisticManager.java
+++ b/symmetric-core/src/test/java/org/jumpmind/symmetric/statistic/MockStatisticManager.java
@@ -157,6 +157,14 @@ public class MockStatisticManager implements IStatisticManager {
     public void incrementTriggersCreatedCount(long count) {
     }
 
+    @Override
+    public void setDataGapCount(long count) {
+    }
+
+    @Override
+    public void setDataUnroutedCount(long count) {
+    }
+
     public void addRouterStats(long startDataId, long endDataId, long dataReadCount,
             long peekAheadFillCount, List<DataGap> dataGaps, Set<String> transactions,
             Collection<OutgoingBatch> batches) {


### PR DESCRIPTION
I thought of 3 options to populate these new columns:

1. Call `RouterService.getUnroutedDataCount()` and `DataService.countDataGaps()` on every `StatisticManager.flush()`
2. Only update the stats when `RouterService.getUnroutedDataCount()`, `DataService.countDataGaps()`, or `DataService.findDataGaps(false)` is called
3. Start with option 2 and fall back to option 1 if there are no stats

I didn't go with option 1 because it would cause many unnecessary database queries. I didn't go with option 2 because it's very uncommon for the open-source version to call `RouterService.getUnroutedDataCount()`, so the `data_unrouted_count` would be left null. I figured option 3 was a good compromise.

I decided to remove the check for `HostStats.isNonZero()` because even when all other stats are 0, the data gap and unrouted data stats are still available.

Because `StatisticManager` now needs to access `RouterService` but `AbstractSymmetricEngine.init()` calls `createStatisticManager()` before `buildRouterService()`, I had to change the constructor to pass in the `ISymmetricEngine` rather than the individual services.

As usual, let me know if any of this needs changed.