### PR TITLE
0007088: Fixed registration failure when a console role exists with a role ID that comes before its parent role ID alphabetically

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/DataExtractorService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/DataExtractorService.java
@@ -266,18 +266,9 @@ public class DataExtractorService extends AbstractService implements IDataExtrac
             for (int i = 0; i < triggerRouters.size(); i++) {
                 TriggerRouter triggerRouter = triggerRouters.get(i);
                 TriggerHistory triggerHistory = triggerHistories.get(i);
-                Table table = symmetricDialect.getPlatform().getTableFromCache(triggerHistory.getSourceCatalogName(), triggerHistory.getSourceSchemaName(),
-                        triggerHistory.getSourceTableName(), false);
-                String initialLoadSql = "1=1 order by ";
-                String quote = platform.getDdlBuilder().getDatabaseInfo().getDelimiterToken();
-                Column[] pkColumns = table.getPrimaryKeyColumns();
-                for (int j = 0; j < pkColumns.length; j++) {
-                    if (j > 0) {
-                        initialLoadSql += ", ";
-                    }
-                    initialLoadSql += quote + pkColumns[j].getName() + quote;
-                }
-                if (!triggerRouter.getTrigger().getSourceTableName().endsWith(TableConstants.SYM_NODE_IDENTITY)) {
+                String tableName = triggerRouter.getTrigger().getSourceTableName();
+                if (!tableName.endsWith(TableConstants.SYM_NODE_IDENTITY)) {
+                    String initialLoadSql = buildInitialLoadSqlForConfigurationTable(triggerHistory, tableName);
                     initialLoadEvents.add(new SelectFromTableEvent(targetNode, triggerRouter, triggerHistory, initialLoadSql));
                 } else {
                     Data data = new Data(1, null, targetNode.getNodeId(), DataEventType.INSERT, triggerHistory.getSourceTableName(), null, triggerHistory,
@@ -313,6 +304,24 @@ public class DataExtractorService extends AbstractService implements IDataExtrac
                         TableConstants.SYM_NODE_SECURITY).equalsIgnoreCase(sourceTableName)) {
             sql.append(String.format(" where created_at_node_id != '%s' or created_at_node_id is null", targetNode.getNodeId()));
         }
+    }
+
+    private String buildInitialLoadSqlForConfigurationTable(TriggerHistory triggerHistory, String tableName) {
+        String initialLoadSql = Constants.ALWAYS_TRUE_CONDITION;
+        if (!tableName.endsWith(TableConstants.SYM_CONSOLE_ROLE)) {
+            initialLoadSql += " order by ";
+            String quote = platform.getDdlBuilder().getDatabaseInfo().getDelimiterToken();
+            Table table = symmetricDialect.getPlatform().getTableFromCache(triggerHistory.getSourceCatalogName(),
+                    triggerHistory.getSourceSchemaName(), triggerHistory.getSourceTableName(), false);
+            Column[] pkColumns = table.getPrimaryKeyColumns();
+            for (int j = 0; j < pkColumns.length; j++) {
+                if (j > 0) {
+                    initialLoadSql += ", ";
+                }
+                initialLoadSql += quote + pkColumns[j].getName() + quote;
+            }
+        }
+        return initialLoadSql;
     }
 
     private List<OutgoingBatch> filterBatchesForExtraction(OutgoingBatches batches,


### PR DESCRIPTION
Unlike the [PR for 3.16](https://github.com/jumpmindinc/symmetric-ds/pull/403), it wasn't necessary to change `SelectFromTableSource.selectNext()` because the 3.15 version doesn't contain a check that dereferences the `outgoingBatch` variable.