### PR TITLE
 0007085: introduce latest switch for release workflow 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,10 @@ on:
                 type: string
                 description: Full version (major.minor.patch) number to release, e.g. 1.2.3.
                 required: true
+            latest:
+                type: boolean
+                description: Whether this release is going to be the latest (major.minor.patch) version.
+                required: true
                 
 run-name: "Release: ${{ inputs.version }}"
 
@@ -75,6 +79,7 @@ jobs:
                     -PrestAPISecret=${{ secrets.MANTIS_API_KEY }}
               working-directory: symmetric-assemble
               env:
+                  LATEST: ${{ github.event.inputs.latest }}
                   ORG_GRADLE_PROJECT_signingKey: ${{ secrets.PGP_KEY }}
                   ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.PGP_KEY_PASSWORD }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,7 @@ jobs:
             - name: Publish
               run: |
                 ./gradlew clean jar releaseSymmetric deploy publishDocker \
+                    -Platest="$LATEST" \
                     -Pversion=${{ github.event.inputs.version }} \
                     -PscmVersion=${{ github.sha }} \
                     -PscmBranch=${{ github.base_ref }} \

--- a/symmetric-assemble/build.gradle
+++ b/symmetric-assemble/build.gradle
@@ -181,6 +181,8 @@ task generateJavadoc(type: Javadoc) {
 	}
 }
 
+def isLatest = project.hasProperty("latest") && project.property("latest") == "true"
+
 task publishJavadoc {
     dependsOn generateJavadoc
 	group = 'SymmetricDS'
@@ -222,14 +224,16 @@ task publishSymmetric {
                 include(name: 'symmetric-server-' + version + '.zip')
             }
         }
-        println "Setting latest file on SourceForge to symmetricds-$majorMinorVersion/symmetric-server-" + version + ".zip"
-        exec {
-            commandLine "curl"
-            args "-s", "-S", "-H", "Accept: application/json", "-X", "PUT",
-                "-d", "default=windows&default=mac&default=linux&default=bsd&default=solaris&default=others",
-                "-d", "api_key=$sourceforgeApiKey",
-                "https://sourceforge.net/projects/symmetricds/files/symmetricds/symmetricds-$majorMinorVersion/symmetric-server-" + version + ".zip"
-        }
+        if (isLatest) {
+			println "Setting latest file on SourceForge to symmetricds-$majorMinorVersion/symmetric-server-" + version + ".zip"
+        	exec {
+            	commandLine "curl"
+            	args "-s", "-S", "-H", "Accept: application/json", "-X", "PUT",
+                	"-d", "default=windows&default=mac&default=linux&default=bsd&default=solaris&default=others",
+                	"-d", "api_key=$sourceforgeApiKey",
+                	"https://sourceforge.net/projects/symmetricds/files/symmetricds/symmetricds-$majorMinorVersion/symmetric-server-" + version + ".zip"
+        	}
+		}
     }
 }
 
@@ -267,18 +271,17 @@ task buildImage(type: com.bmuschko.gradle.docker.tasks.image.DockerBuildImage) {
     buildArgs = ["SERVER_ZIP":"symmetric-server-${version}.zip"]
 }
 
-task publishDockerLatest(type: com.bmuschko.gradle.docker.tasks.image.DockerPushImage) {
-    dependsOn buildImage
-    images.empty()
-    images.add("jumpmind/symmetricds:latest")
-}
-
 task publishDocker(type: com.bmuschko.gradle.docker.tasks.image.DockerPushImage) {
     dependsOn buildImage
     images.empty()
     images.add("jumpmind/symmetricds:${version}".toString())
     images.add("jumpmind/symmetricds:${majorMinorVersion}".toString())
-    doLast {
+    
+	if (isLatest) {
+    	images.add("jumpmind/symmetricds:latest")
+    }
+	
+	doLast {
         println "Pushing Docker Image to the jumpmind/symmetricds Repository"
     }
 }


### PR DESCRIPTION
Worked for 3.16 release. Porting to 3.15. This will prevent the 3.15 releases from publishing as "latest" version in SourceForge, which requires a manual change. 