### PR TITLE
0007080: web console hangs switching screens

### DIFF
--- a/symmetric-assemble/common.gradle
+++ b/symmetric-assemble/common.gradle
@@ -326,7 +326,7 @@ subprojects { subproject ->
         mysqlVersion = '8.4.0'
         servletVersion = '4.0.1'
         springVersion = '6.2.11'
-        springBootVersion = '3.5.6'
+        springBootVersion = '3.5.5'
         jtdsVersion = '1.3.1'
         bouncyCastleVersion = '1.81'
         animalSnifferVersion = '1.23'


### PR DESCRIPTION
When opening any screen in the web console, the UI hangs for 10 seconds every time. The UI is unresponsive to the user and displays the blue bar along the top that grows from left to right. The following error message is written to the log:

[gui] - ServerRpcHandler - Resynchronizing UI by client's request. A network message was lost before reaching the client and the client is reloading the full UI state. This typically happens because of a bad network connection with packet loss or because of some part of the network infrastructure (load balancer, proxy) terminating a push (websocket or long-polling) connection. If you are using push with a proxy, make sure the push timeout is set to be smaller than the proxy connection timeout

After downgrading Spring Boot from 3.5.6 to 3.5.5, the issue appears to have gone away.  This should clear the way to re-release Pro versions 3.15.20 and 3.16.7.  I already deleted those releases and tags, so a new build of those versions should work.