### PR TITLE
0007036: Took the database platform's case sensitivity into consideration when checking whether an index needs modified

### DIFF
--- a/symmetric-db/src/main/java/org/jumpmind/db/alter/ModelComparator.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/alter/ModelComparator.java
@@ -43,14 +43,11 @@ import java.math.BigDecimal;
 
 import java.sql.Types;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang3.Strings;
-import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.jumpmind.db.model.Column;
 import org.jumpmind.db.model.ColumnTypes;
 import org.jumpmind.db.model.Database;
@@ -251,12 +248,6 @@ public class ModelComparator {
                 // we have to use the target table here because the index might
                 // reference a new column
                 changes.add(new AddIndexChange(targetTable, targetIndex));
-            } else {
-                if (!new EqualsBuilder().append(new HashSet<IIndex>(Arrays.asList(targetIndex)), new HashSet<IIndex>(Arrays.asList(sourceIndex))).isEquals()) {
-                    log.info("Index {} needs to be modified (removed/created) for table {}", targetIndex.getName(), sourceTable.getName());
-                    changes.add(new RemoveIndexChange(sourceTable, sourceIndex));
-                    changes.add(new AddIndexChange(targetTable, targetIndex));
-                }
             }
         }
     }

--- a/symmetric-db/src/test/java/org/jumpmind/db/alter/ModelComparatorTest.java
+++ b/symmetric-db/src/test/java/org/jumpmind/db/alter/ModelComparatorTest.java
@@ -1,0 +1,145 @@
+/**
+ * Licensed to JumpMind Inc under one or more contributor
+ * license agreements.  See the NOTICE file distributed
+ * with this work for additional information regarding
+ * copyright ownership.  JumpMind Inc licenses this file
+ * to you under the GNU General Public License, version 3.0 (GPLv3)
+ * (the "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3.0 (GPLv3) along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jumpmind.db.alter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+
+import org.jumpmind.db.model.IIndex;
+import org.jumpmind.db.model.IndexColumn;
+import org.jumpmind.db.model.NonUniqueIndex;
+import org.jumpmind.db.model.Table;
+import org.jumpmind.db.model.UniqueIndex;
+import org.jumpmind.db.platform.DatabaseInfo;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class ModelComparatorTest {
+    private ArrayList<IModelChange> changeList = new ArrayList<IModelChange>();
+    private Table sourceTable = new Table("test");
+    private Table targetTable = new Table("test");
+    private static IIndex nonUniqueIndexLowercase;
+    private static IIndex uniqueIndexLowercase;
+    private static IIndex nonUniqueIndexLowercaseColumnUppercase;
+    private static IIndex uniqueIndexLowercaseColumnUppercase;
+    private static IIndex nonUniqueIndexUppercase;
+    private static IIndex uniqueIndexUppercase;
+
+    @BeforeAll
+    public static void setUpAll() {
+        nonUniqueIndexLowercase = new NonUniqueIndex("nonunique");
+        nonUniqueIndexLowercase.addColumn(new IndexColumn("nonuniquecolumn"));
+        uniqueIndexLowercase = new UniqueIndex("unique");
+        uniqueIndexLowercase.addColumn(new IndexColumn("uniquecolumn"));
+        nonUniqueIndexLowercaseColumnUppercase = new NonUniqueIndex("nonunique");
+        nonUniqueIndexLowercaseColumnUppercase.addColumn(new IndexColumn("NONUNIQUECOLUMN"));
+        uniqueIndexLowercaseColumnUppercase = new UniqueIndex("unique");
+        uniqueIndexLowercaseColumnUppercase.addColumn(new IndexColumn("UNIQUECOLUMN"));
+        nonUniqueIndexUppercase = new NonUniqueIndex("NONUNIQUE");
+        nonUniqueIndexUppercase.addColumn(new IndexColumn("NONUNIQUECOLUMN"));
+        uniqueIndexUppercase = new UniqueIndex("UNIQUE");
+        uniqueIndexUppercase.addColumn(new IndexColumn("UNIQUECOLUMN"));
+    }
+
+    @BeforeEach
+    public void setUpEach() {
+        changeList.clear();
+        sourceTable.removeAllIndexes();
+        targetTable.removeAllIndexes();
+    }
+
+    @Test
+    public void testDetectIndexChangesCaseSensitive() {
+        ModelComparator modelComparator = new ModelComparator(null, new DatabaseInfo(), true);
+        targetTable.addIndex(nonUniqueIndexLowercase);
+        targetTable.addIndex(uniqueIndexLowercase);
+        modelComparator.detectIndexChanges(null, sourceTable, null, targetTable, changeList);
+        assertEquals(2, changeList.size());
+        assertTrue(changeList.stream().anyMatch(c -> c instanceof AddIndexChange && ((AddIndexChange) c).getNewIndex().equals(nonUniqueIndexLowercase)));
+        assertTrue(changeList.stream().anyMatch(c -> c instanceof AddIndexChange && ((AddIndexChange) c).getNewIndex().equals(uniqueIndexLowercase)));
+        changeList.clear();
+        sourceTable.addIndex(nonUniqueIndexUppercase);
+        sourceTable.addIndex(uniqueIndexUppercase);
+        modelComparator.detectIndexChanges(null, sourceTable, null, targetTable, changeList);
+        assertEquals(4, changeList.size());
+        assertTrue(changeList.stream().anyMatch(c -> c instanceof AddIndexChange && ((AddIndexChange) c).getNewIndex().equals(nonUniqueIndexLowercase)));
+        assertTrue(changeList.stream().anyMatch(c -> c instanceof AddIndexChange && ((AddIndexChange) c).getNewIndex().equals(uniqueIndexLowercase)));
+        assertTrue(changeList.stream().anyMatch(c -> c instanceof RemoveIndexChange && ((RemoveIndexChange) c).getIndex().equals(nonUniqueIndexUppercase)));
+        assertTrue(changeList.stream().anyMatch(c -> c instanceof RemoveIndexChange && ((RemoveIndexChange) c).getIndex().equals(uniqueIndexUppercase)));
+        changeList.clear();
+        sourceTable.removeAllIndexes();
+        sourceTable.addIndex(nonUniqueIndexLowercaseColumnUppercase);
+        sourceTable.addIndex(uniqueIndexLowercaseColumnUppercase);
+        modelComparator.detectIndexChanges(null, sourceTable, null, targetTable, changeList);
+        assertEquals(4, changeList.size());
+        assertTrue(changeList.stream().anyMatch(c -> c instanceof AddIndexChange && ((AddIndexChange) c).getNewIndex().equals(nonUniqueIndexLowercase)));
+        assertTrue(changeList.stream().anyMatch(c -> c instanceof AddIndexChange && ((AddIndexChange) c).getNewIndex().equals(uniqueIndexLowercase)));
+        assertTrue(changeList.stream().anyMatch(c -> c instanceof RemoveIndexChange && ((RemoveIndexChange) c).getIndex().equals(
+                nonUniqueIndexLowercaseColumnUppercase)));
+        assertTrue(changeList.stream().anyMatch(c -> c instanceof RemoveIndexChange && ((RemoveIndexChange) c).getIndex().equals(
+                uniqueIndexLowercaseColumnUppercase)));
+        changeList.clear();
+        sourceTable.removeAllIndexes();
+        sourceTable.addIndex(nonUniqueIndexLowercase);
+        sourceTable.addIndex(uniqueIndexLowercase);
+        modelComparator.detectIndexChanges(null, sourceTable, null, targetTable, changeList);
+        assertEquals(0, changeList.size());
+        targetTable.removeAllIndexes();
+        modelComparator.detectIndexChanges(null, sourceTable, null, targetTable, changeList);
+        assertEquals(2, changeList.size());
+        assertTrue(changeList.stream().anyMatch(c -> c instanceof RemoveIndexChange && ((RemoveIndexChange) c).getIndex().equals(nonUniqueIndexLowercase)));
+        assertTrue(changeList.stream().anyMatch(c -> c instanceof RemoveIndexChange && ((RemoveIndexChange) c).getIndex().equals(uniqueIndexLowercase)));
+    }
+
+    @Test
+    public void testDetectIndexChangesCaseInsensitive() {
+        ModelComparator modelComparator = new ModelComparator(null, new DatabaseInfo(), false);
+        targetTable.addIndex(nonUniqueIndexLowercase);
+        targetTable.addIndex(uniqueIndexLowercase);
+        modelComparator.detectIndexChanges(null, sourceTable, null, targetTable, changeList);
+        assertEquals(2, changeList.size());
+        assertTrue(changeList.stream().anyMatch(c -> c instanceof AddIndexChange && ((AddIndexChange) c).getNewIndex().equals(nonUniqueIndexLowercase)));
+        assertTrue(changeList.stream().anyMatch(c -> c instanceof AddIndexChange && ((AddIndexChange) c).getNewIndex().equals(uniqueIndexLowercase)));
+        changeList.clear();
+        sourceTable.addIndex(nonUniqueIndexUppercase);
+        sourceTable.addIndex(uniqueIndexUppercase);
+        modelComparator.detectIndexChanges(null, sourceTable, null, targetTable, changeList);
+        assertEquals(0, changeList.size());
+        sourceTable.removeAllIndexes();
+        sourceTable.addIndex(nonUniqueIndexLowercaseColumnUppercase);
+        sourceTable.addIndex(uniqueIndexLowercaseColumnUppercase);
+        modelComparator.detectIndexChanges(null, sourceTable, null, targetTable, changeList);
+        assertEquals(0, changeList.size());
+        sourceTable.removeAllIndexes();
+        sourceTable.addIndex(nonUniqueIndexLowercase);
+        sourceTable.addIndex(uniqueIndexLowercase);
+        modelComparator.detectIndexChanges(null, sourceTable, null, targetTable, changeList);
+        assertEquals(0, changeList.size());
+        targetTable.removeAllIndexes();
+        modelComparator.detectIndexChanges(null, sourceTable, null, targetTable, changeList);
+        assertEquals(2, changeList.size());
+        assertTrue(changeList.stream().anyMatch(c -> c instanceof RemoveIndexChange && ((RemoveIndexChange) c).getIndex().equals(nonUniqueIndexLowercase)));
+        assertTrue(changeList.stream().anyMatch(c -> c instanceof RemoveIndexChange && ((RemoveIndexChange) c).getIndex().equals(uniqueIndexLowercase)));
+    }
+}


### PR DESCRIPTION
It turns out that the whole `else if` block that checks whether an index needs modified is unnecessary (and causes unexpected behavior in its current state). This is because the code earlier in `ModelComparator.detectIndexChanges()` already handles removing extra indexes and adding missing indexes. It calls `findCorrespondingIndex()`, which already accounts for the platform's case sensitivity.

I added unit tests to verify that it works as expected. Without my change, `ModelComparatorTest.testDetectIndexChangesCaseInsensitive()` fails because on line 128, `changeList.size()` returns 4 instead of 0. Let me know if I'm missing anything.