### PR TITLE
SYM-7135: Added H2 SYM_DATA_DATA_ID_SEQ sequence if missing during an upgrade

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/db/DatabaseUpgradeListener.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/db/DatabaseUpgradeListener.java
@@ -340,6 +340,33 @@ public class DatabaseUpgradeListener implements IDatabaseUpgradeListener, ISymme
                     + " where source_node_id = ? and completed = 1)",
                     engine.getNodeId(), engine.getNodeId());
         }
+        if (engine.getDatabasePlatform().getName().equals(DatabaseNamesConstants.H2)) {
+            String dataIdSequenceName = symmetricDialect.getSequenceName(SequenceIdentifier.DATA).toUpperCase() + "_SEQ";
+            if (engine.getSqlTemplate().queryForInt("select count(*) from information_schema.sequences where sequence_name = ?", dataIdSequenceName) == 0) {
+                String dataTableName = TableConstants.getTableName(tablePrefix, TableConstants.SYM_DATA);
+                ISqlTransaction transaction = null;
+                try {
+                    transaction = engine.getSqlTemplate().startSqlTransaction();
+                    transaction.prepareAndExecute("set exclusive 1");
+                    long maxDataId = Math.max(transaction.queryForInt("select max(data_id) from " + dataTableName), 1);
+                    log.info("After upgrade, creating {} sequence with a value of {} because it doesn't exist", dataIdSequenceName, maxDataId + 1);
+                    transaction.prepareAndExecute("create sequence \"" + dataIdSequenceName + "\" start with " + (maxDataId + 1));
+                    log.info("After upgrade, altering {}.data_id to use the new sequence instead of auto_increment", dataTableName);
+                    transaction.prepareAndExecute("alter table " + dataTableName
+                            + " alter column data_id bigint not null default nextval('" + dataIdSequenceName + "')");
+                    transaction.prepareAndExecute("set exclusive 0");
+                } catch (Exception e) {
+                    log.info("Unable to create sequence: {}", e.getMessage());
+                    if (transaction != null) {
+                        transaction.rollback();
+                    }
+                } finally {
+                    if (transaction != null) {
+                        transaction.close();
+                    }
+                }
+            }
+        }
         engine.getPullService().pullConfigData(false);
         return sb.toString();
     }

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/db/DatabaseUpgradeListener.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/db/DatabaseUpgradeListener.java
@@ -341,31 +341,7 @@ public class DatabaseUpgradeListener implements IDatabaseUpgradeListener, ISymme
                     engine.getNodeId(), engine.getNodeId());
         }
         if (engine.getDatabasePlatform().getName().equals(DatabaseNamesConstants.H2)) {
-            String dataIdSequenceName = symmetricDialect.getSequenceName(SequenceIdentifier.DATA).toUpperCase() + "_SEQ";
-            if (engine.getSqlTemplate().queryForInt("select count(*) from information_schema.sequences where sequence_name = ?", dataIdSequenceName) == 0) {
-                String dataTableName = TableConstants.getTableName(tablePrefix, TableConstants.SYM_DATA);
-                ISqlTransaction transaction = null;
-                try {
-                    transaction = engine.getSqlTemplate().startSqlTransaction();
-                    transaction.prepareAndExecute("set exclusive 1");
-                    long maxDataId = Math.max(transaction.queryForInt("select max(data_id) from " + dataTableName), 1);
-                    log.info("After upgrade, creating {} sequence with a value of {} because it doesn't exist", dataIdSequenceName, maxDataId + 1);
-                    transaction.prepareAndExecute("create sequence \"" + dataIdSequenceName + "\" start with " + (maxDataId + 1));
-                    log.info("After upgrade, altering {}.data_id to use the new sequence instead of auto_increment", dataTableName);
-                    transaction.prepareAndExecute("alter table " + dataTableName
-                            + " alter column data_id bigint not null default nextval('" + dataIdSequenceName + "')");
-                    transaction.prepareAndExecute("set exclusive 0");
-                } catch (Exception e) {
-                    log.info("Unable to create sequence: {}", e.getMessage());
-                    if (transaction != null) {
-                        transaction.rollback();
-                    }
-                } finally {
-                    if (transaction != null) {
-                        transaction.close();
-                    }
-                }
-            }
+            createH2SequenceIfMissing(symmetricDialect, tablePrefix);
         }
         engine.getPullService().pullConfigData(false);
         return sb.toString();
@@ -557,6 +533,34 @@ public class DatabaseUpgradeListener implements IDatabaseUpgradeListener, ISymme
     protected boolean isUpgradeFromPre316(String tablePrefix, Database currentModel) {
         Table table = currentModel.findTable(tablePrefix + "_" + TableConstants.SYM_EXTRACT_REQUEST);
         return table != null && table.findColumn("extract_thread_id") == null;
+    }
+
+    protected void createH2SequenceIfMissing(ISymmetricDialect symmetricDialect, String tablePrefix) {
+        String dataIdSequenceName = symmetricDialect.getSequenceName(SequenceIdentifier.DATA).toUpperCase() + "_SEQ";
+        if (engine.getSqlTemplate().queryForInt("select count(*) from information_schema.sequences where sequence_name = ?", dataIdSequenceName) == 0) {
+            String dataTableName = TableConstants.getTableName(tablePrefix, TableConstants.SYM_DATA);
+            ISqlTransaction transaction = null;
+            try {
+                transaction = engine.getSqlTemplate().startSqlTransaction();
+                transaction.prepareAndExecute("set exclusive 1");
+                long maxDataId = Math.max(transaction.queryForInt("select max(data_id) from " + dataTableName), 1);
+                log.info("After upgrade, creating {} sequence with a value of {} because it doesn't exist", dataIdSequenceName, maxDataId + 1);
+                transaction.prepareAndExecute("create sequence \"" + dataIdSequenceName + "\" start with " + (maxDataId + 1));
+                log.info("After upgrade, altering {}.data_id to use the new sequence instead of auto_increment", dataTableName);
+                transaction.prepareAndExecute("alter table " + dataTableName
+                        + " alter column data_id bigint not null default nextval('" + dataIdSequenceName + "')");
+                transaction.prepareAndExecute("set exclusive 0");
+            } catch (Exception e) {
+                log.info("Unable to create sequence: {}", e.getMessage());
+                if (transaction != null) {
+                    transaction.rollback();
+                }
+            } finally {
+                if (transaction != null) {
+                    transaction.close();
+                }
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
It would have been good to limit the `information_schema.sequences` query to only run on an upgrade from 3.16.7 or earlier. Usually there's a check for a particular schema change to determine the version that is being upgraded from, but there are no schema changes in the upgrade from an earlier 3.16 version to 3.16.8.

If it isn't okay to run this query every time an H2 node is upgraded, then I could make this change in 3.17.0 instead or I could try checking `sym_node.symmetric_version` instead of relying on a schema change.