### PR TITLE
SYM-7186: Fixed NullPointerException when resolving a unique key violation on a table that is referenced by a table in different schema

### DIFF
--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/AbstractJdbcDdlReader.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/AbstractJdbcDdlReader.java
@@ -1200,11 +1200,11 @@ public abstract class AbstractJdbcDdlReader implements IDdlReader {
             fk = new ForeignKey(fkName);
             fk.setForeignTableName((String) values.get(getName("FKTABLE_NAME")));
             try {
-                fk.setForeignTableCatalog((String) values.get(getName("FKTABLE_CAT")));
+                fk.setForeignTableCatalog((String) values.getOrDefault(getName("FKTABLE_CAT"), values.get(getName("fktable_cat"))));
             } catch (Exception e) {
             }
             try {
-                fk.setForeignTableSchema((String) values.get(getName("FKTABLE_SCHEM")));
+                fk.setForeignTableSchema((String) values.getOrDefault(getName("FKTABLE_SCHEM"), values.get(getName("fktable_schem"))));
             } catch (Exception e) {
             }
             knownFks.put(fkName, fk);
@@ -1832,7 +1832,7 @@ public abstract class AbstractJdbcDdlReader implements IDdlReader {
 
     private Table lookupForeignTable(IDatabasePlatform platform, ForeignKey fk, TableRow tableRow, boolean clearPrimaryKeys) {
         Table foreignTable = null;
-        Table table = platform.getTableFromCache(tableRow.getTable().getCatalog(), tableRow.getTable().getSchema(), fk.getForeignTableName(), false);
+        Table table = platform.getTableFromCache(fk.getForeignTableCatalog(), fk.getForeignTableSchema(), fk.getForeignTableName(), false);
         if (table == null) {
             table = fk.getForeignTable();
             if (table == null) {

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/AbstractJdbcDdlReader.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/AbstractJdbcDdlReader.java
@@ -1695,7 +1695,7 @@ public abstract class AbstractJdbcDdlReader implements IDdlReader {
                 Collection<ForeignKey> exportedKeys = getExportedKeys(tableRow.getTable());
                 if (exportedKeys != null) {
                     for (ForeignKey fk : exportedKeys) {
-                        Table foreignTable = lookupForeignTable(platform, fk, tableRow, false);
+                        Table foreignTable = lookupForeignTable(platform, fk, false);
                         if (foreignTable != null) {
                             // Get the column names used by the foreign table and the values to bind to them from the primary table
                             Row selectRow = new Row(fk.getReferenceCount());
@@ -1772,7 +1772,7 @@ public abstract class AbstractJdbcDdlReader implements IDdlReader {
         for (TableRow tableRow : tableRows) {
             if (visited.add(tableRow)) {
                 for (ForeignKey fk : tableRow.getTable().getForeignKeys()) {
-                    Table foreignTable = lookupForeignTable(platform, fk, tableRow, true);
+                    Table foreignTable = lookupForeignTable(platform, fk, true);
                     if (foreignTable != null) {
                         Row whereRow = new Row(fk.getReferenceCount());
                         String referenceColumnName = null;
@@ -1830,7 +1830,7 @@ public abstract class AbstractJdbcDdlReader implements IDdlReader {
         return fkDepList;
     }
 
-    private Table lookupForeignTable(IDatabasePlatform platform, ForeignKey fk, TableRow tableRow, boolean clearPrimaryKeys) {
+    private Table lookupForeignTable(IDatabasePlatform platform, ForeignKey fk, boolean clearPrimaryKeys) {
         Table foreignTable = null;
         Table table = platform.getTableFromCache(fk.getForeignTableCatalog(), fk.getForeignTableSchema(), fk.getForeignTableName(), false);
         if (table == null) {

--- a/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/AbstractJdbcDdlReaderTest.java
+++ b/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/AbstractJdbcDdlReaderTest.java
@@ -1,0 +1,71 @@
+/**
+ * Licensed to JumpMind Inc under one or more contributor
+ * license agreements.  See the NOTICE file distributed
+ * with this work for additional information regarding
+ * copyright ownership.  JumpMind Inc licenses this file
+ * to you under the GNU General Public License, version 3.0 (GPLv3)
+ * (the "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3.0 (GPLv3) along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jumpmind.db.platform;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jumpmind.db.model.ForeignKey;
+import org.jumpmind.db.model.Reference;
+import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
+
+public class AbstractJdbcDdlReaderTest {
+    @Test
+    public void testReadExportedKey() throws SQLException {
+        AbstractJdbcDdlReader ddlReader = mock(AbstractJdbcDdlReader.class, Answers.CALLS_REAL_METHODS);
+        Map<String, Object> metadataMap = new HashMap<String, Object>();
+        metadataMap.put("FK_NAME", "test_fk");
+        metadataMap.put("FKTABLE_NAME", "test_table");
+        metadataMap.put("fktable_cat", "test_catalog_lowercase");
+        metadataMap.put("fktable_schem", "test_schema_lowercase");
+        metadataMap.put("FKCOLUMN_NAME", "foreign_col");
+        metadataMap.put("PKCOLUMN_NAME", "local_col");
+        metadataMap.put("KEY_SEQ", (short) 123);
+        Map<String, ForeignKey> fkMap = new HashMap<String, ForeignKey>();
+        ddlReader.readExportedKey(null, metadataMap, fkMap);
+        assertEquals(1, fkMap.size());
+        ForeignKey fk = fkMap.get("test_fk");
+        assertEquals("test_fk", fk.getName());
+        assertEquals("test_table", fk.getForeignTableName());
+        assertEquals("test_catalog_lowercase", fk.getForeignTableCatalog());
+        assertEquals("test_schema_lowercase", fk.getForeignTableSchema());
+        assertEquals(1, fk.getReferenceCount());
+        Reference reference = fk.getFirstReference();
+        assertEquals("foreign_col", reference.getForeignColumnName());
+        assertEquals("local_col", reference.getLocalColumnName());
+        assertEquals(123, reference.getSequenceValue());
+        metadataMap.put("FKTABLE_CAT", "TEST_CATALOG_UPPERCASE");
+        metadataMap.put("FKTABLE_SCHEM", "TEST_SCHEMA_UPPERCASE");
+        fkMap.clear();
+        ddlReader.readExportedKey(null, metadataMap, fkMap);
+        assertEquals(1, fkMap.size());
+        fk = fkMap.get("test_fk");
+        assertEquals("TEST_CATALOG_UPPERCASE", fk.getForeignTableCatalog());
+        assertEquals("TEST_SCHEMA_UPPERCASE", fk.getForeignTableSchema());
+        ddlReader.readExportedKey(null, metadataMap, fkMap);
+        assertEquals(1, fkMap.size());
+    }
+}


### PR DESCRIPTION
Currently `AbstractJdbcDdlReader.lookupForeignTable()` uses the referenced table's catalog and schema instead of the referencing table's catalog and schema. As a result, if the tables are in different schemas, either the table is not found or the wrong table is found, which causes the `NullPointerException`. The change to this method makes it use the referencing table's catalog and schema instead.

I reproduced this issue using Postgres and found that the referencing table's catalog and schema were not populated in the `ForeignKey` object because the keys in the metadata were in lowercase instead of uppercase. The change to `AbstractJdbcDdlReader.readExportedKey()` makes it fall back to the lowercase keys for catalog and schema if the uppercase keys are not found.