### PR TITLE
SYM-7203: merge GitHub workflows and its release related changes from 3.16

### DIFF
--- a/.github/workflows/cherry-pick-merged-pr.yml
+++ b/.github/workflows/cherry-pick-merged-pr.yml
@@ -1,0 +1,246 @@
+name: Cherry-pick merged PR
+on:
+  push:
+    branches:
+      - 'release/3.16'
+  workflow_dispatch:
+    inputs:
+      commit_hash:
+        type: string
+        description: Commit hash of the squashed commit to be cherry-picked
+        required: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  GITHUB_BOT_EMAIL: 'jm-commerce-bot[bot]@users.noreply.github.com'
+  GITHUB_BOT_NAME: 'jm-commerce-bot[bot]'
+  GITHUB_BOT_KEY: ${{ secrets.JM_GITHUB_APP_COMMERCE_PK }}
+  GITHUB_BOT_APP_ID: ${{ vars.JM_GITHUB_APP_COMMERCE_BOT_ID }}
+
+jobs:
+  compute-destination-branches:
+    runs-on: ubuntu-latest
+    
+    outputs:
+      destination_branches: ${{ steps.destination-branches.outputs.destination_branches }}
+      pr_number: ${{ steps.pr-number.outputs.group1 }}
+      commit_hash: ${{ steps.commit-info.outputs.commit_hash }}
+    
+    steps:
+      - name: Checkout for commit lookup
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract commit information
+        id: commit-info
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            echo "commit_hash=${{ github.sha }}" >> $GITHUB_OUTPUT
+            cat << 'EOF' >> $GITHUB_OUTPUT
+          commit_message<<COMMIT_EOF
+          ${{ github.event.head_commit.message }}
+          COMMIT_EOF
+          EOF
+          else
+            echo "commit_hash=${{ inputs.commit_hash }}" >> $GITHUB_OUTPUT
+            git_message=$(git log -1 --pretty=format:"%s" ${{ inputs.commit_hash }})
+            echo "commit_message=${git_message}" >> $GITHUB_OUTPUT
+          fi
+          
+      - name: Match PR number from commit message
+        uses: actions-ecosystem/action-regex-match@v2
+        id: pr-number
+        with:
+          text: ${{ steps.commit-info.outputs.commit_message }}
+          regex: \(#(\d+)\)
+
+      - name: Title regex match
+        uses: actions-ecosystem/action-regex-match@v2
+        id: title-pattern
+        with:
+          text: ${{ steps.commit-info.outputs.commit_message }}
+          regex: '${{ vars.PR_POLICY_TITLE_PATTERN }}'
+          flags: 'm'
+
+      - name: Extract JIRA ticket
+        id: extract-jira-ticket
+        run: |
+          MATCHED="${{ steps.title-pattern.outputs.match }}"
+    
+          if [ -n "$MATCHED" ]; then
+            JIRA_KEY=$(echo "$MATCHED" | grep -oE '^SYM-[0-9]+')
+            echo "jira_ticket=${JIRA_KEY}" >> $GITHUB_OUTPUT
+            echo "Extracted JIRA ticket: ${JIRA_KEY}"
+          else
+            echo "jira_ticket=" >> $GITHUB_OUTPUT
+            echo "No JIRA ticket found in commit message"
+          fi
+          
+      - name: Get fix versions
+        id: fix-versions
+        if: steps.pr-number.outputs.match != '' && steps.extract-jira-ticket.outputs.jira_ticket != ''
+        env:
+          JIRA_KEY: ${{ steps.extract-jira-ticket.outputs.jira_ticket }}
+          JIRA_URL: ${{ secrets.JIRA_URL }}
+          JIRA_USER: ${{ secrets.JIRA_USER }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+        run: |
+          RESPONSE_STATUS=$(curl -s -w "%{response_code}" -o /tmp/jira_response.json -X GET \
+            --user '${{ secrets.JIRA_USER }}:${{ secrets.JIRA_API_KEY }}' \
+            --header 'Content-Type: application/json' \
+            --header 'Accept: application/json' \
+            "$JIRA_URL/rest/api/3/issue/$JIRA_KEY?fields=fixVersions")
+          
+          RESPONSE_BODY=$(cat /tmp/jira_response.json)
+
+          if [ "$RESPONSE_STATUS" -ge 200 ] && [ "$RESPONSE_STATUS" -lt 300 ]; then
+            echo "Successfully retrieved ${JIRA_KEY} ticket from JIRA"
+          else
+            echo "HTTP ${RESPONSE_STATUS}: Failed to GET ${JIRA_KEY} ticket from JIRA"
+            echo "$RESPONSE_BODY"
+            exit 1
+          fi
+          
+          FIX_VERSIONS=$(echo "$RESPONSE_BODY" | jq -r '.fields.fixVersions[].name' | tr '\n' ' ')
+          
+          if [ -z "$FIX_VERSIONS" ]; then
+            echo "No fix versions found for ticket '$JIRA_KEY'"
+            echo "fix_versions=" >> $GITHUB_OUTPUT
+          else
+            echo "Found fix versions: '$FIX_VERSIONS', for '$JIRA_KEY'"
+            echo "fix_versions=$FIX_VERSIONS" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Map fix versions to branches
+        id: destination-branches
+        if: steps.pr-number.outputs.match != '' && steps.extract-jira-ticket.outputs.jira_ticket != ''
+        run: |
+          FIX_VERSIONS="${{ steps.fix-versions.outputs.fix_versions }}"
+          CURRENT_BRANCH="${{ github.ref_name }}"
+
+          if [ -n "$FIX_VERSIONS" ]; then
+            RELEASE_BRANCHES=""
+            for VERSION in $FIX_VERSIONS; do
+              # Extract major.minor (strip patch version)
+              BRANCH_VERSION=$(echo "$VERSION" | cut -d'.' -f1,2)
+              TARGET_BRANCH="release/${BRANCH_VERSION}"
+              
+              # Skip if this is the current branch
+              if [ "$TARGET_BRANCH" != "$CURRENT_BRANCH" ]; then
+                RELEASE_BRANCHES="${RELEASE_BRANCHES}${TARGET_BRANCH} "
+              else
+                echo "Skipping current branch: ${TARGET_BRANCH}"
+              fi
+            done
+      
+            RELEASE_BRANCHES=$(echo "$RELEASE_BRANCHES" | tr ' ' '\n' | sort -u | tr '\n' ' ' | sed 's/ $//')
+            
+            if [ -n "$RELEASE_BRANCHES" ]; then
+              JSON_ARRAY=$(printf '%s\n' $RELEASE_BRANCHES | jq -R -s -c 'split("\n") | map(select(length > 0))')
+              
+              echo "Destination branches: ${JSON_ARRAY}"
+              echo "destination_branches=${JSON_ARRAY}" >> $GITHUB_OUTPUT
+            else
+              echo "No other branches to cherry-pick to (only current branch in fix versions)"
+              echo "destination_branches=[]" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "No fix versions found"
+            echo "destination_branches=[]" >> $GITHUB_OUTPUT
+          fi
+            
+  cherry-pick-to-branches:
+    runs-on: ubuntu-latest
+    needs: compute-destination-branches
+    continue-on-error: true
+    if: needs.compute-destination-branches.outputs.destination_branches != '[]'
+    strategy:
+      matrix:
+        branch: ${{ fromJson(needs.compute-destination-branches.outputs.destination_branches) }}
+    
+    steps:
+      - name: Create App Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          owner: jumpmindinc
+          app-id: ${{ env.GITHUB_BOT_APP_ID }}
+          private-key: ${{ env.GITHUB_BOT_KEY }}
+
+      - name: Checkout Source
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: '0'
+          ref: '${{ matrix.branch }}'
+
+      - name: Set git user config
+        id: git-setup
+        run: |
+          git config --global user.email "${{ env.GITHUB_BOT_EMAIL }}"
+          git config --global user.name "${{ env.GITHUB_BOT_NAME }}"
+          echo "unique_branch=cherry-pick-${{ needs.compute-destination-branches.outputs.commit_hash }}-${{ matrix.branch }}" >> $GITHUB_OUTPUT
+
+      - name: Cherry pick commit
+        id: cherry-pick
+        shell: bash
+        run: |
+          git status
+          git checkout -b ${{ steps.git-setup.outputs.unique_branch }}
+          if ! git cherry-pick ${{ needs.compute-destination-branches.outputs.commit_hash }}; then
+            echo "has_conflict=true" >> $GITHUB_OUTPUT
+            git status
+            git add -u
+            git cherry-pick --continue --no-edit
+          fi
+          git push --set-upstream origin ${{ steps.git-setup.outputs.unique_branch }}
+
+      - name: Open PR
+        id: open-pr
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const mainPR = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: ${{ needs.compute-destination-branches.outputs.pr_number }}
+            });
+            const body = `Original commit hash: ${{ needs.compute-destination-branches.outputs.commit_hash }}
+            
+            This was created by a bot`;
+            const cherryPickPR = await github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: '${{ steps.git-setup.outputs.unique_branch }}',
+              base: '${{ matrix.branch }}',
+              title: `${mainPR.data.title} #${{ needs.compute-destination-branches.outputs.pr_number }}`,
+              body: body
+            });
+
+            console.log('New Pr Number: ', cherryPickPR.data.number);
+            console.log('Original Pr Author: ', mainPR.data.user);
+            
+            github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: cherryPickPR.data.number,
+              assignees: [mainPR.data.user.login]
+            });
+            
+            if ('true' == '${{ steps.cherry-pick.outputs.has_conflict}}') {
+              const comment = `There is a conflict in this PR that will most likely fail the build.
+              It must be resolved manually in order to successfully merge.`
+
+              github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: cherryPickPR.data.number,
+                body: comment
+              });
+            }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,111 @@
+name: Release
+
+on:
+    workflow_dispatch:
+        inputs:
+            version:
+                type: string
+                description: Full version (major.minor.patch) number to release, e.g. 1.2.3.
+                required: true
+            latest:
+                type: boolean
+                description: Whether this release is going to be the latest (major.minor.patch) version.
+                required: true
+                
+run-name: "Release: ${{ inputs.version }}"
+
+jobs:
+    create-release:        
+        runs-on: runs-on=${{ github.run_id }}/runner=2cpu-linux-x64
+        permissions:
+            contents: write
+
+        steps:
+            - uses: runs-on/action@v2
+            
+            - name: Validate release version input
+              shell: bash
+              run: |
+                echo "Validating release version: ${{ github.event.inputs.version }}"
+                if [[ ! "${{ github.event.inputs.version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                    echo "ERROR: Invalid version input. Must be of the format major.minor.patch, e.g. 3.16.6."
+                    exit 1
+                fi
+
+            - name: Validate branch
+              shell: bash
+              run: |
+                BRANCH_NAME="${GITHUB_REF##refs/heads/}"
+                echo "Validating branch $BRANCH_NAME"
+                if [[ "$BRANCH_NAME" != release/* ]]; then
+                    echo "ERROR: This workflow only supports a release/* branch."
+                    exit 1
+                fi
+                
+            - name: Checkout Source
+              uses: actions/checkout@v4
+              with:
+                  clean: true
+            
+            - name: Set up Java
+              uses: actions/setup-java@v4
+              with:
+                  java-version: 17
+                  distribution: 'temurin'
+                  cache: gradle
+
+            - name: Setup Gradle
+              uses: gradle/actions/setup-gradle@v4
+
+            - name: Build with Gradle
+              run: |
+                ./gradlew clean build
+              working-directory: symmetric-assemble
+            
+            - name: Publish
+              run: |
+                ./gradlew clean jar releaseSymmetric deploy publishDocker \
+                    -Platest="$LATEST" \
+                    -Pversion=${{ github.event.inputs.version }} \
+                    -PdeployPassword=${{ secrets.MAVEN_REPO_PASSWORD }} \
+                    -PdeployUploadUrl=${{ secrets.MAVEN_REPO_URL }} \
+                    -PdeployUser=${{ secrets.MAVEN_REPO_USER }} \
+                    -PdockerPassword=${{ secrets.DOCKERHUB_PASSWORD }} \
+                    -PdockerUser=${{ secrets.DOCKERHUB_USER }} \
+                    -PsourceforgeApiKey=${{ secrets.SOURCEFORGE_API_KEY }} \
+                    -PsourceforgePassword=${{ secrets.SOURCEFORGE_PASSWORD }} \
+                    -PsourceforgeUser=${{ secrets.SOURCEFORGE_USER }}
+              working-directory: symmetric-assemble
+              env:
+                  LATEST: ${{ github.event.inputs.latest }}
+                  ORG_GRADLE_PROJECT_signingKey: ${{ secrets.PGP_KEY }}
+                  ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.PGP_KEY_PASSWORD }}
+
+            - name: Does Tag Exist?
+              id: check_tag_exists
+              run: |
+                TAG="${{ github.event.inputs.version }}"
+                if git ls-remote --tags origin | grep "refs/tags/$TAG$" >/dev/null; then
+                    echo "Tag $TAG already exists. Skipping tagging."
+                else
+                    echo "should_tag=true" >> $GITHUB_OUTPUT
+                fi
+
+            - name: Create Tag
+              if: steps.check_tag_exists.outputs.should_tag
+              id: create_tag
+              run: |
+                TAG="${{ github.event.inputs.version }}"
+                git tag $TAG
+                git push origin $TAG
+          
+                echo "TAG=$TAG" >> $GITHUB_OUTPUT
+                
+            - name: Create Release in GitHub
+              if: steps.check_tag_exists.outputs.should_tag
+              uses: softprops/action-gh-release@v2
+              with:
+                tag_name: ${{ steps.create_tag.outputs.TAG }}
+                name: "Release ${{ steps.create_tag.outputs.TAG }}"
+                draft: false
+                prerelease: false

--- a/.github/workflows/resolve-ticket-on-merge.yml
+++ b/.github/workflows/resolve-ticket-on-merge.yml
@@ -1,0 +1,56 @@
+name: Resolve JIRA ticket on PR merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - 'release/*'
+      
+jobs:
+  resolve-jira-ticket:
+    if: github.event.pull_request.merged == true
+    runs-on: runs-on=${{ github.run_id }}/runner=2cpu-linux-x64   
+    steps:
+      - uses: runs-on/action@v2
+      
+      - name: Checkout source
+        uses: actions/checkout@v4
+        with:
+          clean: true
+          fetch-depth: 2
+      
+      - name: Extract JIRA ticket from commit
+        id: extract
+        run: |
+          COMMIT_MSG=$(git log -1 --pretty=%B)
+          
+          JIRA_KEY=$(echo "$COMMIT_MSG" | grep -oE '^SYM-[0-9]+')
+          
+          echo "Commit message: $COMMIT_MSG"
+          echo "jira_key=${JIRA_KEY}" >> $GITHUB_OUTPUT
+
+          if [ -n "$JIRA_KEY" ]; then
+            echo "Found JIRA ticket: ${JIRA_KEY}"
+          else
+            echo "Warning: No JIRA ticket found in commit message"
+          fi
+      
+      - name: Update JIRA ticket to resolved status
+        if: steps.extract.outputs.jira_key != ''
+        run: |
+          JIRA_KEY="${{ steps.extract.outputs.jira_key }}"
+          
+          echo "Updating ${JIRA_KEY} to Resolved status..."
+          
+          RESPONSE_STATUS=$(curl -s -w "%{response_code}\n" -X POST \
+            --user '${{ secrets.JIRA_USER }}:${{ secrets.JIRA_API_KEY }}' \
+            --header 'Content-Type: application/json' \
+            --header 'Accept: application/json' \
+            --data '{"transition":{"id":"7"}}' \
+            "${{ secrets.JIRA_URL }}/rest/api/2/issue/${JIRA_KEY}/transitions")
+          
+          if [ "$RESPONSE_STATUS" -ge 200 ] && [ "$RESPONSE_STATUS" -lt 300 ]; then
+            echo "Successfully updated ${JIRA_KEY} to Resolved"
+          else
+            echo "Failed to update ${JIRA_KEY}. HTTP ${RESPONSE_STATUS}"
+          fi

--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -1,7 +1,9 @@
 name: Sonar Scan
 on:
+  push:
+    branches:
+      - 'release/**'
   workflow_call:
-  workflow_dispatch:
 
 jobs:
   sonar-scan:

--- a/.github/workflows/update-private-tickets.yml
+++ b/.github/workflows/update-private-tickets.yml
@@ -1,0 +1,123 @@
+name: Update Private Tickets to Public
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'The release version.'
+        required: true
+        type: string
+jobs:
+  update-private-tickets-to-public:
+    runs-on: runs-on=${{ github.run_id }}/runner=2cpu-linux-x64
+    
+    steps:
+      - uses: runs-on/action@v2
+      
+      - name: GET private tickets
+        id: get-tickets
+        env:
+          JIRA_URL: ${{ secrets.JIRA_URL }}
+          JIRA_USER: ${{ secrets.JIRA_USER }}
+          JIRA_API_KEY: ${{ secrets.JIRA_API_KEY }}
+          VERSION: ${{ github.event.inputs.version }}
+        run: |
+          JQL="project=SYM AND status=Closed AND fixVersion='$VERSION' AND level=Private AND component NOT IN (pro)" 
+          ENCODED_JQL=$(echo "$JQL" | jq -sRr @uri)
+          echo "Calling JIRA GET API with JQL: $JQL"
+
+          RESPONSE_STATUS=$(curl -s -w "%{response_code}" -o /tmp/jira_response.json -X GET \
+            --user '${{ secrets.JIRA_USER }}:${{ secrets.JIRA_API_KEY }}' \
+            --header 'Content-Type: application/json' \
+            --header 'Accept: application/json' \
+            "$JIRA_URL/rest/api/3/search/jql?jql=$ENCODED_JQL&fields=key&maxResults=500")
+          
+          RESPONSE_BODY=$(cat /tmp/jira_response.json)
+
+          if [ "$RESPONSE_STATUS" -ge 200 ] && [ "$RESPONSE_STATUS" -lt 300 ]; then
+            echo "Successfully retrieved private tickets from JIRA"
+          else
+            echo "HTTP ${RESPONSE_STATUS}: Failed to GET private issues from JIRA"
+            echo "$RESPONSE_BODY"
+            exit 1
+          fi
+          
+          PRIVATE_TICKETS=$(echo "$RESPONSE_BODY" | jq -r '.issues[].key' | tr '\n' ' ')
+          
+          if [ -z "$PRIVATE_TICKETS" ]; then
+            echo "No private tickets found for version '$VERSION'"
+            echo "private_tickets=" >> $GITHUB_OUTPUT
+          else
+            echo "Private tickets to update for version '$VERSION': $PRIVATE_TICKETS"
+            echo "private_tickets=$PRIVATE_TICKETS" >> $GITHUB_OUTPUT
+          fi
+          
+          # Save full response for summary
+          echo "$RESPONSE_BODY" > jira_response.json
+      
+      - name: Update private tickets to public
+        if: steps.get-tickets.outputs.private_tickets != null && steps.get-tickets.outputs.private_tickets != ''
+        env:
+          JIRA_URL: ${{ secrets.JIRA_URL }}
+          JIRA_USER: ${{ secrets.JIRA_USER }}
+          JIRA_API_KEY: ${{ secrets.JIRA_API_KEY }}
+          PRIVATE_TICKETS: ${{ steps.get-tickets.outputs.private_tickets }}
+          VERSION: ${{ github.event.inputs.version }}
+        run: |
+          SUCCESS_COUNT=0
+          FAILURE_COUNT=0
+          FAILED_TICKETS=""
+          
+          for TICKET in $PRIVATE_TICKETS; do
+            echo "Updating $TICKET to public..."
+            
+            RESPONSE_STATUS=$(curl -s -w "%{response_code}\n" -X PUT \
+              --header 'Content-Type: application/json' \
+              --header 'Accept: application/json' \
+              --user '${{ secrets.JIRA_USER }}:${{ secrets.JIRA_API_KEY }}' \
+              --data '{"fields":{"security":null}}' \
+              "$JIRA_URL/rest/api/3/issue/$TICKET")
+            
+            if [ "$RESPONSE_STATUS" -eq 204 ] || [ "$RESPONSE_STATUS" -eq 200 ]; then
+              echo "Successfully updated $TICKET"
+              SUCCESS_COUNT=$((SUCCESS_COUNT + 1))
+            else
+              echo "HTTP $RESPONSE_STATUS: Failed to update $TICKET"
+              FAILURE_COUNT=$((FAILURE_COUNT + 1))
+              FAILED_TICKETS="$FAILED_TICKETS $TICKET"
+            fi
+          done
+          
+          echo "SUCCESS_COUNT=$SUCCESS_COUNT" >> $GITHUB_ENV
+          echo "FAILURE_COUNT=$FAILURE_COUNT" >> $GITHUB_ENV
+          echo "FAILED_TICKETS=$FAILED_TICKETS" >> $GITHUB_ENV
+      
+      - name: Generate Summary
+        if: always()
+        run: |
+          echo "## JIRA Ticket Update Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Release Version:** ${{ github.event.inputs.version }}" >> $GITHUB_STEP_SUMMARY
+
+          PRIVATE_TICKETS="${{ steps.get-tickets.outputs.private_tickets }}"
+          PRIVATE_TICKET_COUNT=$(echo "$PRIVATE_TICKETS" | wc -w)
+
+          if [ "$PRIVATE_TICKET_COUNT" -eq 0 ]; then
+            echo "No private tickets found for version '${{ github.event.inputs.version }}'" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "**Total private tickets found:** $PRIVATE_TICKET_COUNT" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "**Successfully updated:** ${SUCCESS_COUNT:-0}" >> $GITHUB_STEP_SUMMARY
+            
+            if [ "${FAILURE_COUNT:-0}" -gt 0 ]; then
+              echo "**Failed to update:** $FAILURE_COUNT" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "**Failed tickets:**$FAILED_TICKETS" >> $GITHUB_STEP_SUMMARY
+            fi
+          fi
+      
+      - name: Fail when updates failed
+        if: env.FAILURE_COUNT != '' && env.FAILURE_COUNT != '0'
+        run: |
+          echo "Some tickets failed to update. Please check the tickets manually and update accordingly."
+          exit 1

--- a/symmetric-assemble/asciidoc.gradle
+++ b/symmetric-assemble/asciidoc.gradle
@@ -63,7 +63,8 @@ task generateReleaseNotes {
 				symAssembleDir + '/build/docJars/pro-' + latestPreviousVersion + "/symmetric-console-default.properties",
 				symAssembleDir + '/build/docJars/pro-' + latestPreviousVersion + "/console-schema.xml",
 				symAssembleDir + '/src/asciidoc/generated/release-notes.ad',
-				'https://status.symmetricds.org/api/get-issues.php?version=' + version.substring(0, version.lastIndexOf(".")) + '&secret=' + restAPISecret
+				version.substring(0, version.lastIndexOf(".")),
+				"https://jumpmind.atlassian.net"
 			]
 		}
 	}

--- a/symmetric-assemble/build.gradle
+++ b/symmetric-assemble/build.gradle
@@ -8,7 +8,6 @@ buildscript {
         classpath 'org.asciidoctor:asciidoctor-gradle-jvm:4.0.4'
 		classpath 'com.diffplug.spotless:spotless-plugin-gradle:7.0.3'
 		classpath 'com.bmuschko:gradle-docker-plugin:9.4.0'
-        classpath 'io.github.humblerookie:gradle-github-plugin:0.5.0'
         classpath 'org.jacoco:org.jacoco.ant:0.8.12'
     }
 }
@@ -23,7 +22,6 @@ apply plugin: 'java-library'
 apply plugin: 'idea'
 apply plugin: 'eclipse'
 apply plugin: 'com.bmuschko.docker-remote-api'
-apply plugin: 'io.github.humblerookie.gradle'
 apply plugin: 'jacoco'
 
 allprojects {
@@ -37,16 +35,6 @@ allprojects {
 
 task develop {
     dependsOn tasks.cleanEclipse, tasks.eclipse, tasks.cleanIdea, tasks.idea, tasks.compileTestJava
-}
-
-github {
-    owner = 'jumpmindinc'
-    repo = 'symmetric-ds'
-    token = githubToken
-    tagName = version
-    targetCommitish = scmBranch.substring(scmBranch.lastIndexOf('/')+1)
-    name = version
-    prerelease = false
 }
 
 idea {

--- a/symmetric-assemble/build.gradle
+++ b/symmetric-assemble/build.gradle
@@ -181,6 +181,8 @@ task generateJavadoc(type: Javadoc) {
 	}
 }
 
+def isLatest = project.hasProperty("latest") && project.property("latest") == "true"
+
 task publishJavadoc {
     dependsOn generateJavadoc
 	group = 'SymmetricDS'
@@ -222,14 +224,16 @@ task publishSymmetric {
                 include(name: 'symmetric-server-' + version + '.zip')
             }
         }
-        println "Setting latest file on SourceForge to symmetricds-$majorMinorVersion/symmetric-server-" + version + ".zip"
-        exec {
-            commandLine "curl"
-            args "-s", "-S", "-H", "Accept: application/json", "-X", "PUT",
-                "-d", "default=windows&default=mac&default=linux&default=bsd&default=solaris&default=others",
-                "-d", "api_key=$sourceforgeApiKey",
-                "https://sourceforge.net/projects/symmetricds/files/symmetricds/symmetricds-$majorMinorVersion/symmetric-server-" + version + ".zip"
-        }
+        if (isLatest) {    
+	    println "Setting latest file on SourceForge to symmetricds-$majorMinorVersion/symmetric-server-" + version + ".zip"
+            exec {
+                commandLine "curl"
+                args "-s", "-S", "-H", "Accept: application/json", "-X", "PUT",
+                    "-d", "default=windows&default=mac&default=linux&default=bsd&default=solaris&default=others",
+                    "-d", "api_key=$sourceforgeApiKey",
+                    "https://sourceforge.net/projects/symmetricds/files/symmetricds/symmetricds-$majorMinorVersion/symmetric-server-" + version + ".zip"
+            }     
+	}
     }
 }
 
@@ -267,17 +271,16 @@ task buildImage(type: com.bmuschko.gradle.docker.tasks.image.DockerBuildImage) {
     buildArgs = ["SERVER_ZIP":"symmetric-server-${version}.zip"]
 }
 
-task publishDockerLatest(type: com.bmuschko.gradle.docker.tasks.image.DockerPushImage) {
-    dependsOn buildImage
-    images.empty()
-    images.add("jumpmind/symmetricds:latest")
-}
-
 task publishDocker(type: com.bmuschko.gradle.docker.tasks.image.DockerPushImage) {
     dependsOn buildImage
     images.empty()
     images.add("jumpmind/symmetricds:${version}".toString())
     images.add("jumpmind/symmetricds:${majorMinorVersion}".toString())
+    
+    if (isLatest) {
+	images.add("jumpmind/symmetricds:latest")
+    }
+
     doLast {
         println "Pushing Docker Image to the jumpmind/symmetricds Repository"
     }

--- a/symmetric-assemble/common.gradle
+++ b/symmetric-assemble/common.gradle
@@ -238,6 +238,7 @@ subprojects { subproject ->
 		}
 		
 		signing {
+			useInMemoryPgpKeys(findProperty("signingKey"), findProperty("signingPassword"))
 			sign publishing.publications.symmetricLibrary
 		}
     }

--- a/symmetric-assemble/gradle.properties
+++ b/symmetric-assemble/gradle.properties
@@ -18,7 +18,5 @@ vaadinPluginVersion=24.9.3
 org.gradle.daemon=false
 org.gradle.jvmargs=-Xmx4096M
 latestPreviousVersion=3.16.6
-restAPISecret=?
 dockerUser=?
 dockerPassword=?
-githubToken=?

--- a/symmetric-db/build.gradle
+++ b/symmetric-db/build.gradle
@@ -9,6 +9,7 @@ apply from: symAssembleDir + '/common.gradle'
             exclude group: "commons-collections"
             exclude group: 'commons-logging'
         }
+        implementation("org.springframework:spring-web:$springVersion")
         
         compileOnly ("com.datastax.cassandra:cassandra-driver-core:3.11.5") {
             exclude group: 'org.slf4j'

--- a/symmetric-db/src/main/java/org/jumpmind/db/io/Issue.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/io/Issue.java
@@ -55,12 +55,13 @@ public class Issue {
 
     public int getPriorityAsInt() {
         if (priority != null) {
-            if (priority.equalsIgnoreCase("low"))
+            if (priority.equalsIgnoreCase("low")) {
                 return 1;
-            else if (priority.equalsIgnoreCase("medium"))
+            } else if (priority.equalsIgnoreCase("medium")) {
                 return 2;
-            else if (priority.equalsIgnoreCase("high"))
+            } else if (priority.equalsIgnoreCase("high")) {
                 return 3;
+            }
         }
         return -1;
     }
@@ -95,5 +96,18 @@ public class Issue {
 
     public void setTag(String tag) {
         this.tag = tag;
+    }
+
+    @Override
+    public String toString() {
+        return "Issue{" +
+                "id='" + id + '\'' +
+                ", version='" + version + '\'' +
+                ", project='" + project + '\'' +
+                ", priority='" + priority + '\'' +
+                ", summary='" + summary + '\'' +
+                ", category='" + category + '\'' +
+                ", tag='" + tag + '\'' +
+                '}';
     }
 }

--- a/symmetric-db/src/main/java/org/jumpmind/db/io/ReleaseNotesConstants.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/io/ReleaseNotesConstants.java
@@ -30,7 +30,7 @@ public class ReleaseNotesConstants {
     public static final String PRO_PROPERTIES_DIR = "../../symmetric-pro/symmetric-pro/src/main/resources/symmetric-console-default.properties";
     public static final String SCHEMA_DIR = "../symmetric-core/src/main/resources/symmetric-schema.xml";
     public static final String PRO_SCHEMA_DIR = "../../symmetric-pro/symmetric-pro/src/main/resources/console-schema.xml";
-    public static final String ISSUE_URL = "https://www.symmetricds.org/issues/view.php?id=%s[%s]";
+    public static final String ISSUE_URL = "https://jumpmind.atlassian.net/browse/%s[%s]";
     public static final String PROPERTIES_OLD_LOCATION = "build/";
     public static final String NOTES_HEADER = "= Release Notes";
     public static final String OVERVIEW_HEADER = "== Overview";
@@ -103,4 +103,6 @@ public class ReleaseNotesConstants {
     public static final String ISSUES_VERSION_HEADER_PRO = "*%s (Pro)*";
     public static final String ISSUES_VERSION_HEADER = "*%s*";
     public static final String ISSUES_FORMAT = "%s - %s";
+    public static final String SYMMETRIC_DS_PROJECT = "symmetric-ds";
+    public static final String SYMMETRIC_PRO_PROJECT = "symmetric-pro";
 }

--- a/symmetric-db/src/main/java/org/jumpmind/db/io/ReleaseNotesGenerator.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/io/ReleaseNotesGenerator.java
@@ -137,7 +137,7 @@ public class ReleaseNotesGenerator {
             if (conn.getResponseCode() != 200) {
                 throw new RuntimeException("Failed : HTTP Error code : " + conn.getResponseCode());
             }
-            return parsePageResult(readResponse(conn));
+            return parsePageResult(majorMinorVersion, readResponse(conn));
         } finally {
             if (conn != null) {
                 conn.disconnect();
@@ -180,9 +180,9 @@ public class ReleaseNotesGenerator {
     /**
      * Parses a page result containing issues and pagination info.
      */
-    private static PageResult parsePageResult(String json) {
+    private static PageResult parsePageResult(String majorMinorVersion, String json) {
         JsonObject rootObject = new Gson().fromJson(json, JsonObject.class);
-        List<Issue> issues = parseIssues(rootObject);
+        List<Issue> issues = parseIssues(majorMinorVersion, rootObject);
         String nextPageToken = null;
         JsonElement nextPageTokenElement = rootObject.get("nextPageToken");
         if (nextPageTokenElement != null && !nextPageTokenElement.isJsonNull()) {
@@ -194,7 +194,7 @@ public class ReleaseNotesGenerator {
     /**
      * Parses and extracts issues from the root JSON object.
      */
-    private static List<Issue> parseIssues(JsonObject root) {
+    private static List<Issue> parseIssues(String majorMinorVersion, JsonObject root) {
         List<Issue> issues = new ArrayList<>();
         JsonArray issuesArray = root.getAsJsonArray("issues");
         if (issuesArray == null || issuesArray.size() == 0) {
@@ -202,7 +202,7 @@ public class ReleaseNotesGenerator {
             return issues;
         }
         for (JsonElement issueElement : issuesArray) {
-            issues.add(parseIssue(issueElement.getAsJsonObject()));
+            issues.add(parseIssue(majorMinorVersion, issueElement.getAsJsonObject()));
         }
         return issues;
     }
@@ -210,7 +210,7 @@ public class ReleaseNotesGenerator {
     /**
      * Parses a single issue from JSON.
      */
-    private static Issue parseIssue(JsonObject issueObj) {
+    private static Issue parseIssue(String majorMinorVersion, JsonObject issueObj) {
         Issue issue = new Issue();
         issue.setId(getStringValue(issueObj, "key"));
         JsonObject fields = issueObj.getAsJsonObject("fields");
@@ -222,8 +222,18 @@ public class ReleaseNotesGenerator {
         issue.setPriority(getNestedStringValue(fields, "priority", "name"));
         JsonArray fixVersions = fields.getAsJsonArray("fixVersions");
         if (fixVersions != null && fixVersions.size() > 0) {
-            JsonObject firstVersion = fixVersions.get(0).getAsJsonObject();
-            issue.setVersion(getStringValue(firstVersion, "name"));
+            for (JsonElement issueFixVersionEle : fixVersions) {
+                JsonObject issueFixVersionObj = issueFixVersionEle.getAsJsonObject();
+                String issueFixVersion = getStringValue(issueFixVersionObj, "name");
+                String[] versionParts = issueFixVersion.split("\\.");
+                String fixVersionMajorMinor = versionParts.length >= 2
+                        ? versionParts[0] + "." + versionParts[1]
+                        : issueFixVersion;
+                if (majorMinorVersion.equals(fixVersionMajorMinor)) {
+                    issue.setVersion(issueFixVersion);
+                    break;
+                }
+            }
         }
         parseComponents(fields, issue);
         return issue;

--- a/symmetric-db/src/main/java/org/jumpmind/db/io/ReleaseNotesGenerator.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/io/ReleaseNotesGenerator.java
@@ -20,11 +20,14 @@
  */
 package org.jumpmind.db.io;
 
+import static org.jumpmind.db.io.ReleaseNotesConstants.*;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -55,8 +58,12 @@ import org.jumpmind.db.model.Reference;
 import org.jumpmind.db.model.Table;
 import org.jumpmind.properties.DefaultParameterParser;
 import org.jumpmind.properties.DefaultParameterParser.ParameterMetaData;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 
 public class ReleaseNotesGenerator {
     private static int features = 0;
@@ -77,11 +84,11 @@ public class ReleaseNotesGenerator {
         String issuesFile = directory + "issues.ad";
         String tablesFile = directory + "tables.ad";
         String parametersFile = directory + "parameters.ad";
-        if (args.length < 6) {
+        if (args.length < 7) {
             System.err.println("wrong usage");
             System.exit(-1);
         }
-        List<Issue> issues = buildIssuesFromRestAPI(args[5]);
+        List<Issue> issues = buildIssuesFromJira(args[6], args[5]);
         String properties = args[0];
         String schema = args[1];
         String proProperties = args[2];
@@ -103,58 +110,184 @@ public class ReleaseNotesGenerator {
         parametersSec.close();
     }
 
-    protected static List<Issue> buildIssuesFromRestAPI(String url) throws Exception {
-        URL apiURL = new URL(url);
-        HttpURLConnection conn = (HttpURLConnection) apiURL.openConnection();
-        if (conn.getResponseCode() != 200) {
-            throw new RuntimeException("Failed : HTTP Error code : " + conn.getResponseCode());
+    /**
+     * Builds a complete list of issues from a JIRA API that returns paginated results.
+     */
+    private static List<Issue> buildIssuesFromJira(String url, String majorMinorVersion) throws Exception {
+        List<Issue> issues = new ArrayList<>();
+        String nextPageToken = null;
+        do {
+            PageResult issuesPage = fetchIssuesPage(url, majorMinorVersion, nextPageToken);
+            issues.addAll(issuesPage.getIssues());
+            nextPageToken = issuesPage.getNextPageToken();
+            if (nextPageToken != null) {
+                System.out.println("INFO: There are more issues to fetch. Calling the API again for the next page of results.");
+            }
+        } while (nextPageToken != null);
+        return issues;
+    }
+
+    /**
+     * Fetches a single page of issues.
+     */
+    private static PageResult fetchIssuesPage(String url, String majorMinorVersion, String pageToken) throws Exception {
+        HttpURLConnection conn = null;
+        try {
+            conn = buildJiraConnection(url, majorMinorVersion, pageToken);
+            if (conn.getResponseCode() != 200) {
+                throw new RuntimeException("Failed : HTTP Error code : " + conn.getResponseCode());
+            }
+            return parsePageResult(readResponse(conn));
+        } finally {
+            if (conn != null) {
+                conn.disconnect();
+            }
         }
-        InputStreamReader in = new InputStreamReader(conn.getInputStream());
-        BufferedReader br = new BufferedReader(in);
-        StringBuilder buffer = new StringBuilder();
-        buffer.append("[");
-        String output;
-        while ((output = br.readLine()) != null) {
-            buffer.append(output);
+    }
+
+    private static HttpURLConnection buildJiraConnection(String url, String majorMinorVersion, String nextPageToken)
+            throws IOException {
+        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUriString(url)
+                .path("/rest/api/3/search/jql")
+                .queryParam("jql", "project=SYM AND status = Closed AND fixVersion ~ \"" + majorMinorVersion + ".*\"")
+                .queryParam("fields", "key,issuetype,priority,summary,fixVersions,components")
+                .queryParam("maxResults", 100);
+        if (nextPageToken != null) {
+            uriBuilder.queryParam("nextPageToken", nextPageToken);
         }
-        buffer.append("]");
-        String json = buffer.toString();
-        json = json.replaceAll("\\}\\{", "},{");
-        conn.disconnect();
-        List<Issue> issues = new ArrayList<Issue>();
-        @SuppressWarnings("unchecked")
-        List<Map<String, String>> root = new Gson().fromJson(json, List.class);
-        for (Map<String, String> map : root) {
-            Issue issue = new Issue();
-            issue.setId(map.get("id"));
-            issue.setCategory(map.get("category"));
-            issue.setProject(map.get("project"));
-            issue.setPriority(map.get("priority"));
-            issue.setSummary(map.get("summary"));
-            issue.setTag(map.get("tag"));
-            issue.setVersion(map.get("version"));
-            issues.add(issue);
+        URL jiraApi = new URL(uriBuilder.build().toUriString());
+        HttpURLConnection connection = (HttpURLConnection) jiraApi.openConnection();
+        connection.setRequestProperty("Accept", "application/json");
+        connection.setRequestProperty("Content-Type", "application/json");
+        return connection;
+    }
+
+    /**
+     * Reads the successful response from the connection.
+     */
+    private static String readResponse(HttpURLConnection conn) throws Exception {
+        try (BufferedReader br = new BufferedReader(
+                new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8))) {
+            StringBuilder buffer = new StringBuilder();
+            String output;
+            while ((output = br.readLine()) != null) {
+                buffer.append(output);
+            }
+            return buffer.toString();
+        }
+    }
+
+    /**
+     * Parses a page result containing issues and pagination info.
+     */
+    private static PageResult parsePageResult(String json) {
+        JsonObject rootObject = new Gson().fromJson(json, JsonObject.class);
+        List<Issue> issues = parseIssues(rootObject);
+        String nextPageToken = null;
+        JsonElement nextPageTokenElement = rootObject.get("nextPageToken");
+        if (nextPageTokenElement != null && !nextPageTokenElement.isJsonNull()) {
+            nextPageToken = nextPageTokenElement.getAsString();
+        }
+        return new PageResult(issues, nextPageToken);
+    }
+
+    /**
+     * Parses and extracts issues from the root JSON object.
+     */
+    private static List<Issue> parseIssues(JsonObject root) {
+        List<Issue> issues = new ArrayList<>();
+        JsonArray issuesArray = root.getAsJsonArray("issues");
+        if (issuesArray == null || issuesArray.size() == 0) {
+            System.out.println("WARNING: No issues found in response");
+            return issues;
+        }
+        for (JsonElement issueElement : issuesArray) {
+            issues.add(parseIssue(issueElement.getAsJsonObject()));
         }
         return issues;
     }
 
+    /**
+     * Parses a single issue from JSON.
+     */
+    private static Issue parseIssue(JsonObject issueObj) {
+        Issue issue = new Issue();
+        issue.setId(getStringValue(issueObj, "key"));
+        JsonObject fields = issueObj.getAsJsonObject("fields");
+        if (fields == null) {
+            throw new IllegalArgumentException("Issue is missing JSON fields object.");
+        }
+        issue.setSummary(getStringValue(fields, "summary"));
+        issue.setCategory(getNestedStringValue(fields, "issuetype", "name"));
+        issue.setPriority(getNestedStringValue(fields, "priority", "name"));
+        JsonArray fixVersions = fields.getAsJsonArray("fixVersions");
+        if (fixVersions != null && fixVersions.size() > 0) {
+            JsonObject firstVersion = fixVersions.get(0).getAsJsonObject();
+            issue.setVersion(getStringValue(firstVersion, "name"));
+        }
+        parseComponents(fields, issue);
+        return issue;
+    }
+
+    /**
+     * Parses components from JsonObject and sets the project and tag on the issue.
+     */
+    private static void parseComponents(JsonObject fields, Issue issue) {
+        JsonArray components = fields.getAsJsonArray("components");
+        for (JsonElement componentElement : components) {
+            JsonObject componentObj = componentElement.getAsJsonObject();
+            String componentName = getStringValue(componentObj, "name");
+            if (componentName == null) {
+                continue;
+            } else if ("pro".equalsIgnoreCase(componentName)) {
+                issue.setProject(SYMMETRIC_PRO_PROJECT);
+            } else if (Arrays.asList(tags).contains(componentName)) {
+                issue.setTag(componentName);
+            }
+        }
+        if (issue.getProject() == null) {
+            issue.setProject(SYMMETRIC_DS_PROJECT);
+        }
+    }
+
+    /**
+     * Safely extracts a nested string value from a JsonObject.
+     */
+    private static String getNestedStringValue(JsonObject obj, String parentKey, String childKey) {
+        if (obj == null || !obj.has(parentKey) || obj.get(parentKey).isJsonNull()) {
+            return null;
+        }
+        JsonObject parent = obj.getAsJsonObject(parentKey);
+        return getStringValue(parent, childKey);
+    }
+
+    /**
+     * Safely extracts a string value from a JsonObject.
+     */
+    private static String getStringValue(JsonObject obj, String key) {
+        if (obj == null || !obj.has(key) || obj.get(key).isJsonNull()) {
+            return null;
+        }
+        return obj.get(key).getAsString();
+    }
+
     protected static void writeFinalNotes(PrintWriter writer, String[] sections) {
-        writer.println(ReleaseNotesConstants.NOTES_HEADER);
+        writer.println(NOTES_HEADER);
         writer.println();
-        writer.println(ReleaseNotesConstants.OVERVIEW_HEADER);
+        writer.println(OVERVIEW_HEADER);
         writer.println();
-        writer.println(ReleaseNotesConstants.PRO_TOKEN_START);
-        writer.println(String.format(ReleaseNotesConstants.OVERVIEW_PRO_DESC, features, improvements, fixes));
-        writer.println(ReleaseNotesConstants.PRO_TOKEN_END);
-        writer.println(ReleaseNotesConstants.OS_TOKEN_START);
-        writer.println(String.format(ReleaseNotesConstants.OVERVIEW_DESC, osFeatures, osImprovements, osFixes));
-        writer.println(ReleaseNotesConstants.OS_TOKEN_END);
+        writer.println(PRO_TOKEN_START);
+        writer.println(String.format(OVERVIEW_PRO_DESC, features, improvements, fixes));
+        writer.println(PRO_TOKEN_END);
+        writer.println(OS_TOKEN_START);
+        writer.println(String.format(OVERVIEW_DESC, osFeatures, osImprovements, osFixes));
+        writer.println(OS_TOKEN_END);
         writer.println();
         for (String section : sections) {
             if (Arrays.asList(writtenSections).contains(section)) {
-                writer.println(String.format(ReleaseNotesConstants.INCLUDE_FORMAT_WRITTEN, "{includedir}", section));
+                writer.println(String.format(INCLUDE_FORMAT_WRITTEN, "{includedir}", section));
             } else {
-                writer.println(String.format(ReleaseNotesConstants.INCLUDE_FORMAT_GENERATED, "{includedir}/generated", section));
+                writer.println(String.format(INCLUDE_FORMAT_GENERATED, "{includedir}/generated", section));
             }
         }
     }
@@ -163,13 +296,13 @@ public class ReleaseNotesGenerator {
             throws Exception {
         DefaultParameterParser parser = new DefaultParameterParser(new FileInputStream(propertiesLoc));
         Map<String, ParameterMetaData> previousParamMap = parser.parse();
-        parser = new DefaultParameterParser(new FileInputStream(ReleaseNotesConstants.PROPERTIES_DIR));
+        parser = new DefaultParameterParser(new FileInputStream(PROPERTIES_DIR));
         Map<String, ParameterMetaData> currentParamMap = parser.parse();
         parser = new DefaultParameterParser(new FileInputStream(proPropertiesLoc));
         Map<String, ParameterMetaData> previousProParamMap = parser.parse();
         Map<String, ParameterMetaData> currentProParamMap = new HashMap<String, ParameterMetaData>();
         try {
-            parser = new DefaultParameterParser(new FileInputStream(ReleaseNotesConstants.PRO_PROPERTIES_DIR));
+            parser = new DefaultParameterParser(new FileInputStream(PRO_PROPERTIES_DIR));
             currentProParamMap = parser.parse();
         } catch (FileNotFoundException e) {
         }
@@ -212,46 +345,46 @@ public class ReleaseNotesGenerator {
             if (currentProParams.containsAll(inCurrentNotPrevious)
                     && currentProParams.containsAll(modifiedSincePrevious)
                     && previousProParams.containsAll(inPreviousNotCurrent)) {
-                writer.println(ReleaseNotesConstants.PRO_TOKEN_START);
+                writer.println(PRO_TOKEN_START);
             }
-            writer.println(ReleaseNotesConstants.PARAMETER_SEC_HEADER);
-            writer.println(ReleaseNotesConstants.PARAMETER_SEC_DESC);
+            writer.println(PARAMETER_SEC_HEADER);
+            writer.println(PARAMETER_SEC_DESC);
             writer.println();
             if (currentProParams.containsAll(inCurrentNotPrevious)
                     && currentProParams.containsAll(modifiedSincePrevious)
                     && previousProParams.containsAll(inPreviousNotCurrent)) {
-                writer.println(ReleaseNotesConstants.PRO_TOKEN_END);
+                writer.println(PRO_TOKEN_END);
             }
         }
         if (inCurrentNotPrevious.size() > 0) {
             if (currentProParams.containsAll(inCurrentNotPrevious)) {
-                writer.println(ReleaseNotesConstants.PRO_TOKEN_START);
+                writer.println(PRO_TOKEN_START);
             }
-            writer.println(ReleaseNotesConstants.PARAMETER_NEW_HEADER);
+            writer.println(PARAMETER_NEW_HEADER);
             writer.println();
             if (currentProParams.containsAll(inCurrentNotPrevious)) {
-                writer.println(ReleaseNotesConstants.PRO_TOKEN_END);
+                writer.println(PRO_TOKEN_END);
             }
             List<String> parameters = new ArrayList<String>(inCurrentNotPrevious);
             parameters.sort(new StringComparator());
             for (String parameter : parameters) {
                 ParameterMetaData metaData = currentProParamMap.get(parameter);
                 if (metaData != null) {
-                    writer.println(ReleaseNotesConstants.PRO_TOKEN_START);
-                    writer.println(String.format(ReleaseNotesConstants.PARAMETER_PRO_FORMAT, parameter));
+                    writer.println(PRO_TOKEN_START);
+                    writer.println(String.format(PARAMETER_PRO_FORMAT, parameter));
                     writer.println();
                     writer.println(metaData.getDescription() != null
-                            ? String.format(ReleaseNotesConstants.PARAMETER_DESC_FORMAT,
+                            ? String.format(PARAMETER_DESC_FORMAT,
                                     metaData.getDescription().trim(),
                                     metaData.getDefaultValue())
                             : "");
-                    writer.println(ReleaseNotesConstants.PRO_TOKEN_END);
+                    writer.println(PRO_TOKEN_END);
                 } else {
                     metaData = currentParamMap.get(parameter);
-                    writer.println(String.format(ReleaseNotesConstants.PARAMETER_FORMAT, parameter));
+                    writer.println(String.format(PARAMETER_FORMAT, parameter));
                     writer.println();
                     writer.println(metaData.getDescription() != null
-                            ? String.format(ReleaseNotesConstants.PARAMETER_DESC_FORMAT,
+                            ? String.format(PARAMETER_DESC_FORMAT,
                                     metaData.getDescription().trim(),
                                     metaData.getDefaultValue())
                             : "");
@@ -262,35 +395,35 @@ public class ReleaseNotesGenerator {
         if (modifiedSincePrevious.size() > 0 || inPreviousNotCurrent.size() > 0) {
             if (currentProParams.containsAll(modifiedSincePrevious)
                     && previousProParams.containsAll(inPreviousNotCurrent)) {
-                writer.println(ReleaseNotesConstants.PRO_TOKEN_START);
+                writer.println(PRO_TOKEN_START);
             }
-            writer.println(ReleaseNotesConstants.PARAMETER_MOD_HEADER);
+            writer.println(PARAMETER_MOD_HEADER);
             writer.println();
             if (currentProParams.containsAll(modifiedSincePrevious)
                     && previousProParams.containsAll(inPreviousNotCurrent)) {
-                writer.println(ReleaseNotesConstants.PRO_TOKEN_END);
+                writer.println(PRO_TOKEN_END);
             }
             List<String> parameters = new ArrayList<String>(modifiedSincePrevious);
             parameters.sort(new StringComparator());
             for (String parameter : parameters) {
                 ParameterMetaData metaData = currentProParamMap.get(parameter);
                 if (metaData != null) {
-                    writer.println(ReleaseNotesConstants.PRO_TOKEN_START);
-                    writer.println(String.format(ReleaseNotesConstants.PARAMETER_PRO_FORMAT, parameter));
+                    writer.println(PRO_TOKEN_START);
+                    writer.println(String.format(PARAMETER_PRO_FORMAT, parameter));
                     writer.println();
                     writer.println(metaData.getDescription() != null
-                            ? String.format(ReleaseNotesConstants.PARAMETER_DESC_MOD_FORMAT,
+                            ? String.format(PARAMETER_DESC_MOD_FORMAT,
                                     metaData.getDescription().trim(),
                                     previousProParamMap.get(parameter).getDefaultValue(),
                                     metaData.getDefaultValue())
                             : "");
-                    writer.println(ReleaseNotesConstants.PRO_TOKEN_END);
+                    writer.println(PRO_TOKEN_END);
                 } else {
                     metaData = currentParamMap.get(parameter);
-                    writer.println(String.format(ReleaseNotesConstants.PARAMETER_FORMAT, parameter));
+                    writer.println(String.format(PARAMETER_FORMAT, parameter));
                     writer.println();
                     writer.println(metaData.getDescription() != null
-                            ? String.format(ReleaseNotesConstants.PARAMETER_DESC_MOD_FORMAT,
+                            ? String.format(PARAMETER_DESC_MOD_FORMAT,
                                     metaData.getDescription().trim(),
                                     previousParamMap.get(parameter).getDefaultValue(),
                                     metaData.getDefaultValue())
@@ -302,15 +435,15 @@ public class ReleaseNotesGenerator {
             parameters.sort(new StringComparator());
             for (String parameter : inPreviousNotCurrent) {
                 if (previousProParamMap.containsKey(parameter)) {
-                    writer.println(ReleaseNotesConstants.PRO_TOKEN_START);
-                    writer.println(String.format(ReleaseNotesConstants.PARAMETER_PRO_FORMAT, parameter));
+                    writer.println(PRO_TOKEN_START);
+                    writer.println(String.format(PARAMETER_PRO_FORMAT, parameter));
                     writer.println();
-                    writer.println(ReleaseNotesConstants.PARAMETER_DESC_REMOVED);
-                    writer.println(ReleaseNotesConstants.PRO_TOKEN_END);
+                    writer.println(PARAMETER_DESC_REMOVED);
+                    writer.println(PRO_TOKEN_END);
                 } else {
-                    writer.println(String.format(ReleaseNotesConstants.PARAMETER_FORMAT, parameter));
+                    writer.println(String.format(PARAMETER_FORMAT, parameter));
                     writer.println();
-                    writer.println(ReleaseNotesConstants.PARAMETER_DESC_REMOVED);
+                    writer.println(PARAMETER_DESC_REMOVED);
                 }
                 writer.println();
             }
@@ -324,14 +457,14 @@ public class ReleaseNotesGenerator {
 
     protected static void writeTablesSection(PrintWriter writer, String schemaLoc, String proSchemaLoc) {
         Database dbOld = DatabaseXmlUtil.read(new File(schemaLoc));
-        Database dbCurrent = DatabaseXmlUtil.read(new File(ReleaseNotesConstants.SCHEMA_DIR));
+        Database dbCurrent = DatabaseXmlUtil.read(new File(SCHEMA_DIR));
         Database dbProOld = new Database();
         File proSchemaFile = new File(proSchemaLoc);
         if (proSchemaFile.canRead()) {
             dbProOld = DatabaseXmlUtil.read(proSchemaFile);
         }
         Database dbProCurrent = new Database();
-        File dbProCurrentFile = new File(ReleaseNotesConstants.PRO_SCHEMA_DIR);
+        File dbProCurrentFile = new File(PRO_SCHEMA_DIR);
         if (dbProCurrentFile.canRead()) {
             dbProCurrent = DatabaseXmlUtil.read(dbProCurrentFile);
         }
@@ -376,15 +509,15 @@ public class ReleaseNotesGenerator {
                     for (ForeignKey foreignKey : allFKeys) {
                         if (foreignKeys.contains(foreignKey) && !oldForeignKeys.contains(foreignKey)) {
                             changeList.add(
-                                    String.format(ReleaseNotesConstants.TABLES_ADD_FKEY_FORMAT, foreignKey.getName(),
-                                            String.join(ReleaseNotesConstants.VALUE_SEPARATOR,
+                                    String.format(TABLES_ADD_FKEY_FORMAT, foreignKey.getName(),
+                                            String.join(VALUE_SEPARATOR,
                                                     Arrays.asList(foreignKey.getReferences()).stream()
                                                             .map(e -> e.getLocalColumnName())
                                                             .collect(Collectors.toList()))));
                         } else if (!foreignKeys.contains(foreignKey) && oldForeignKeys.contains(foreignKey)) {
                             changeList.add(
-                                    String.format(ReleaseNotesConstants.TABLES_DEL_FKEY_FORMAT, foreignKey.getName(),
-                                            String.join(ReleaseNotesConstants.VALUE_SEPARATOR,
+                                    String.format(TABLES_DEL_FKEY_FORMAT, foreignKey.getName(),
+                                            String.join(VALUE_SEPARATOR,
                                                     Arrays.asList(foreignKey.getReferences()).stream()
                                                             .map(e -> e.getLocalColumnName())
                                                             .collect(Collectors.toList()))));
@@ -399,18 +532,18 @@ public class ReleaseNotesGenerator {
                             Set<Reference> newReferencesSet = new HashSet<>(Arrays.asList(newFKey.getReferences()));
                             if (oldFKey.isAutoIndexPresent() != newFKey.isAutoIndexPresent()) {
                                 changeList.add(String.format(
-                                        ReleaseNotesConstants.MODIFIED_CONSTANT_FKEY + " "
-                                                + ReleaseNotesConstants.TABLES_MOD_COLUMN_FORMAT,
-                                        foreignKey.getName(), ReleaseNotesConstants.MODIFIED_CONSTANT_IS_AUTOIDX,
+                                        MODIFIED_CONSTANT_FKEY + " "
+                                                + TABLES_MOD_COLUMN_FORMAT,
+                                        foreignKey.getName(), MODIFIED_CONSTANT_IS_AUTOIDX,
                                         oldFKey.isAutoIndexPresent(), newFKey.isAutoIndexPresent()));
                             }
                             if (!oldReferencesSet.equals(newReferencesSet)) {
-                                changeList.add(String.format(ReleaseNotesConstants.TABLES_MOD_FKEY_FORMAT,
+                                changeList.add(String.format(TABLES_MOD_FKEY_FORMAT,
                                         foreignKey.getName(),
-                                        String.join(ReleaseNotesConstants.VALUE_SEPARATOR,
+                                        String.join(VALUE_SEPARATOR,
                                                 oldReferencesSet.stream().map(e -> e.getForeignColumnName())
                                                         .collect(Collectors.toList())),
-                                        String.join(ReleaseNotesConstants.VALUE_SEPARATOR, newReferencesSet.stream()
+                                        String.join(VALUE_SEPARATOR, newReferencesSet.stream()
                                                 .map(e -> e.getForeignColumnName()).collect(Collectors.toList()))));
                             }
                         }
@@ -422,33 +555,33 @@ public class ReleaseNotesGenerator {
                     boolean removedAny = false;
                     for (String primaryKey : allPKeys) {
                         if (primaryKeys.contains(primaryKey) && !oldPrimaryKeys.contains(primaryKey)) {
-                            added.append(primaryKey + ReleaseNotesConstants.VALUE_SEPARATOR);
+                            added.append(primaryKey + VALUE_SEPARATOR);
                             addedAny = true;
                         } else if (!primaryKeys.contains(primaryKey) && oldPrimaryKeys.contains(primaryKey)) {
-                            removed.append(primaryKey + ReleaseNotesConstants.VALUE_SEPARATOR);
+                            removed.append(primaryKey + VALUE_SEPARATOR);
                             removedAny = true;
                         }
                     }
                     if (addedAny) {
-                        added.delete(added.length() - ReleaseNotesConstants.VALUE_SEPARATOR.length(), added.length());
-                        changeList.add(String.format(ReleaseNotesConstants.TABLES_ADD_PKEY_FORMAT, added.toString()));
+                        added.delete(added.length() - VALUE_SEPARATOR.length(), added.length());
+                        changeList.add(String.format(TABLES_ADD_PKEY_FORMAT, added.toString()));
                     }
                     if (removedAny) {
-                        removed.delete(removed.length() - ReleaseNotesConstants.VALUE_SEPARATOR.length(),
+                        removed.delete(removed.length() - VALUE_SEPARATOR.length(),
                                 removed.length());
-                        changeList.add(String.format(ReleaseNotesConstants.TABLES_DEL_PKEY_FORMAT, removed.toString()));
+                        changeList.add(String.format(TABLES_DEL_PKEY_FORMAT, removed.toString()));
                     }
                     // Indices
                     for (IIndex index : allIndices) {
                         if (indices.stream().anyMatch(e -> e.getName().equals(index.getName()))
                                 && !oldIndices.stream().anyMatch(e -> e.getName().equals(index.getName()))) {
-                            changeList.add(String.format(ReleaseNotesConstants.TABLES_ADD_INDEX_FORMAT, index.getName(),
-                                    String.join(ReleaseNotesConstants.VALUE_SEPARATOR, Arrays.asList(index.getColumns())
+                            changeList.add(String.format(TABLES_ADD_INDEX_FORMAT, index.getName(),
+                                    String.join(VALUE_SEPARATOR, Arrays.asList(index.getColumns())
                                             .stream().map(e -> e.getName()).collect(Collectors.toList()))));
                         } else if (!indices.stream().anyMatch(e -> e.getName().equals(index.getName()))
                                 && oldIndices.stream().anyMatch(e -> e.getName().equals(index.getName()))) {
-                            changeList.add(String.format(ReleaseNotesConstants.TABLES_DEL_INDEX_FORMAT, index.getName(),
-                                    String.join(ReleaseNotesConstants.VALUE_SEPARATOR, Arrays.asList(index.getColumns())
+                            changeList.add(String.format(TABLES_DEL_INDEX_FORMAT, index.getName(),
+                                    String.join(VALUE_SEPARATOR, Arrays.asList(index.getColumns())
                                             .stream().map(e -> e.getName()).collect(Collectors.toList()))));
                         } else {
                             IIndex oldIndex = oldIndices.stream()
@@ -460,18 +593,18 @@ public class ReleaseNotesGenerator {
                             Set<IndexColumn> oldReferencesSet = new HashSet<>(Arrays.asList(oldIndex.getColumns()));
                             Set<IndexColumn> newReferencesSet = new HashSet<>(Arrays.asList(newIndex.getColumns()));
                             if (oldIndex.isUnique() != newIndex.isUnique()) {
-                                changeList.add(ReleaseNotesConstants.MODIFIED_CONSTANT_INDEX + " "
-                                        + String.format(ReleaseNotesConstants.TABLES_MOD_COLUMN_FORMAT, index.getName(),
-                                                ReleaseNotesConstants.MODIFIED_CONSTANT_IS_UNQ, oldIndex.isUnique(),
+                                changeList.add(MODIFIED_CONSTANT_INDEX + " "
+                                        + String.format(TABLES_MOD_COLUMN_FORMAT, index.getName(),
+                                                MODIFIED_CONSTANT_IS_UNQ, oldIndex.isUnique(),
                                                 newIndex.isUnique()));
                             }
                             if (!oldReferencesSet.equals(newReferencesSet)) {
                                 changeList.add(
-                                        String.format(ReleaseNotesConstants.TABLES_MOD_INDEX_FORMAT, index.getName(),
-                                                String.join(ReleaseNotesConstants.VALUE_SEPARATOR,
+                                        String.format(TABLES_MOD_INDEX_FORMAT, index.getName(),
+                                                String.join(VALUE_SEPARATOR,
                                                         oldReferencesSet.stream().map(e -> e.getName())
                                                                 .collect(Collectors.toList())),
-                                                String.join(ReleaseNotesConstants.VALUE_SEPARATOR, newReferencesSet
+                                                String.join(VALUE_SEPARATOR, newReferencesSet
                                                         .stream().map(e -> e.getName()).collect(Collectors.toList()))));
                             }
                         }
@@ -488,75 +621,77 @@ public class ReleaseNotesGenerator {
                                 mapList.add(column);
                             }
                         }
-                        if (mapList.size() > 0)
+                        if (mapList.size() > 0) {
                             tableColMap.put(table, mapList);
+                        }
                     }
                     for (Column column : ColsNew) {
                         try {
                             Column oldColumn = ColsOld.stream().filter(o -> o.getName().equals(column.getName()))
                                     .findFirst().get();
                             if (oldColumn.isTimestampWithTimezone() != column.isTimestampWithTimezone()) {
-                                changeList.add(String.format(ReleaseNotesConstants.TABLES_MOD_COLUMN_FORMAT,
-                                        column.getName(), ReleaseNotesConstants.MODIFIED_CONSTANT_IS_TIMEZONE,
+                                changeList.add(String.format(TABLES_MOD_COLUMN_FORMAT,
+                                        column.getName(), MODIFIED_CONSTANT_IS_TIMEZONE,
                                         oldColumn.isTimestampWithTimezone(), column.isTimestampWithTimezone()));
                             }
                             if (oldColumn.isDistributionKey() != column.isDistributionKey()) {
-                                changeList.add(String.format(ReleaseNotesConstants.TABLES_MOD_COLUMN_FORMAT,
-                                        column.getName(), ReleaseNotesConstants.MODIFIED_CONSTANT_IS_DIST,
+                                changeList.add(String.format(TABLES_MOD_COLUMN_FORMAT,
+                                        column.getName(), MODIFIED_CONSTANT_IS_DIST,
                                         oldColumn.isDistributionKey(), column.isDistributionKey()));
                             }
                             if (oldColumn.isAutoIncrement() != column.isAutoIncrement()) {
-                                changeList.add(String.format(ReleaseNotesConstants.TABLES_MOD_COLUMN_FORMAT,
-                                        column.getName(), ReleaseNotesConstants.MODIFIED_CONSTANT_IS_AUTOINC,
+                                changeList.add(String.format(TABLES_MOD_COLUMN_FORMAT,
+                                        column.getName(), MODIFIED_CONSTANT_IS_AUTOINC,
                                         oldColumn.isAutoIncrement(), column.isAutoIncrement()));
                             }
                             if (oldColumn.isUnique() != column.isUnique()) {
-                                changeList.add(String.format(ReleaseNotesConstants.TABLES_MOD_COLUMN_FORMAT,
-                                        column.getName(), ReleaseNotesConstants.MODIFIED_CONSTANT_IS_UNQ,
+                                changeList.add(String.format(TABLES_MOD_COLUMN_FORMAT,
+                                        column.getName(), MODIFIED_CONSTANT_IS_UNQ,
                                         oldColumn.isUnique(), column.isUnique()));
                             }
                             if (oldColumn.getPrecisionRadix() != column.getPrecisionRadix()) {
-                                changeList.add(String.format(ReleaseNotesConstants.TABLES_MOD_COLUMN_FORMAT,
-                                        column.getName(), ReleaseNotesConstants.MODIFIED_CONSTANT_RADIX,
+                                changeList.add(String.format(TABLES_MOD_COLUMN_FORMAT,
+                                        column.getName(), MODIFIED_CONSTANT_RADIX,
                                         oldColumn.getPrecisionRadix(), column.getPrecisionRadix()));
                             }
                             if (isChanged(oldColumn.getDefaultValue(), column.getDefaultValue())) {
-                                changeList.add(String.format(ReleaseNotesConstants.TABLES_MOD_COLUMN_FORMAT,
-                                        column.getName(), ReleaseNotesConstants.MODIFIED_CONSTANT_DEF_VAL,
-                                        oldColumn.getDefaultValue() == null ? ReleaseNotesConstants.NULL
+                                changeList.add(String.format(TABLES_MOD_COLUMN_FORMAT,
+                                        column.getName(), MODIFIED_CONSTANT_DEF_VAL,
+                                        oldColumn.getDefaultValue() == null ? NULL
                                                 : (isVarcharOrChar(column.getMappedTypeCode())
                                                         ? "\"" + column.getDefaultValue() + "\""
                                                         : column.getDefaultValue()),
-                                        column.getDefaultValue() == null ? ReleaseNotesConstants.NULL
+                                        column.getDefaultValue() == null ? NULL
                                                 : (isVarcharOrChar(column.getMappedTypeCode())
                                                         ? "\"" + column.getDefaultValue() + "\""
                                                         : column.getDefaultValue())));
                             }
                             if (isChanged(oldColumn.getMappedType(), column.getMappedType())) {
-                                changeList.add(String.format(ReleaseNotesConstants.TABLES_MOD_COLUMN_FORMAT,
-                                        column.getName(), ReleaseNotesConstants.MODIFIED_CONSTANT_TYPE,
-                                        oldColumn.getMappedType() == null ? ReleaseNotesConstants.NULL
+                                changeList.add(String.format(TABLES_MOD_COLUMN_FORMAT,
+                                        column.getName(), MODIFIED_CONSTANT_TYPE,
+                                        oldColumn.getMappedType() == null ? NULL
                                                 : oldColumn.getMappedType(),
-                                        column.getMappedType() == null ? ReleaseNotesConstants.NULL
+                                        column.getMappedType() == null ? NULL
                                                 : column.getMappedType()));
                             }
                             if (isChanged(oldColumn.getSize(), column.getSize())) {
-                                changeList.add(String.format(ReleaseNotesConstants.TABLES_MOD_COLUMN_FORMAT,
-                                        column.getName(), ReleaseNotesConstants.MODIFIED_CONSTANT_SIZE,
-                                        oldColumn.getSize() == null ? ReleaseNotesConstants.NULL : oldColumn.getSize(),
-                                        column.getSize() == null ? ReleaseNotesConstants.NULL : column.getSize()));
+                                changeList.add(String.format(TABLES_MOD_COLUMN_FORMAT,
+                                        column.getName(), MODIFIED_CONSTANT_SIZE,
+                                        oldColumn.getSize() == null ? NULL : oldColumn.getSize(),
+                                        column.getSize() == null ? NULL : column.getSize()));
                             }
                             if (oldColumn.isRequired() != column.isRequired()) {
-                                changeList.add(String.format(ReleaseNotesConstants.TABLES_MOD_COLUMN_FORMAT,
-                                        column.getName(), ReleaseNotesConstants.MODIFIED_CONSTANT_IS_REQ,
+                                changeList.add(String.format(TABLES_MOD_COLUMN_FORMAT,
+                                        column.getName(), MODIFIED_CONSTANT_IS_REQ,
                                         oldColumn.isRequired(), column.isRequired()));
                             }
                         } catch (NoSuchElementException e) {
                             System.out.println("No match found for column \"" + column.getName() + "\", assuming new");
                         }
                     }
-                    if (changeList.size() > 0)
+                    if (changeList.size() > 0) {
                         tableChangeMap.put(table, changeList);
+                    }
                 }
             }
             if (isNewTable) {
@@ -566,86 +701,86 @@ public class ReleaseNotesGenerator {
         if (newTables.size() > 0 || tableColMap.size() > 0 || tableChangeMap.size() > 0) {
             if (tablesProCurrent.containsAll(newTables) && tablesProCurrent.containsAll(tableColMap.keySet())
                     && tablesProCurrent.containsAll(tableChangeMap.keySet())) {
-                writer.println(ReleaseNotesConstants.PRO_TOKEN_START);
+                writer.println(PRO_TOKEN_START);
             }
-            writer.println(ReleaseNotesConstants.TABLES_SEC_HEADER);
-            writer.println(ReleaseNotesConstants.TABLES_SEC_DESC);
+            writer.println(TABLES_SEC_HEADER);
+            writer.println(TABLES_SEC_DESC);
             writer.println();
             if (tablesProCurrent.containsAll(newTables) && tablesProCurrent.containsAll(tableColMap.keySet())
                     && tablesProCurrent.containsAll(tableChangeMap.keySet())) {
-                writer.println(ReleaseNotesConstants.PRO_TOKEN_END);
+                writer.println(PRO_TOKEN_END);
             }
             if (newTables.size() > 0) {
                 if (tablesProCurrent.containsAll(newTables)) {
-                    writer.println(ReleaseNotesConstants.PRO_TOKEN_START);
+                    writer.println(PRO_TOKEN_START);
                 }
-                writer.println(ReleaseNotesConstants.TABLES_NEW_HEADER);
+                writer.println(TABLES_NEW_HEADER);
                 writer.println();
-                writer.println(ReleaseNotesConstants.TABLES_TABLE_HEADER);
+                writer.println(TABLES_TABLE_HEADER);
                 writer.println();
                 for (Table table : newTables) {
                     String desc = table.getDescription();
                     String name = table.getNameLowerCase();
                     if (tablesProCurrent.contains(table)) {
-                        writer.println(ReleaseNotesConstants.PRO_TOKEN_START);
-                        writer.println(String.format(ReleaseNotesConstants.TABLES_TABLE_ELEMENT_PRO, name, desc));
-                        writer.println(ReleaseNotesConstants.PRO_TOKEN_END);
+                        writer.println(PRO_TOKEN_START);
+                        writer.println(String.format(TABLES_TABLE_ELEMENT_PRO, name, desc));
+                        writer.println(PRO_TOKEN_END);
                         writer.println();
                     } else {
-                        writer.println(String.format(ReleaseNotesConstants.TABLES_TABLE_ELEMENT, name, desc));
+                        writer.println(String.format(TABLES_TABLE_ELEMENT, name, desc));
                         writer.println();
                     }
                 }
-                writer.println(ReleaseNotesConstants.TABLES_TABLE_FOOTER);
+                writer.println(TABLES_TABLE_FOOTER);
                 if (tablesProCurrent.containsAll(newTables)) {
-                    writer.println(ReleaseNotesConstants.PRO_TOKEN_END);
+                    writer.println(PRO_TOKEN_END);
                 }
             }
             if (tableColMap.size() > 0) {
-                writer.println(ReleaseNotesConstants.TABLES_NEW_COL_HEADER);
+                writer.println(TABLES_NEW_COL_HEADER);
                 writer.println();
                 List<Table> tables = new ArrayList<Table>(tableColMap.keySet());
                 tables.sort(new TableComparator());
                 for (Table table : tables) {
                     if (tablesProCurrent.contains(table)) {
-                        writer.println(ReleaseNotesConstants.PRO_TOKEN_START);
-                        writer.println(String.format(ReleaseNotesConstants.TABLES_COL_HEADER_PRO, table.getName().toUpperCase()));
+                        writer.println(PRO_TOKEN_START);
+                        writer.println(String.format(TABLES_COL_HEADER_PRO, table.getName().toUpperCase()));
                         writer.println();
                     } else {
-                        writer.println(String.format(ReleaseNotesConstants.TABLES_COL_HEADER, table.getName().toUpperCase()));
+                        writer.println(String.format(TABLES_COL_HEADER, table.getName().toUpperCase()));
                         writer.println();
                     }
                     for (Column column : tableColMap.get(table)) {
-                        writer.println(String.format(ReleaseNotesConstants.TABLES_COLUMN_ELEMENT, column.getName(),
+                        writer.println(String.format(TABLES_COLUMN_ELEMENT, column.getName(),
                                 column.getDescription()));
                         writer.println();
                     }
-                    writer.println(ReleaseNotesConstants.TABLES_TABLE_FOOTER);
+                    writer.println(TABLES_TABLE_FOOTER);
                     if (tablesProCurrent.contains(table)) {
-                        writer.println(ReleaseNotesConstants.PRO_TOKEN_END);
+                        writer.println(PRO_TOKEN_END);
                     }
                     writer.println();
                 }
             }
             writer.println();
             if (tableChangeMap.size() > 0) {
-                writer.println(ReleaseNotesConstants.TABLES_MODIFIED_HEADER);
+                writer.println(TABLES_MODIFIED_HEADER);
                 writer.println();
                 List<Table> tables = new ArrayList<Table>(tableChangeMap.keySet());
                 tables.sort(new TableComparator());
                 for (Table table : tables) {
                     if (tablesProCurrent.contains(table)) {
-                        writer.println(ReleaseNotesConstants.PRO_TOKEN_START);
+                        writer.println(PRO_TOKEN_START);
                         writer.println(
-                                String.format(ReleaseNotesConstants.TABLES_MODIFIED_CAPTION_PRO, table.getName().toUpperCase()));
+                                String.format(TABLES_MODIFIED_CAPTION_PRO, table.getName().toUpperCase()));
                     } else {
-                        writer.println(String.format(ReleaseNotesConstants.TABLES_MODIFIED_CAPTION, table.getName().toUpperCase()));
+                        writer.println(String.format(TABLES_MODIFIED_CAPTION, table.getName().toUpperCase()));
                     }
                     for (String change : tableChangeMap.get(table)) {
-                        writer.println(String.format(ReleaseNotesConstants.TABLES_MODIFIED_ELEMENT, change));
+                        writer.println(String.format(TABLES_MODIFIED_ELEMENT, change));
                     }
                     if (tablesProCurrent.contains(table)) {
-                        writer.println(ReleaseNotesConstants.PRO_TOKEN_END);
+                        writer.println(PRO_TOKEN_END);
                     }
                     writer.println();
                 }
@@ -683,37 +818,37 @@ public class ReleaseNotesGenerator {
             String category) {
         int issuesWritten = 0;
         if (issues.stream().anyMatch(e -> e.getVersion().equalsIgnoreCase(version)
-                && e.getProject().equalsIgnoreCase("symmetric-pro") && e.getCategory().equalsIgnoreCase(category))) {
-            writer.println(ReleaseNotesConstants.PRO_TOKEN_START);
-            writer.println(ReleaseNotesConstants.ISSUES_SEC_SEPARATOR);
-            writer.println(ReleaseNotesConstants.ISSUES_HARDBREAKS);
-            writer.println(String.format(ReleaseNotesConstants.ISSUES_VERSION_HEADER_PRO, version));
+                && e.getProject().equalsIgnoreCase(SYMMETRIC_PRO_PROJECT) && e.getCategory().equalsIgnoreCase(category))) {
+            writer.println(PRO_TOKEN_START);
+            writer.println(ISSUES_SEC_SEPARATOR);
+            writer.println(ISSUES_HARDBREAKS);
+            writer.println(String.format(ISSUES_VERSION_HEADER_PRO, version));
             for (Issue issue : issues) {
-                if (issue.getProject().equalsIgnoreCase("symmetric-pro") && issue.getVersion().equalsIgnoreCase(version)
+                if (issue.getProject().equalsIgnoreCase(SYMMETRIC_PRO_PROJECT) && issue.getVersion().equalsIgnoreCase(version)
                         && issue.getCategory().equalsIgnoreCase(category)) {
-                    String idWithLink = (String.format(ReleaseNotesConstants.ISSUE_URL, issue.getId(), issue.getId()));
-                    writer.println(String.format(ReleaseNotesConstants.ISSUES_FORMAT, idWithLink, issue.getSummary()));
+                    String idWithLink = (String.format(ISSUE_URL, issue.getId(), issue.getId()));
+                    writer.println(String.format(ISSUES_FORMAT, idWithLink, issue.getSummary()));
                     issuesWritten++;
                 }
             }
-            writer.println(ReleaseNotesConstants.ISSUES_SEC_SEPARATOR);
-            writer.println(ReleaseNotesConstants.PRO_TOKEN_END);
+            writer.println(ISSUES_SEC_SEPARATOR);
+            writer.println(PRO_TOKEN_END);
         }
         if (issues.stream().anyMatch(e -> e.getVersion().equalsIgnoreCase(version)
-                && !e.getProject().equalsIgnoreCase("symmetric-pro") && e.getCategory().equalsIgnoreCase(category))) {
-            writer.println(ReleaseNotesConstants.ISSUES_SEC_SEPARATOR);
-            writer.println(ReleaseNotesConstants.ISSUES_HARDBREAKS);
-            writer.println(String.format(ReleaseNotesConstants.ISSUES_VERSION_HEADER, version));
+                && !e.getProject().equalsIgnoreCase(SYMMETRIC_PRO_PROJECT) && e.getCategory().equalsIgnoreCase(category))) {
+            writer.println(ISSUES_SEC_SEPARATOR);
+            writer.println(ISSUES_HARDBREAKS);
+            writer.println(String.format(ISSUES_VERSION_HEADER, version));
             for (Issue issue : issues) {
-                if (!issue.getProject().equalsIgnoreCase("symmetric-pro")
+                if (!issue.getProject().equalsIgnoreCase(SYMMETRIC_PRO_PROJECT)
                         && issue.getVersion().equalsIgnoreCase(version)
                         && issue.getCategory().equalsIgnoreCase(category)) {
-                    String idWithLink = (String.format(ReleaseNotesConstants.ISSUE_URL, issue.getId(), issue.getId()));
-                    writer.println(String.format(ReleaseNotesConstants.ISSUES_FORMAT, idWithLink, issue.getSummary()));
+                    String idWithLink = (String.format(ISSUE_URL, issue.getId(), issue.getId()));
+                    writer.println(String.format(ISSUES_FORMAT, idWithLink, issue.getSummary()));
                     issuesWritten++;
                 }
             }
-            writer.println(ReleaseNotesConstants.ISSUES_SEC_SEPARATOR);
+            writer.println(ISSUES_SEC_SEPARATOR);
         }
         return issuesWritten;
     }
@@ -723,9 +858,9 @@ public class ReleaseNotesGenerator {
         Map<String, String> categoryHeaders = new HashMap<>();
         Map<String, Integer> trackers = new HashMap<>();
         Map<String, Integer> proTrackers = new HashMap<>();
-        categoryHeaders.put(categories[0], ReleaseNotesConstants.ISSUES_FEATURES_HEADER);
-        categoryHeaders.put(categories[1], ReleaseNotesConstants.ISSUES_IMPROVEMENTS_HEADER);
-        categoryHeaders.put(categories[2], ReleaseNotesConstants.ISSUES_BUG_FIXES_HEADER);
+        categoryHeaders.put(categories[0], ISSUES_FEATURES_HEADER);
+        categoryHeaders.put(categories[1], ISSUES_IMPROVEMENTS_HEADER);
+        categoryHeaders.put(categories[2], ISSUES_BUG_FIXES_HEADER);
         for (Issue issue : issues) {
             if (!versions.contains(issue.getVersion().toLowerCase())) {
                 versions.add(issue.getVersion().toLowerCase());
@@ -740,20 +875,20 @@ public class ReleaseNotesGenerator {
         fixes = issues.stream().filter(e -> e.getCategory().equalsIgnoreCase(categories[2]))
                 .collect(Collectors.toList()).size();
         osFeatures = issues.stream().filter(e -> e.getCategory().equalsIgnoreCase(categories[0])
-                && !e.getProject().equalsIgnoreCase("symmetric-pro")).collect(Collectors.toList()).size();
+                && !e.getProject().equalsIgnoreCase(SYMMETRIC_PRO_PROJECT)).collect(Collectors.toList()).size();
         osImprovements = issues.stream().filter(e -> e.getCategory().equalsIgnoreCase(categories[1])
-                && !e.getProject().equalsIgnoreCase("symmetric-pro")).collect(Collectors.toList()).size();
+                && !e.getProject().equalsIgnoreCase(SYMMETRIC_PRO_PROJECT)).collect(Collectors.toList()).size();
         osFixes = issues.stream().filter(e -> e.getCategory().equalsIgnoreCase(categories[2])
-                && !e.getProject().equalsIgnoreCase("symmetric-pro")).collect(Collectors.toList()).size();
+                && !e.getProject().equalsIgnoreCase(SYMMETRIC_PRO_PROJECT)).collect(Collectors.toList()).size();
         trackers.put(categories[0], features);
         trackers.put(categories[1], improvements);
         trackers.put(categories[2], fixes);
         int proFeatures = issues.stream().filter(e -> e.getCategory().equalsIgnoreCase(categories[0])
-                && e.getProject().equalsIgnoreCase("symmetric-pro")).collect(Collectors.toList()).size();
+                && e.getProject().equalsIgnoreCase(SYMMETRIC_PRO_PROJECT)).collect(Collectors.toList()).size();
         int proImprovements = issues.stream().filter(e -> e.getCategory().equalsIgnoreCase(categories[1])
-                && e.getProject().equalsIgnoreCase("symmetric-pro")).collect(Collectors.toList()).size();
+                && e.getProject().equalsIgnoreCase(SYMMETRIC_PRO_PROJECT)).collect(Collectors.toList()).size();
         int proFixes = issues.stream().filter(e -> e.getCategory().equalsIgnoreCase(categories[2])
-                && e.getProject().equalsIgnoreCase("symmetric-pro")).collect(Collectors.toList()).size();
+                && e.getProject().equalsIgnoreCase(SYMMETRIC_PRO_PROJECT)).collect(Collectors.toList()).size();
         proTrackers.put(categories[0], proFeatures);
         proTrackers.put(categories[1], proImprovements);
         proTrackers.put(categories[2], proFixes);
@@ -765,24 +900,24 @@ public class ReleaseNotesGenerator {
         }
         if (features > 0 || improvements > 0 || fixes > 0) {
             if (allSymProIssues) {
-                writer.println(ReleaseNotesConstants.PRO_TOKEN_START);
+                writer.println(PRO_TOKEN_START);
             }
-            writer.println(ReleaseNotesConstants.ISSUES_SEC_HEADER);
+            writer.println(ISSUES_SEC_HEADER);
             if (allSymProIssues) {
-                writer.println(ReleaseNotesConstants.PRO_TOKEN_END);
+                writer.println(PRO_TOKEN_END);
             }
         }
         for (String category : categories) {
             if (trackers.get(category) > 0) {
                 if (trackers.get(category).equals(proTrackers.get(category))) {
-                    writer.println(ReleaseNotesConstants.PRO_TOKEN_START);
+                    writer.println(PRO_TOKEN_START);
                 }
                 writer.println(categoryHeaders.get(category));
                 for (String version : versions) {
                     writeMinorVersionIssues(writer, issues, version, category);
                 }
                 if (trackers.get(category).equals(proTrackers.get(category))) {
-                    writer.println(ReleaseNotesConstants.PRO_TOKEN_END);
+                    writer.println(PRO_TOKEN_END);
                 }
             }
         }
@@ -791,9 +926,9 @@ public class ReleaseNotesGenerator {
 
     protected static void writeFixesSection(PrintWriter writer, List<Issue> issues) {
         int osSecurityFixes = issues.stream().filter(e -> e.getTag() != null && e.getTag().equalsIgnoreCase(tags[0])
-                && !e.getProject().equalsIgnoreCase("symmetric-pro")).collect(Collectors.toList()).size();
+                && !e.getProject().equalsIgnoreCase(SYMMETRIC_PRO_PROJECT)).collect(Collectors.toList()).size();
         int osPerformanceFixes = issues.stream().filter(e -> e.getTag() != null && e.getTag().equalsIgnoreCase(tags[1])
-                && !e.getProject().equalsIgnoreCase("symmetric-pro")).collect(Collectors.toList()).size();
+                && !e.getProject().equalsIgnoreCase(SYMMETRIC_PRO_PROJECT)).collect(Collectors.toList()).size();
         int allSecurityFixes = issues.stream().filter(e -> e.getTag() != null && e.getTag().equalsIgnoreCase(tags[0]))
                 .collect(Collectors.toList()).size();
         int allPerformanceFixes = issues.stream()
@@ -801,64 +936,64 @@ public class ReleaseNotesGenerator {
                 .size();
         if (allSecurityFixes > 0) {
             if (osSecurityFixes == 0) {
-                writer.println(ReleaseNotesConstants.PRO_TOKEN_START);
+                writer.println(PRO_TOKEN_START);
             }
-            writer.println(ReleaseNotesConstants.FIXES_SECURITY_HEADER);
+            writer.println(FIXES_SECURITY_HEADER);
             writer.println();
-            writer.println(ReleaseNotesConstants.FIXES_TABLE_HEADER);
+            writer.println(FIXES_TABLE_HEADER);
             writer.println();
             issues.sort(new IssueComparator());
             for (Issue issue : issues) {
                 if (issue.getTag() != null && issue.getTag().equalsIgnoreCase(tags[0])) {
-                    String idWithLink = (String.format(ReleaseNotesConstants.ISSUE_URL, issue.getId(), issue.getId()));
-                    if (issue.getProject().equalsIgnoreCase("symmetric-pro")) {
-                        writer.println(ReleaseNotesConstants.PRO_TOKEN_START);
-                        writer.println(String.format(ReleaseNotesConstants.FIXES_TABLE_ELEMENT_PRO, idWithLink,
+                    String idWithLink = (String.format(ISSUE_URL, issue.getId(), issue.getId()));
+                    if (issue.getProject().equalsIgnoreCase(SYMMETRIC_PRO_PROJECT)) {
+                        writer.println(PRO_TOKEN_START);
+                        writer.println(String.format(FIXES_TABLE_ELEMENT_PRO, idWithLink,
                                 issue.getSummary(),
                                 issue.getPriority().substring(0, 1).toUpperCase() + issue.getPriority().substring(1)));
-                        writer.println(ReleaseNotesConstants.PRO_TOKEN_END);
+                        writer.println(PRO_TOKEN_END);
                     } else {
-                        writer.println(String.format(ReleaseNotesConstants.FIXES_TABLE_ELEMENT, idWithLink,
+                        writer.println(String.format(FIXES_TABLE_ELEMENT, idWithLink,
                                 issue.getSummary(),
                                 issue.getPriority().substring(0, 1).toUpperCase() + issue.getPriority().substring(1)));
                     }
                     writer.println();
                 }
             }
-            writer.println(ReleaseNotesConstants.FIXES_TABLE_FOOTER);
+            writer.println(FIXES_TABLE_FOOTER);
             if (osSecurityFixes == 0) {
-                writer.println(ReleaseNotesConstants.PRO_TOKEN_END);
+                writer.println(PRO_TOKEN_END);
             }
         }
         writer.println();
         if (allPerformanceFixes > 0) {
             if (osPerformanceFixes == 0) {
-                writer.println(ReleaseNotesConstants.PRO_TOKEN_START);
+                writer.println(PRO_TOKEN_START);
             }
-            writer.println(ReleaseNotesConstants.FIXES_PERFORMANCE_HEADER);
+            writer.println(FIXES_PERFORMANCE_HEADER);
             writer.println();
-            writer.println(ReleaseNotesConstants.FIXES_TABLE_HEADER);
+            writer.println(FIXES_TABLE_HEADER);
             writer.println();
             for (Issue issue : issues) {
                 if (issue.getTag() != null && issue.getTag().equalsIgnoreCase(tags[1])) {
-                    String idWithLink = (String.format(ReleaseNotesConstants.ISSUE_URL, issue.getId(), issue.getId()));
-                    if (issue.getProject().equalsIgnoreCase("symmetric-pro")) {
-                        writer.println(ReleaseNotesConstants.PRO_TOKEN_START);
-                        writer.println(String.format(ReleaseNotesConstants.FIXES_TABLE_ELEMENT_PRO, idWithLink,
+                    String idWithLink = (String.format(ISSUE_URL, issue.getId(), issue.getId()));
+                    if (issue.getProject().equalsIgnoreCase(SYMMETRIC_PRO_PROJECT)) {
+                        writer.println(PRO_TOKEN_START);
+                        writer.println(String.format(FIXES_TABLE_ELEMENT_PRO, idWithLink,
                                 issue.getSummary(),
                                 issue.getPriority().substring(0, 1).toUpperCase() + issue.getPriority().substring(1)));
-                        writer.println(ReleaseNotesConstants.PRO_TOKEN_END);
+                        writer.println(PRO_TOKEN_END);
                     } else {
-                        writer.println(String.format(ReleaseNotesConstants.FIXES_TABLE_ELEMENT, idWithLink,
+                        writer.println(String.format(FIXES_TABLE_ELEMENT, idWithLink,
                                 issue.getSummary(),
                                 issue.getPriority().substring(0, 1).toUpperCase() + issue.getPriority().substring(1)));
                     }
                     writer.println();
                 }
             }
-            writer.println(ReleaseNotesConstants.FIXES_TABLE_FOOTER);
+            writer.println(FIXES_TABLE_FOOTER);
             if (osPerformanceFixes == 0) {
-                writer.println(ReleaseNotesConstants.PRO_TOKEN_END);
+                writer.println(PRO_TOKEN_END);
             }
         }
     }
@@ -904,6 +1039,27 @@ public class ReleaseNotesGenerator {
         @Override
         public int compare(Issue i1, Issue i2) {
             return i1.getId().compareTo(i2.getId());
+        }
+    }
+
+    /**
+     * Helper class to encapsulate a page of issues with pagination info.
+     */
+    private static class PageResult {
+        private final List<Issue> issues;
+        private final String nextPageToken;
+
+        public PageResult(List<Issue> issues, String nextPageToken) {
+            this.issues = issues;
+            this.nextPageToken = nextPageToken;
+        }
+
+        public List<Issue> getIssues() {
+            return issues;
+        }
+
+        public String getNextPageToken() {
+            return nextPageToken;
         }
     }
 }

--- a/symmetric-server/build.gradle
+++ b/symmetric-server/build.gradle
@@ -163,8 +163,7 @@ apply from: symAssembleDir + '/asciidoc.gradle'
         }
     }
     
-    
-    serverDistZip.dependsOn { ':symmetric-server:jar' }
+	serverDistZip.dependsOn { ':symmetric-server:jar' }
     serverDistZip.dependsOn { ':symmetric-server:generateDocs' }
     generateAppendixes.dependsOn(project(':symmetric-server').jar)
     generateAppendixes.dependsOn(project(':symmetric-util').jar)


### PR DESCRIPTION
These are changes already in 3.16, but have not been merged into 3.17 for various reasons. All center around GitHub workflows, releasing, and release notes generation so they have not been needed up to this point.

Some GitHub workflows, like the cherry-pick automation should not work on this branch, since it still is configured to run on our default branch, which at the moment is still release/3.16. 