### PR TITLE
SYM-7238: Fix maven central plugin java incompatibility.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
             - name: Set up Java
               uses: actions/setup-java@v4
               with:
-                  java-version: 17
+                  java-version: 21
                   distribution: 'temurin'
                   cache: gradle
 

--- a/symmetric-assemble/common.gradle
+++ b/symmetric-assemble/common.gradle
@@ -131,6 +131,9 @@ subprojects { subproject ->
     }
 
 	java {
+    	toolchain {
+    		languageVersion = JavaLanguageVersion.of(17)
+    	}
     	sourceCompatibility=JavaVersion.VERSION_17
     	targetCompatibility=JavaVersion.VERSION_17
     }


### PR DESCRIPTION
Performing on 3.15 first to see how it goes. 

The plugin we use to publish to Maven Central is only compatible with Java 21 or higher. There is a known issue for the exception we faced when attempting to release 3.15. The idea here is to workaround the incompatibility by using Java 21 for the build while building and releasing a Java 17 compatible Symmetric. 