### PR TITLE
SYM-7258: Fixed DDL looping back to the source node when sending a load with create_table=1 to a node with DDL capture enabled

### DIFF
--- a/symmetric-client/src/main/java/org/jumpmind/symmetric/db/postgresql/PostgreSqlSymmetricDialect.java
+++ b/symmetric-client/src/main/java/org/jumpmind/symmetric/db/postgresql/PostgreSqlSymmetricDialect.java
@@ -20,9 +20,13 @@
  */
 package org.jumpmind.symmetric.db.postgresql;
 
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.sql.Types;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.commons.lang3.StringUtils;
 import org.jumpmind.db.model.Table;
@@ -275,21 +279,55 @@ public class PostgreSqlSymmetricDialect extends AbstractSymmetricDialect impleme
         }
     }
 
+    private String getDisableSyncTriggersSql() {
+        return "select set_config('" + SYNC_TRIGGERS_DISABLED_VARIABLE + "', '1', false)";
+    }
+
+    private String getDisableSyncNodeSql(String nodeId) {
+        return "select set_config('" + SYNC_NODE_DISABLED_VARIABLE + "', '" + nodeId + "', false)";
+    }
+
+    private String getEnableSyncTriggersSql() {
+        return "select set_config('" + SYNC_TRIGGERS_DISABLED_VARIABLE + "', '', false)";
+    }
+
+    private String getEnableSyncNodeSql() {
+        return "select set_config('" + SYNC_NODE_DISABLED_VARIABLE + "', '', false)";
+    }
+
     @Override
     public void disableSyncTriggers(ISqlTransaction transaction, String nodeId) {
-        transaction.prepareAndExecute("select set_config('" + SYNC_TRIGGERS_DISABLED_VARIABLE + "', '1', false)");
+        transaction.prepareAndExecute(getDisableSyncTriggersSql());
         if (nodeId == null) {
             nodeId = "";
         }
-        transaction.prepareAndExecute("select set_config('" + SYNC_NODE_DISABLED_VARIABLE + "', '" + nodeId + "', false)");
+        transaction.prepareAndExecute(getDisableSyncNodeSql(nodeId));
     }
 
     @Override
     public void enableSyncTriggers(ISqlTransaction transaction) {
-        transaction.prepareAndExecute("select set_config('" + SYNC_TRIGGERS_DISABLED_VARIABLE
-                + "', '', false)");
-        transaction.prepareAndExecute("select set_config('" + SYNC_NODE_DISABLED_VARIABLE
-                + "', '', false)");
+        transaction.prepareAndExecute(getEnableSyncTriggersSql());
+        transaction.prepareAndExecute(getEnableSyncNodeSql());
+    }
+
+    @Override
+    public void disableSyncTriggers(Connection connection, String nodeId) {
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute(getDisableSyncTriggersSql());
+            stmt.execute(getDisableSyncNodeSql(Objects.toString(nodeId, "")));
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void enableSyncTriggers(Connection connection) {
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute(getEnableSyncTriggersSql());
+            stmt.execute(getEnableSyncNodeSql());
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Override

--- a/symmetric-client/src/main/java/org/jumpmind/symmetric/db/postgresql/PostgreSqlSymmetricDialect.java
+++ b/symmetric-client/src/main/java/org/jumpmind/symmetric/db/postgresql/PostgreSqlSymmetricDialect.java
@@ -59,6 +59,10 @@ public class PostgreSqlSymmetricDialect extends AbstractSymmetricDialect impleme
     protected String sharedNodeDisabledFunction;
     protected String sharedReadLargeObjectFunction;
     protected boolean versionSupportsReplaceTriggers;
+    private int triggersDisabledCount;
+    private int nodeDisabledCount;
+    private int triggersEnabledCount;
+    private int nodeEnabledCount;
 
     public PostgreSqlSymmetricDialect(IParameterService parameterService, IDatabasePlatform platform) {
         super(parameterService, platform);
@@ -280,18 +284,22 @@ public class PostgreSqlSymmetricDialect extends AbstractSymmetricDialect impleme
     }
 
     private String getDisableSyncTriggersSql() {
+        triggersDisabledCount++;
         return "select set_config('" + SYNC_TRIGGERS_DISABLED_VARIABLE + "', '1', false)";
     }
 
     private String getDisableSyncNodeSql(String nodeId) {
+        nodeDisabledCount++;
         return "select set_config('" + SYNC_NODE_DISABLED_VARIABLE + "', '" + nodeId + "', false)";
     }
 
     private String getEnableSyncTriggersSql() {
+        triggersEnabledCount++;
         return "select set_config('" + SYNC_TRIGGERS_DISABLED_VARIABLE + "', '', false)";
     }
 
     private String getEnableSyncNodeSql() {
+        nodeEnabledCount++;
         return "select set_config('" + SYNC_NODE_DISABLED_VARIABLE + "', '', false)";
     }
 
@@ -420,5 +428,21 @@ public class PostgreSqlSymmetricDialect extends AbstractSymmetricDialect impleme
 
     public boolean supportsReplaceTriggers() {
         return versionSupportsReplaceTriggers;
+    }
+
+    public int getTriggersDisabledCount() {
+        return triggersDisabledCount;
+    }
+
+    public int getNodeDisabledCount() {
+        return nodeDisabledCount;
+    }
+
+    public int getTriggersEnabledCount() {
+        return triggersEnabledCount;
+    }
+
+    public int getNodeEnabledCount() {
+        return nodeEnabledCount;
     }
 }

--- a/symmetric-client/src/main/java/org/jumpmind/symmetric/db/postgresql/PostgreSqlTriggerTemplate.java
+++ b/symmetric-client/src/main/java/org/jumpmind/symmetric/db/postgresql/PostgreSqlTriggerTemplate.java
@@ -144,7 +144,7 @@ public class PostgreSqlTriggerTemplate extends AbstractTriggerTemplate {
                 + "\n      INSERT INTO $(defaultSchema)$(prefixName)_data(table_name, event_type, trigger_hist_id, row_data, channel_id, source_node_id, transaction_id, create_time) "
                 + "\n      VALUES (tableName, 'S', histId, "
                 + "\n         '\"delimiter " + sqlBatchDelimiter + ";' || chr(13) || chr(10) || replace(replace(eventDdl,'\\','\\\\'),'\"','\\\"') || chr(13) || chr(10) || '\",ddl',"
-                + "\n         channelId, 'source',"
+                + "\n         channelId, $(defaultSchema)$(prefixName)_node_disabled(),"
                 + "\n         TO_CHAR(CURRENT_TIMESTAMP, 'truncate-YYYY-MM-DD')||'T'||TO_CHAR(CURRENT_TIMESTAMP, 'HH24:MI:MSOF'), " + currentTimestampAndZoneExpression + "); "
                 + "\n      RAISE NOTICE 'Captured truncate event for table; Schema=%, Table=%, Channel=%, Command=%', tableSchema, tableName, channelId, eventDdl;"
                 + "\n    else "

--- a/symmetric-client/src/main/java/org/jumpmind/symmetric/db/postgresql/PostgreSqlTriggerTemplate.java
+++ b/symmetric-client/src/main/java/org/jumpmind/symmetric/db/postgresql/PostgreSqlTriggerTemplate.java
@@ -144,7 +144,7 @@ public class PostgreSqlTriggerTemplate extends AbstractTriggerTemplate {
                 + "\n      INSERT INTO $(defaultSchema)$(prefixName)_data(table_name, event_type, trigger_hist_id, row_data, channel_id, source_node_id, transaction_id, create_time) "
                 + "\n      VALUES (tableName, 'S', histId, "
                 + "\n         '\"delimiter " + sqlBatchDelimiter + ";' || chr(13) || chr(10) || replace(replace(eventDdl,'\\','\\\\'),'\"','\\\"') || chr(13) || chr(10) || '\",ddl',"
-                + "\n         channelId, $(defaultSchema)$(prefixName)_node_disabled(),"
+                + "\n         channelId, 'source',"
                 + "\n         TO_CHAR(CURRENT_TIMESTAMP, 'truncate-YYYY-MM-DD')||'T'||TO_CHAR(CURRENT_TIMESTAMP, 'HH24:MI:MSOF'), " + currentTimestampAndZoneExpression + "); "
                 + "\n      RAISE NOTICE 'Captured truncate event for table; Schema=%, Table=%, Channel=%, Command=%', tableSchema, tableName, channelId, eventDdl;"
                 + "\n    else "

--- a/symmetric-client/src/main/java/org/jumpmind/symmetric/ext/BulkDataLoaderFactory.java
+++ b/symmetric-client/src/main/java/org/jumpmind/symmetric/ext/BulkDataLoaderFactory.java
@@ -54,10 +54,10 @@ public class BulkDataLoaderFactory extends AbstractDataLoaderFactory implements 
         IDatabasePlatform platform = engine.getTargetDialect().getPlatform();
         if (engine.getParameterService().is(ParameterConstants.JDBC_EXECUTE_BULK_BATCH_OVERRIDE, false)) {
             return new JdbcBatchBulkDatabaseWriter(symmetricDialect.getPlatform(), platform,
-                    symmetricDialect.getTablePrefix(), buildParameterDatabaseWriterSettings(conflictSettings));
+                    symmetricDialect.getTablePrefix(), buildParameterDatabaseWriterSettings(symmetricDialect, conflictSettings));
         } else {
             return new JdbcBatchBulkDatabaseWriter(symmetricDialect.getPlatform(), platform,
-                    symmetricDialect.getTablePrefix(), buildParameterDatabaseWriterSettings(conflictSettings));
+                    symmetricDialect.getTablePrefix(), buildParameterDatabaseWriterSettings(symmetricDialect, conflictSettings));
         }
     }
 

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/db/AbstractSymmetricDialect.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/db/AbstractSymmetricDialect.java
@@ -826,6 +826,14 @@ abstract public class AbstractSymmetricDialect implements ISymmetricDialect {
     }
 
     @Override
+    public void disableSyncTriggers(java.sql.Connection connection, String nodeId) {
+    }
+
+    @Override
+    public void enableSyncTriggers(java.sql.Connection connection) {
+    }
+
+    @Override
     public boolean supportsTransactionId() {
         return false;
     }

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/db/ISymmetricDialect.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/db/ISymmetricDialect.java
@@ -20,6 +20,7 @@
  */
 package org.jumpmind.symmetric.db;
 
+import java.sql.Connection;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -169,6 +170,10 @@ public interface ISymmetricDialect {
     public void disableSyncTriggers(ISqlTransaction transaction, String nodeId);
 
     public void enableSyncTriggers(ISqlTransaction transaction);
+
+    public void disableSyncTriggers(Connection connection, String nodeId);
+
+    public void enableSyncTriggers(Connection connection);
 
     public String getSyncTriggersExpression();
 

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/load/AbstractDataLoaderFactory.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/load/AbstractDataLoaderFactory.java
@@ -20,12 +20,17 @@
  */
 package org.jumpmind.symmetric.load;
 
+import java.sql.Connection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
+import org.jumpmind.db.sql.IConnectionHandler;
+import org.jumpmind.db.sql.IDdlExecutionCallback;
+import org.jumpmind.db.sql.ISqlTemplate;
 import org.jumpmind.symmetric.common.ParameterConstants;
+import org.jumpmind.symmetric.db.ISymmetricDialect;
 import org.jumpmind.symmetric.io.data.writer.Conflict;
 import org.jumpmind.symmetric.io.data.writer.DatabaseWriterSettings;
 import org.jumpmind.symmetric.io.data.writer.Conflict.DetectConflict;
@@ -39,7 +44,15 @@ public abstract class AbstractDataLoaderFactory {
     protected final Logger log = LoggerFactory.getLogger(getClass());
 
     public DatabaseWriterSettings buildParameterDatabaseWriterSettings(List<? extends Conflict> conflictSettings) {
+        return buildParameterDatabaseWriterSettings(null, conflictSettings);
+    }
+
+    public DatabaseWriterSettings buildParameterDatabaseWriterSettings(final ISymmetricDialect symmetricDialect,
+            List<? extends Conflict> conflictSettings) {
         DatabaseWriterSettings settings = new DatabaseWriterSettings();
+        if (symmetricDialect != null) {
+            setDdlExecutionCallback(settings, symmetricDialect);
+        }
         settings.setCreateTableAlterCaseToMatchDatabaseDefault(
                 parameterService.is(ParameterConstants.DATA_LOADER_CREATE_TABLE_ALTER_TO_MATCH_DB_CASE, true));
         settings.setCreateTableWithoutDefaultsOnError(
@@ -115,6 +128,30 @@ public abstract class AbstractDataLoaderFactory {
         settings.setKeepBulkStagingFiles(parameterService.is(ParameterConstants.KEEP_BULK_STAGING_FILES));
         settings.setMsSqlBulkLoadBcpCodePage(parameterService.getString(ParameterConstants.MSSQL_BULK_LOAD_BCP_CODE_PAGE));
         return settings;
+    }
+
+    protected void setDdlExecutionCallback(DatabaseWriterSettings settings, ISymmetricDialect symmetricDialect) {
+        settings.setDdlExecutionCallback(new IDdlExecutionCallback() {
+            @Override
+            public void beforeDdlExecution(ISqlTemplate sqlTemplate, String sourceNodeId) {
+                sqlTemplate.setThreadLocalConnectionHandler(new IConnectionHandler() {
+                    @Override
+                    public void before(Connection connection) {
+                        symmetricDialect.disableSyncTriggers(connection, sourceNodeId);
+                    }
+
+                    @Override
+                    public void after(Connection connection) {
+                        symmetricDialect.enableSyncTriggers(connection);
+                    }
+                });
+            }
+
+            @Override
+            public void afterDdlExecution(ISqlTemplate sqlTemplate) {
+                sqlTemplate.clearThreadLocalConnectionHandler();
+            }
+        });
     }
 
     protected boolean getDefaultTreatBitAsInteger() {

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/load/DefaultDataLoaderFactory.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/load/DefaultDataLoaderFactory.java
@@ -100,7 +100,7 @@ public class DefaultDataLoaderFactory extends AbstractDataLoaderFactory implemen
                 // TODO: Evaluate if ConflictResolver will work for Cassandra and if so remove duplicate code.
                 return new CassandraDatabaseWriter(symmetricDialect.getPlatform(), symmetricDialect.getTargetPlatform(),
                         symmetricDialect.getTablePrefix(), new DefaultTransformWriterConflictResolver(transformWriter),
-                        buildDatabaseWriterSettings(filters, errorHandlers, conflictSettings, resolvedData));
+                        buildDatabaseWriterSettings(symmetricDialect, filters, errorHandlers, conflictSettings, resolvedData));
             } else if (targetPlatform instanceof KafkaPlatform) {
                 String url;
                 String producer;
@@ -128,7 +128,7 @@ public class DefaultDataLoaderFactory extends AbstractDataLoaderFactory implemen
                 channelReload = Constants.CHANNEL_RELOAD;
                 return new KafkaWriter(symmetricDialect.getPlatform(), symmetricDialect.getTargetPlatform(),
                         runtimeConfigTablePrefix, new DefaultTransformWriterConflictResolver(transformWriter),
-                        buildDatabaseWriterSettings(filters, errorHandlers, conflictSettings, resolvedData), producer, outputFormat, topicBy,
+                        buildDatabaseWriterSettings(symmetricDialect, filters, errorHandlers, conflictSettings, resolvedData), producer, outputFormat, topicBy,
                         messageBy, confluentUrl, schemaPackage, externalNodeID, url, loadOnlyPrefix, props, channelReload);
             }
         } catch (Exception e) {
@@ -292,7 +292,8 @@ public class DefaultDataLoaderFactory extends AbstractDataLoaderFactory implemen
         DynamicDefaultDatabaseWriter writer = null;
         if (engine.getCacheManager().isUsingTargetExternalId(false)) {
             writer = new DynamicDefaultDatabaseWriter(symmetricDialect.getPlatform(), symmetricDialect.getTargetPlatform(),
-                    symmetricDialect.getTablePrefix(), resolver, buildDatabaseWriterSettings(filters, errorHandlers, conflictSettings, resolvedData)) {
+                    symmetricDialect.getTablePrefix(), resolver, buildDatabaseWriterSettings(symmetricDialect, filters, errorHandlers, conflictSettings,
+                            resolvedData)) {
                 @Override
                 protected String getTableKey(Table table) {
                     if (!table.getName().contains(batch.getSourceNodeId())) {
@@ -331,7 +332,8 @@ public class DefaultDataLoaderFactory extends AbstractDataLoaderFactory implemen
             };
         } else {
             writer = new DynamicDefaultDatabaseWriter(symmetricDialect.getPlatform(), symmetricDialect.getTargetPlatform(),
-                    symmetricDialect.getTablePrefix(), resolver, buildDatabaseWriterSettings(filters, errorHandlers, conflictSettings, resolvedData));
+                    symmetricDialect.getTablePrefix(), resolver, buildDatabaseWriterSettings(symmetricDialect, filters, errorHandlers, conflictSettings,
+                            resolvedData));
         }
         return writer;
     }
@@ -344,6 +346,12 @@ public class DefaultDataLoaderFactory extends AbstractDataLoaderFactory implemen
     protected DatabaseWriterSettings buildDatabaseWriterSettings(List<IDatabaseWriterFilter> filters,
             List<IDatabaseWriterErrorHandler> errorHandlers, List<? extends Conflict> conflictSettings,
             List<ResolvedData> resolvedDatas) {
+        return buildDatabaseWriterSettings(null, filters, errorHandlers, conflictSettings, resolvedDatas);
+    }
+
+    protected DatabaseWriterSettings buildDatabaseWriterSettings(final ISymmetricDialect symmetricDialect,
+            List<IDatabaseWriterFilter> filters, List<IDatabaseWriterErrorHandler> errorHandlers,
+            List<? extends Conflict> conflictSettings, List<ResolvedData> resolvedDatas) {
         DatabaseWriterSettings settings = buildParameterDatabaseWriterSettings(conflictSettings);
         settings.setDatabaseWriterFilters(filters);
         settings.setDatabaseWriterErrorHandlers(errorHandlers);
@@ -354,6 +362,9 @@ public class DefaultDataLoaderFactory extends AbstractDataLoaderFactory implemen
         IAlterDatabaseInterceptor[] interceptors = alterDatabaseInterceptors
                 .toArray(new IAlterDatabaseInterceptor[alterDatabaseInterceptors.size()]);
         settings.setAlterDatabaseInterceptors(interceptors);
+        if (symmetricDialect != null) {
+            setDdlExecutionCallback(settings, symmetricDialect);
+        }
         return settings;
     }
 

--- a/symmetric-db/src/main/java/org/jumpmind/db/sql/AbstractSqlTemplate.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/sql/AbstractSqlTemplate.java
@@ -333,4 +333,12 @@ abstract public class AbstractSqlTemplate implements ISqlTemplate {
     public boolean doesObjectNotExist(Throwable ex) {
         return false;
     }
+
+    @Override
+    public void setThreadLocalConnectionHandler(IConnectionHandler handler) {
+    }
+
+    @Override
+    public void clearThreadLocalConnectionHandler() {
+    }
 }

--- a/symmetric-db/src/main/java/org/jumpmind/db/sql/IDdlExecutionCallback.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/sql/IDdlExecutionCallback.java
@@ -1,0 +1,27 @@
+/**
+ * Licensed to JumpMind Inc under one or more contributor
+ * license agreements.  See the NOTICE file distributed
+ * with this work for additional information regarding
+ * copyright ownership.  JumpMind Inc licenses this file
+ * to you under the GNU General Public License, version 3.0 (GPLv3)
+ * (the "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3.0 (GPLv3) along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jumpmind.db.sql;
+
+public interface IDdlExecutionCallback {
+    void beforeDdlExecution(ISqlTemplate sqlTemplate, String sourceNodeId);
+
+    void afterDdlExecution(ISqlTemplate sqlTemplate);
+}

--- a/symmetric-db/src/main/java/org/jumpmind/db/sql/ISqlTemplate.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/sql/ISqlTemplate.java
@@ -152,4 +152,8 @@ public interface ISqlTemplate {
 
     public long insertWithGeneratedKey(final String sql, String column, final String sequenceName,
             final Object[] args, final int[] types);
+
+    void setThreadLocalConnectionHandler(IConnectionHandler handler);
+
+    void clearThreadLocalConnectionHandler();
 }

--- a/symmetric-io/src/main/java/org/jumpmind/symmetric/io/data/writer/DatabaseWriterSettings.java
+++ b/symmetric-io/src/main/java/org/jumpmind/symmetric/io/data/writer/DatabaseWriterSettings.java
@@ -28,6 +28,7 @@ import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 import org.jumpmind.db.model.Table;
 import org.jumpmind.db.platform.IAlterDatabaseInterceptor;
+import org.jumpmind.db.sql.IDdlExecutionCallback;
 import org.jumpmind.symmetric.io.data.Batch;
 
 public class DatabaseWriterSettings {
@@ -69,6 +70,7 @@ public class DatabaseWriterSettings {
     protected boolean createTableIncludeApplicationTriggers = false;
     protected boolean keepBulkStagingFiles = false;
     protected String msSqlBulkLoadBcpCodePage;
+    protected IDdlExecutionCallback ddlExecutionCallback;
 
     public void setAlterDatabaseInterceptors(IAlterDatabaseInterceptor[] alterDatabaseInterceptors) {
         this.alterDatabaseInterceptors = alterDatabaseInterceptors;
@@ -419,5 +421,13 @@ public class DatabaseWriterSettings {
 
     public void setMsSqlBulkLoadBcpCodePage(String msSqlBulkLoadBcpCodePage) {
         this.msSqlBulkLoadBcpCodePage = msSqlBulkLoadBcpCodePage;
+    }
+
+    public IDdlExecutionCallback getDdlExecutionCallback() {
+        return ddlExecutionCallback;
+    }
+
+    public void setDdlExecutionCallback(IDdlExecutionCallback ddlExecutionCallback) {
+        this.ddlExecutionCallback = ddlExecutionCallback;
     }
 }

--- a/symmetric-io/src/main/java/org/jumpmind/symmetric/io/data/writer/DefaultDatabaseWriter.java
+++ b/symmetric-io/src/main/java/org/jumpmind/symmetric/io/data/writer/DefaultDatabaseWriter.java
@@ -702,7 +702,7 @@ public class DefaultDatabaseWriter extends AbstractDatabaseWriter {
             }
             IDdlExecutionCallback callback = writerSettings.getDdlExecutionCallback();
             String sourceNodeId = batch != null ? batch.getSourceNodeId() : null;
-            boolean shouldUseCallback = callback != null && sourceNodeId != null && !sourceNodeId.isEmpty();
+            boolean shouldUseCallback = callback != null && StringUtils.isNotEmpty(sourceNodeId);
             if (shouldUseCallback) {
                 callback.beforeDdlExecution(getTargetPlatform().getSqlTemplate(), sourceNodeId);
             }

--- a/symmetric-io/src/main/java/org/jumpmind/symmetric/io/data/writer/DefaultDatabaseWriter.java
+++ b/symmetric-io/src/main/java/org/jumpmind/symmetric/io/data/writer/DefaultDatabaseWriter.java
@@ -51,6 +51,7 @@ import org.jumpmind.db.platform.IDatabasePlatform;
 import org.jumpmind.db.sql.DataTruncationException;
 import org.jumpmind.db.sql.DmlStatement;
 import org.jumpmind.db.sql.DmlStatement.DmlType;
+import org.jumpmind.db.sql.IDdlExecutionCallback;
 import org.jumpmind.db.sql.ISqlRowMapper;
 import org.jumpmind.db.sql.ISqlTemplate;
 import org.jumpmind.db.sql.ISqlTransaction;
@@ -699,11 +700,23 @@ public class DefaultDatabaseWriter extends AbstractDatabaseWriter {
                     }
                 }
             }
-            if (writerSettings.isAlterTable()) {
-                getTargetPlatform().alterTables(!writerSettings.isCreateTableFailOnError(), writerSettings.isCreateTableIncludeApplicationTriggers(),
-                        writerSettings.getRuntimeConfigTriggerPrefix(), writerSettings.getAlterDatabaseInterceptors(), db.getTables());
-            } else {
-                getTargetPlatform().createDatabase(db, writerSettings.isCreateTableDropFirst(), !writerSettings.isCreateTableFailOnError());
+            IDdlExecutionCallback callback = writerSettings.getDdlExecutionCallback();
+            String sourceNodeId = batch != null ? batch.getSourceNodeId() : null;
+            boolean shouldUseCallback = callback != null && sourceNodeId != null && !sourceNodeId.isEmpty();
+            if (shouldUseCallback) {
+                callback.beforeDdlExecution(getTargetPlatform().getSqlTemplate(), sourceNodeId);
+            }
+            try {
+                if (writerSettings.isAlterTable()) {
+                    getTargetPlatform().alterTables(!writerSettings.isCreateTableFailOnError(), writerSettings.isCreateTableIncludeApplicationTriggers(),
+                            writerSettings.getRuntimeConfigTriggerPrefix(), writerSettings.getAlterDatabaseInterceptors(), db.getTables());
+                } else {
+                    getTargetPlatform().createDatabase(db, writerSettings.isCreateTableDropFirst(), !writerSettings.isCreateTableFailOnError());
+                }
+            } finally {
+                if (shouldUseCallback) {
+                    callback.afterDdlExecution(getTargetPlatform().getSqlTemplate());
+                }
             }
             getTargetPlatform().resetCachedTableModel();
             statistics.get(batch).increment(DataWriterStatisticConstants.CREATECOUNT);

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/sql/JdbcSqlTemplate.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/sql/JdbcSqlTemplate.java
@@ -68,6 +68,7 @@ import org.springframework.jdbc.support.lob.LobHandler;
 
 public class JdbcSqlTemplate extends AbstractSqlTemplate implements ISqlTemplate {
     private static final Logger log = LoggerFactory.getLogger(JdbcSqlTemplate.class);
+    private static final ThreadLocal<IConnectionHandler> threadLocalConnectionHandler = new ThreadLocal<IConnectionHandler>();
     protected DataSource dataSource;
     protected boolean requiresAutoCommitFalseToSetFetchSize = false;
     protected SqlTemplateSettings settings;
@@ -520,12 +521,23 @@ public class JdbcSqlTemplate extends AbstractSqlTemplate implements ISqlTemplate
 
     public <T> T execute(IConnectionCallback<T> callback) {
         Connection c = null;
+        IConnectionHandler handler = threadLocalConnectionHandler.get();
         try {
             c = getConnection();
+            if (handler != null) {
+                handler.before(c);
+            }
             return callback.execute(c);
         } catch (SQLException ex) {
             throw translate(ex);
         } finally {
+            if (handler != null && c != null) {
+                try {
+                    handler.after(c);
+                } catch (Exception e) {
+                    log.warn("Error in connection handler after callback", e);
+                }
+            }
             close(c);
         }
     }
@@ -1322,5 +1334,15 @@ public class JdbcSqlTemplate extends AbstractSqlTemplate implements ISqlTemplate
             }
         }
         return indexName;
+    }
+
+    @Override
+    public void setThreadLocalConnectionHandler(IConnectionHandler handler) {
+        threadLocalConnectionHandler.set(handler);
+    }
+
+    @Override
+    public void clearThreadLocalConnectionHandler() {
+        threadLocalConnectionHandler.remove();
     }
 }


### PR DESCRIPTION
The problem is that `DefaultDatabaseWriter.create()` uses a `SqlScript` to execute DDL instead of the `ISqlTransaction` that has the session variable set that populates the `sym_data.source_node_id` column.

I used Claude to come up with a plan to resolve this and found that a solution is to add an `IConnectionHandler` to set the session variable on the `Connection` used by the `SqlScript` before the DDL is executed, then un-set the variable after it's done. This required the addition of new `Connection`-specific `disableSyncTriggers()` and `enableSyncTriggers()` methods to the dialects that support DDL capture.