### PR TITLE
SYM-7268: Fixed sym_node_group_link.sync_sql_enabled=0 not preventing captured DDL from synchronizing if the DDL affected a table with an active trigger history

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/RouterService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/RouterService.java
@@ -936,8 +936,8 @@ public class RouterService extends AbstractService implements IRouterService, IN
         }
         if (triggerRouters != null && triggerRouters.size() > 0) {
             for (TriggerRouter triggerRouter : triggerRouters) {
-                DataMetaData dataMetaData = new DataMetaData(data, table, triggerRouter.getRouter(),
-                        context.getChannel());
+                Router router = triggerRouter.getRouter();
+                DataMetaData dataMetaData = new DataMetaData(data, table, router, context.getChannel());
                 Collection<String> nodeIds = null;
                 if (triggerRouter.isRouted(data.getDataEventType())) {
                     String targetNodeIds = data.getNodeList();
@@ -954,7 +954,7 @@ public class RouterService extends AbstractService implements IRouterService, IN
                         if (nodeIds.size() == 0 && log.isDebugEnabled()) {
                             log.debug(
                                     "None of the target nodes specified in the data.node_list field ({}) were qualified nodes. Data id {} for table '{}' will not be routed using the {} router",
-                                    new Object[] { targetNodeIds, data.getDataId(), data.getTableName(), triggerRouter.getRouter().getRouterId() });
+                                    new Object[] { targetNodeIds, data.getDataId(), data.getTableName(), router.getRouterId() });
                         }
                     } else if (data.getTriggerHistory().getLastTriggerBuildReason() == TriggerReBuildReason.TRIGGER_HIST_MISSING && !doesColumnCountMatchValues(
                             dataMetaData, data)) {
@@ -967,7 +967,10 @@ public class RouterService extends AbstractService implements IRouterService, IN
                         counterStat.incrementCount();
                     } else {
                         try {
-                            IDataRouter dataRouter = getDataRouter(triggerRouter.getRouter(), dataMetaData);
+                            if (shouldSkipSqlEvent(data, router)) {
+                                continue;
+                            }
+                            IDataRouter dataRouter = getDataRouter(router, dataMetaData);
                             long ts = System.currentTimeMillis();
                             nodeIds = dataRouter.routeToNodes(context, dataMetaData,
                                     findAvailableNodes(triggerRouter, context), false, false,
@@ -1027,6 +1030,16 @@ public class RouterService extends AbstractService implements IRouterService, IN
         context.incrementStat(numberOfDataEventsInserted,
                 ChannelRouterContext.STAT_DATA_EVENTS_INSERTED);
         return numberOfDataEventsInserted;
+    }
+
+    protected boolean shouldSkipSqlEvent(Data data, Router router) {
+        if (data.getDataEventType() == DataEventType.SQL) {
+            NodeGroupLink link = engine.getConfigurationService().getNodeGroupLinkFor(
+                    router.getNodeGroupLink().getSourceNodeGroupId(),
+                    router.getNodeGroupLink().getTargetNodeGroupId(), false);
+            return link != null && !link.isSyncSqlEnabled();
+        }
+        return false;
     }
 
     protected int insertDataEvents(ProcessInfo processInfo, ChannelRouterContext context, DataMetaData dataMetaData,

--- a/symmetric-core/src/test/java/org/jumpmind/symmetric/service/impl/RouterServiceTest.java
+++ b/symmetric-core/src/test/java/org/jumpmind/symmetric/service/impl/RouterServiceTest.java
@@ -20,6 +20,7 @@
  */
 package org.jumpmind.symmetric.service.impl;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -31,10 +32,14 @@ import org.jumpmind.db.platform.DatabaseInfo;
 import org.jumpmind.db.platform.IDatabasePlatform;
 import org.jumpmind.symmetric.ISymmetricEngine;
 import org.jumpmind.symmetric.db.ISymmetricDialect;
+import org.jumpmind.symmetric.io.data.DataEventType;
 import org.jumpmind.symmetric.model.Channel;
+import org.jumpmind.symmetric.model.Data;
+import org.jumpmind.symmetric.model.NodeGroupLink;
 import org.jumpmind.symmetric.model.Router;
 import org.jumpmind.symmetric.model.Trigger;
 import org.jumpmind.symmetric.model.TriggerRouter;
+import org.jumpmind.symmetric.service.IConfigurationService;
 import org.jumpmind.symmetric.service.IExtensionService;
 import org.jumpmind.symmetric.service.IParameterService;
 import org.junit.jupiter.api.BeforeEach;
@@ -45,6 +50,7 @@ public class RouterServiceTest {
     final static String SOURCE_NODE_GROUP = "source";
     final static String TARGET_NODE_GROUP = "target";
     RouterService routerService;
+    IConfigurationService configurationService;
 
     @BeforeEach
     public void setup() {
@@ -53,12 +59,14 @@ public class RouterServiceTest {
         ISymmetricDialect symmetricDialect = mock(ISymmetricDialect.class);
         IDatabasePlatform databasePlatform = mock(IDatabasePlatform.class);
         IExtensionService extensionService = mock(IExtensionService.class);
+        configurationService = mock(IConfigurationService.class);
         when(databasePlatform.getDatabaseInfo()).thenReturn(new DatabaseInfo());
         when(symmetricDialect.getPlatform()).thenReturn(databasePlatform);
         when(engine.getDatabasePlatform()).thenReturn(databasePlatform);
         when(engine.getParameterService()).thenReturn(parameterService);
         when(engine.getSymmetricDialect()).thenReturn(symmetricDialect);
         when(engine.getExtensionService()).thenReturn(extensionService);
+        when(engine.getConfigurationService()).thenReturn(configurationService);
         routerService = new RouterService(engine);
     }
 
@@ -133,5 +141,47 @@ public class RouterServiceTest {
         triggerRouters.add(new TriggerRouter(tableTrigger2, new Router("test", TARGET_NODE_GROUP, SOURCE_NODE_GROUP, "default")));
         triggerRouters.add(new TriggerRouter(tableTrigger3, new Router("test", TARGET_NODE_GROUP, SOURCE_NODE_GROUP, "default")));
         assertTrue(routerService.producesCommonBatches(CHANNEL_2_TEST, SOURCE_NODE_GROUP, triggerRouters));
+    }
+
+    @Test
+    public void testShouldSkipSqlEventWhenSyncSqlDisabled() {
+        NodeGroupLink link = new NodeGroupLink(SOURCE_NODE_GROUP, TARGET_NODE_GROUP);
+        link.setSyncSqlEnabled(false);
+        when(configurationService.getNodeGroupLinkFor(SOURCE_NODE_GROUP, TARGET_NODE_GROUP, false)).thenReturn(link);
+        Data data = new Data();
+        data.setDataEventType(DataEventType.SQL);
+        Router router = new Router("test", SOURCE_NODE_GROUP, TARGET_NODE_GROUP, "default");
+        assertTrue(routerService.shouldSkipSqlEvent(data, router));
+    }
+
+    @Test
+    public void testShouldNotSkipSqlEventWhenSyncSqlEnabled() {
+        NodeGroupLink link = new NodeGroupLink(SOURCE_NODE_GROUP, TARGET_NODE_GROUP);
+        link.setSyncSqlEnabled(true);
+        when(configurationService.getNodeGroupLinkFor(SOURCE_NODE_GROUP, TARGET_NODE_GROUP, false)).thenReturn(link);
+        Data data = new Data();
+        data.setDataEventType(DataEventType.SQL);
+        Router router = new Router("test", SOURCE_NODE_GROUP, TARGET_NODE_GROUP, "default");
+        assertFalse(routerService.shouldSkipSqlEvent(data, router));
+    }
+
+    @Test
+    public void testShouldNotSkipNonSqlEventWhenSyncSqlDisabled() {
+        NodeGroupLink link = new NodeGroupLink(SOURCE_NODE_GROUP, TARGET_NODE_GROUP);
+        link.setSyncSqlEnabled(false);
+        when(configurationService.getNodeGroupLinkFor(SOURCE_NODE_GROUP, TARGET_NODE_GROUP, false)).thenReturn(link);
+        Data data = new Data();
+        data.setDataEventType(DataEventType.INSERT);
+        Router router = new Router("test", SOURCE_NODE_GROUP, TARGET_NODE_GROUP, "default");
+        assertFalse(routerService.shouldSkipSqlEvent(data, router));
+    }
+
+    @Test
+    public void testShouldNotSkipSqlEventWhenLinkNotFound() {
+        when(configurationService.getNodeGroupLinkFor(SOURCE_NODE_GROUP, TARGET_NODE_GROUP, false)).thenReturn(null);
+        Data data = new Data();
+        data.setDataEventType(DataEventType.SQL);
+        Router router = new Router("test", SOURCE_NODE_GROUP, TARGET_NODE_GROUP, "default");
+        assertFalse(routerService.shouldSkipSqlEvent(data, router));
     }
 }


### PR DESCRIPTION
You might notice that `RouterService.shouldSkipSqlEvent()` fetches the group link from the cache even though it can already get it via `router.getNodeGroupLink()`. I saw that `RouterService.findAvailableNodes()` and `ConfigurationChangedDataRouter.routeToNodes()` also get the group link from the cache despite having access to the `TriggerRouter`, so I figured the new method should follow the same pattern.