### PR TITLE
SYM-7246: Made the internal transport fetch the suspended/ignored channels from the target node during a push

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/transport/internal/InternalOutgoingWithResponseTransport.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/transport/internal/InternalOutgoingWithResponseTransport.java
@@ -37,11 +37,17 @@ public class InternalOutgoingWithResponseTransport implements IOutgoingWithRespo
     BufferedReader reader = null;
     OutputStream os = null;
     boolean open = true;
+    NodeChannels nodeChannels = null;
 
     public InternalOutgoingWithResponseTransport(OutputStream os, InputStream respIs) {
+        this(os, respIs, null);
+    }
+
+    public InternalOutgoingWithResponseTransport(OutputStream os, InputStream respIs, NodeChannels nodeChannels) {
         this.os = os;
         this.writer = TransportUtils.toWriter(os);
         this.reader = TransportUtils.toReader(respIs);
+        this.nodeChannels = nodeChannels;
     }
 
     public OutputStream openStream() {
@@ -94,6 +100,14 @@ public class InternalOutgoingWithResponseTransport implements IOutgoingWithRespo
     }
 
     public NodeChannels getSuspendIgnoreChannelLists(IConfigurationService configurationService, String queue, Node targetNode) {
-        return configurationService.getSuspendIgnoreChannelLists();
+        NodeChannels suspendIgnoreChannelsList = new NodeChannels();
+        if (nodeChannels != null) {
+            suspendIgnoreChannelsList.addSuspendChannels(nodeChannels.getSuspendChannels());
+            suspendIgnoreChannelsList.addIgnoreChannels(nodeChannels.getIgnoreChannels());
+        }
+        NodeChannels localSuspendIgnoreChannelsList = configurationService.getSuspendIgnoreChannelLists();
+        suspendIgnoreChannelsList.addSuspendChannels(localSuspendIgnoreChannelsList.getSuspendChannels());
+        suspendIgnoreChannelsList.addIgnoreChannels(localSuspendIgnoreChannelsList.getIgnoreChannels());
+        return suspendIgnoreChannelsList;
     }
 }

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/transport/internal/InternalTransportManager.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/transport/internal/InternalTransportManager.java
@@ -241,6 +241,11 @@ public class InternalTransportManager extends AbstractTransportManager implement
     @Override
     public IOutgoingWithResponseTransport getPushTransport(final Node remote, final Node local, String securityToken,
             Map<String, String> requestProperties, String registrationUrl) throws IOException {
+        ISymmetricEngine targetEngine = getTargetEngine(remote.getSyncUrl());
+        NodeChannels remoteNodeChannels = null;
+        if (targetEngine != null) {
+            remoteNodeChannels = targetEngine.getConfigurationService().getSuspendIgnoreChannelLists(local.getNodeId());
+        }
         final PipedOutputStream pushOs = new PipedOutputStream();
         final PipedInputStream pushIs = new PipedInputStream(pushOs);
         final PipedOutputStream respOs = new PipedOutputStream();
@@ -254,7 +259,7 @@ public class InternalTransportManager extends AbstractTransportManager implement
                 log.debug("Internal push completed for {}", local.getNodeId());
             }
         });
-        return new InternalOutgoingWithResponseTransport(pushOs, respIs);
+        return new InternalOutgoingWithResponseTransport(pushOs, respIs, remoteNodeChannels);
     }
 
     protected void handlePush(ISymmetricEngine engine, Node local, String channelQueue, InputStream is, OutputStream os) throws IOException {

--- a/symmetric-core/src/test/java/org/jumpmind/symmetric/transport/internal/InternalOutgoingWithResponseTransportTest.java
+++ b/symmetric-core/src/test/java/org/jumpmind/symmetric/transport/internal/InternalOutgoingWithResponseTransportTest.java
@@ -1,0 +1,240 @@
+/**
+ * Licensed to JumpMind Inc under one or more contributor
+ * license agreements.  See the NOTICE file distributed
+ * with this work for additional information regarding
+ * copyright ownership.  JumpMind Inc licenses this file
+ * to you under the GNU General Public License, version 3.0 (GPLv3)
+ * (the "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3.0 (GPLv3) along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jumpmind.symmetric.transport.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import org.jumpmind.symmetric.model.Node;
+import org.jumpmind.symmetric.model.NodeChannels;
+import org.jumpmind.symmetric.service.IConfigurationService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class InternalOutgoingWithResponseTransportTest {
+    private ByteArrayOutputStream outputStream;
+    private ByteArrayInputStream responseInputStream;
+    private IConfigurationService configurationService;
+    private Node targetNode;
+
+    @BeforeEach
+    void setUp() {
+        outputStream = new ByteArrayOutputStream();
+        responseInputStream = new ByteArrayInputStream("response".getBytes());
+        configurationService = mock(IConfigurationService.class);
+        targetNode = mock(Node.class);
+        when(targetNode.getNodeId()).thenReturn("target-001");
+    }
+
+    @Test
+    void testConstructorWithTwoArgs() {
+        InternalOutgoingWithResponseTransport transport = new InternalOutgoingWithResponseTransport(outputStream, responseInputStream);
+        assertNotNull(transport);
+        assertTrue(transport.isOpen());
+    }
+
+    @Test
+    void testConstructorWithThreeArgs() {
+        NodeChannels nodeChannels = new NodeChannels();
+        InternalOutgoingWithResponseTransport transport = new InternalOutgoingWithResponseTransport(outputStream, responseInputStream, nodeChannels);
+        assertNotNull(transport);
+        assertTrue(transport.isOpen());
+    }
+
+    @Test
+    void testConstructorWithNullNodeChannels() {
+        InternalOutgoingWithResponseTransport transport = new InternalOutgoingWithResponseTransport(outputStream, responseInputStream, null);
+        assertNotNull(transport);
+        assertTrue(transport.isOpen());
+    }
+
+    @Test
+    void testGetSuspendIgnoreChannelLists_withNullNodeChannels_returnsLocalConfigOnly() {
+        NodeChannels localChannels = new NodeChannels();
+        localChannels.addSuspendChannels("target-001", "channel1");
+        localChannels.addIgnoreChannels("target-001", "channel2");
+        when(configurationService.getSuspendIgnoreChannelLists()).thenReturn(localChannels);
+        InternalOutgoingWithResponseTransport transport = new InternalOutgoingWithResponseTransport(outputStream, responseInputStream);
+        NodeChannels result = transport.getSuspendIgnoreChannelLists(configurationService, "default", targetNode);
+        assertNotNull(result);
+        assertEquals("channel1", result.getSuspendChannelsAsString("target-001"));
+        assertEquals("channel2", result.getIgnoreChannelsAsString("target-001"));
+    }
+
+    @Test
+    void testGetSuspendIgnoreChannelLists_withRemoteNodeChannels_combinesBothConfigs() {
+        NodeChannels remoteChannels = new NodeChannels();
+        remoteChannels.addSuspendChannels("target-001", "remoteChannel1");
+        remoteChannels.addIgnoreChannels("target-001", "remoteChannel2");
+        NodeChannels localChannels = new NodeChannels();
+        localChannels.addSuspendChannels("target-001", "localChannel1");
+        localChannels.addIgnoreChannels("target-001", "localChannel2");
+        when(configurationService.getSuspendIgnoreChannelLists()).thenReturn(localChannels);
+        InternalOutgoingWithResponseTransport transport = new InternalOutgoingWithResponseTransport(outputStream, responseInputStream, remoteChannels);
+        NodeChannels result = transport.getSuspendIgnoreChannelLists(configurationService, "default", targetNode);
+        assertNotNull(result);
+        String suspendChannels = result.getSuspendChannelsAsString("target-001");
+        assertTrue(suspendChannels.contains("remoteChannel1"));
+        assertTrue(suspendChannels.contains("localChannel1"));
+        String ignoreChannels = result.getIgnoreChannelsAsString("target-001");
+        assertTrue(ignoreChannels.contains("remoteChannel2"));
+        assertTrue(ignoreChannels.contains("localChannel2"));
+    }
+
+    @Test
+    void testGetSuspendIgnoreChannelLists_remoteOnlySuspend() {
+        NodeChannels remoteChannels = new NodeChannels();
+        remoteChannels.addSuspendChannels("target-001", "remoteSuspend");
+        NodeChannels localChannels = new NodeChannels();
+        when(configurationService.getSuspendIgnoreChannelLists()).thenReturn(localChannels);
+        InternalOutgoingWithResponseTransport transport = new InternalOutgoingWithResponseTransport(outputStream, responseInputStream, remoteChannels);
+        NodeChannels result = transport.getSuspendIgnoreChannelLists(configurationService, "default", targetNode);
+        assertEquals("remoteSuspend", result.getSuspendChannelsAsString("target-001"));
+        assertEquals("", result.getIgnoreChannelsAsString("target-001"));
+    }
+
+    @Test
+    void testGetSuspendIgnoreChannelLists_localOnlySuspend() {
+        NodeChannels remoteChannels = new NodeChannels();
+        NodeChannels localChannels = new NodeChannels();
+        localChannels.addSuspendChannels("target-001", "localSuspend");
+        when(configurationService.getSuspendIgnoreChannelLists()).thenReturn(localChannels);
+        InternalOutgoingWithResponseTransport transport = new InternalOutgoingWithResponseTransport(outputStream, responseInputStream, remoteChannels);
+        NodeChannels result = transport.getSuspendIgnoreChannelLists(configurationService, "default", targetNode);
+        assertEquals("localSuspend", result.getSuspendChannelsAsString("target-001"));
+    }
+
+    @Test
+    void testGetSuspendIgnoreChannelLists_remoteOnlyIgnore() {
+        NodeChannels remoteChannels = new NodeChannels();
+        remoteChannels.addIgnoreChannels("target-001", "remoteIgnore");
+        NodeChannels localChannels = new NodeChannels();
+        when(configurationService.getSuspendIgnoreChannelLists()).thenReturn(localChannels);
+        InternalOutgoingWithResponseTransport transport = new InternalOutgoingWithResponseTransport(outputStream, responseInputStream, remoteChannels);
+        NodeChannels result = transport.getSuspendIgnoreChannelLists(configurationService, "default", targetNode);
+        assertEquals("", result.getSuspendChannelsAsString("target-001"));
+        assertEquals("remoteIgnore", result.getIgnoreChannelsAsString("target-001"));
+    }
+
+    @Test
+    void testGetSuspendIgnoreChannelLists_localOnlyIgnore() {
+        NodeChannels remoteChannels = new NodeChannels();
+        NodeChannels localChannels = new NodeChannels();
+        localChannels.addIgnoreChannels("target-001", "localIgnore");
+        when(configurationService.getSuspendIgnoreChannelLists()).thenReturn(localChannels);
+        InternalOutgoingWithResponseTransport transport = new InternalOutgoingWithResponseTransport(outputStream, responseInputStream, remoteChannels);
+        NodeChannels result = transport.getSuspendIgnoreChannelLists(configurationService, "default", targetNode);
+        assertEquals("localIgnore", result.getIgnoreChannelsAsString("target-001"));
+    }
+
+    @Test
+    void testGetSuspendIgnoreChannelLists_emptyBothConfigs() {
+        NodeChannels remoteChannels = new NodeChannels();
+        NodeChannels localChannels = new NodeChannels();
+        when(configurationService.getSuspendIgnoreChannelLists()).thenReturn(localChannels);
+        InternalOutgoingWithResponseTransport transport = new InternalOutgoingWithResponseTransport(outputStream, responseInputStream, remoteChannels);
+        NodeChannels result = transport.getSuspendIgnoreChannelLists(configurationService, "default", targetNode);
+        assertNotNull(result);
+        assertEquals("", result.getSuspendChannelsAsString("target-001"));
+        assertEquals("", result.getIgnoreChannelsAsString("target-001"));
+    }
+
+    @Test
+    void testGetSuspendIgnoreChannelLists_multipleChannelsFromRemote() {
+        NodeChannels remoteChannels = new NodeChannels();
+        remoteChannels.addSuspendChannels("target-001", "channel1,channel2,channel3");
+        NodeChannels localChannels = new NodeChannels();
+        when(configurationService.getSuspendIgnoreChannelLists()).thenReturn(localChannels);
+        InternalOutgoingWithResponseTransport transport = new InternalOutgoingWithResponseTransport(outputStream, responseInputStream, remoteChannels);
+        NodeChannels result = transport.getSuspendIgnoreChannelLists(configurationService, "default", targetNode);
+        String suspendChannels = result.getSuspendChannelsAsString("target-001");
+        assertTrue(suspendChannels.contains("channel1"));
+        assertTrue(suspendChannels.contains("channel2"));
+        assertTrue(suspendChannels.contains("channel3"));
+    }
+
+    @Test
+    void testOpenStream() {
+        InternalOutgoingWithResponseTransport transport = new InternalOutgoingWithResponseTransport(outputStream, responseInputStream);
+        assertEquals(outputStream, transport.openStream());
+    }
+
+    @Test
+    void testOpenWriter() {
+        InternalOutgoingWithResponseTransport transport = new InternalOutgoingWithResponseTransport(outputStream, responseInputStream);
+        assertNotNull(transport.openWriter());
+    }
+
+    @Test
+    void testGetWriter() {
+        InternalOutgoingWithResponseTransport transport = new InternalOutgoingWithResponseTransport(outputStream, responseInputStream);
+        assertNotNull(transport.getWriter());
+        assertEquals(transport.openWriter(), transport.getWriter());
+    }
+
+    @Test
+    void testReadResponse() throws IOException {
+        InternalOutgoingWithResponseTransport transport = new InternalOutgoingWithResponseTransport(outputStream, responseInputStream);
+        assertNotNull(transport.readResponse());
+    }
+
+    @Test
+    void testClose() {
+        InternalOutgoingWithResponseTransport transport = new InternalOutgoingWithResponseTransport(outputStream, responseInputStream);
+        assertTrue(transport.isOpen());
+        transport.close();
+        assertFalse(transport.isOpen());
+    }
+
+    @Test
+    void testIsOpen_afterConstruction() {
+        InternalOutgoingWithResponseTransport transport = new InternalOutgoingWithResponseTransport(outputStream, responseInputStream);
+        assertTrue(transport.isOpen());
+    }
+
+    @Test
+    void testIsOpen_afterClose() {
+        InternalOutgoingWithResponseTransport transport = new InternalOutgoingWithResponseTransport(outputStream, responseInputStream);
+        transport.close();
+        assertFalse(transport.isOpen());
+    }
+
+    @Test
+    void testGetSuspendIgnoreChannelLists_differentTargetNodeId() {
+        NodeChannels remoteChannels = new NodeChannels();
+        remoteChannels.addSuspendChannels("other-node", "channel1");
+        remoteChannels.addSuspendChannels("target-001", "channel2");
+        NodeChannels localChannels = new NodeChannels();
+        when(configurationService.getSuspendIgnoreChannelLists()).thenReturn(localChannels);
+        InternalOutgoingWithResponseTransport transport = new InternalOutgoingWithResponseTransport(outputStream, responseInputStream, remoteChannels);
+        NodeChannels result = transport.getSuspendIgnoreChannelLists(configurationService, "default", targetNode);
+        assertEquals("channel2", result.getSuspendChannelsAsString("target-001"));
+        assertEquals("channel1", result.getSuspendChannelsAsString("other-node"));
+    }
+}

--- a/symmetric-core/src/test/java/org/jumpmind/symmetric/transport/internal/InternalTransportManagerTest.java
+++ b/symmetric-core/src/test/java/org/jumpmind/symmetric/transport/internal/InternalTransportManagerTest.java
@@ -404,6 +404,8 @@ public class InternalTransportManagerTest {
 
     @Test
     void testGetPushTransport_returnsOutgoingWithResponseTransport() throws IOException {
+        when(configurationService.getSuspendIgnoreChannelLists(anyString())).thenReturn(new NodeChannels());
+        doReturn(targetEngine).when(manager).getTargetEngine(anyString());
         doNothing().when(manager).runAtClient(anyString(), any(), any(), any());
         IOutgoingWithResponseTransport transport = manager.getPushTransport(remoteNode, localNode, "token", "http://reg");
         assertNotNull(transport);
@@ -412,12 +414,53 @@ public class InternalTransportManagerTest {
 
     @Test
     void testGetPushTransport_withRequestProperties() throws IOException {
+        when(configurationService.getSuspendIgnoreChannelLists(anyString())).thenReturn(new NodeChannels());
+        doReturn(targetEngine).when(manager).getTargetEngine(anyString());
         doNothing().when(manager).runAtClient(anyString(), any(), any(), any());
         Map<String, String> requestProperties = new HashMap<String, String>();
         requestProperties.put(WebConstants.CHANNEL_QUEUE, "custom-queue");
         IOutgoingWithResponseTransport transport = manager.getPushTransport(remoteNode, localNode, "token", requestProperties, "http://reg");
         assertNotNull(transport);
         assertInstanceOf(InternalOutgoingWithResponseTransport.class, transport);
+    }
+
+    @Test
+    void testGetPushTransport_fetchesRemoteSuspendIgnoreConfig() throws IOException {
+        NodeChannels remoteNodeChannels = new NodeChannels();
+        remoteNodeChannels.addSuspendChannels("local-001", "suspended-channel");
+        when(configurationService.getSuspendIgnoreChannelLists(eq("local-001"))).thenReturn(remoteNodeChannels);
+        doReturn(targetEngine).when(manager).getTargetEngine(anyString());
+        doNothing().when(manager).runAtClient(anyString(), any(), any(), any());
+        IOutgoingWithResponseTransport transport = manager.getPushTransport(remoteNode, localNode, "token", "http://reg");
+        assertNotNull(transport);
+        assertInstanceOf(InternalOutgoingWithResponseTransport.class, transport);
+        verify(configurationService).getSuspendIgnoreChannelLists(eq("local-001"));
+    }
+
+    @Test
+    void testGetPushTransport_combinesRemoteAndLocalSuspendIgnoreConfig() throws IOException {
+        NodeChannels remoteNodeChannels = new NodeChannels();
+        remoteNodeChannels.addSuspendChannels("local-001", "remote-suspend");
+        remoteNodeChannels.addIgnoreChannels("local-001", "remote-ignore");
+        when(configurationService.getSuspendIgnoreChannelLists(eq("local-001"))).thenReturn(remoteNodeChannels);
+        NodeChannels localNodeChannels = new NodeChannels();
+        localNodeChannels.addSuspendChannels("local-001", "local-suspend");
+        localNodeChannels.addIgnoreChannels("local-001", "local-ignore");
+        when(configurationService.getSuspendIgnoreChannelLists()).thenReturn(localNodeChannels);
+        when(engine.getConfigurationService()).thenReturn(configurationService);
+        doReturn(targetEngine).when(manager).getTargetEngine(anyString());
+        doNothing().when(manager).runAtClient(anyString(), any(), any(), any());
+        IOutgoingWithResponseTransport transport = manager.getPushTransport(remoteNode, localNode, "token", "http://reg");
+        assertNotNull(transport);
+        Node mockTargetNode = mock(Node.class);
+        when(mockTargetNode.getNodeId()).thenReturn("local-001");
+        NodeChannels combined = transport.getSuspendIgnoreChannelLists(configurationService, "default", mockTargetNode);
+        String suspendChannels = combined.getSuspendChannelsAsString("local-001");
+        String ignoreChannels = combined.getIgnoreChannelsAsString("local-001");
+        assertTrue(suspendChannels.contains("remote-suspend"));
+        assertTrue(suspendChannels.contains("local-suspend"));
+        assertTrue(ignoreChannels.contains("remote-ignore"));
+        assertTrue(ignoreChannels.contains("local-ignore"));
     }
 
     @Test


### PR DESCRIPTION
This fixes the `SimpleIntegrationTest` failure.