### PR TITLE
SYM-7206: Fixed NullPointerException in the JDBC bulk loader

### DIFF
--- a/symmetric-client/src/main/java/org/jumpmind/symmetric/io/JdbcBatchBulkDatabaseWriter.java
+++ b/symmetric-client/src/main/java/org/jumpmind/symmetric/io/JdbcBatchBulkDatabaseWriter.java
@@ -217,8 +217,14 @@ public class JdbcBatchBulkDatabaseWriter extends AbstractBulkDatabaseWriter {
             }
         }
         super.end(batch, inError);
-        String batchInfo = String.format("batch=%d, Table=%s, Rows=%d, Rows per second=%.1f",
-                batch.getBatchId(), targetTable.getName(), totalCommittedRows, getRowsPerSecond());
+        String batchInfo;
+        if (targetTable != null) {
+            batchInfo = String.format("batch=%d, Table=%s, Rows=%d, Rows per second=%.1f",
+                    batch.getBatchId(), targetTable.getName(), totalCommittedRows, getRowsPerSecond());
+        } else {
+            batchInfo = String.format("batch=%d, Rows=%d, Rows per second=%.1f",
+                    batch.getBatchId(), totalCommittedRows, getRowsPerSecond());
+        }
         log.info("Batch committed. " + batchInfo);
     }
 


### PR DESCRIPTION
I encountered the below `NullPointerException` when sending a JDBC bulk load that created target tables. Let me know if there's anything different I should do with the logging when `targetTable` is `null`.

```
2026-02-05 09:56:22,259 ERROR [server] [ManageIncomingBatchListener] [server-dataloader-3] Failed to load batch client-47 StackTraceKey.init [NullPointerException:3673685055] java.lang.NullPointerException: Cannot invoke "org.jumpmind.db.model.Table.getName()" because "this.targetTable" is null
	at org.jumpmind.symmetric.io.JdbcBatchBulkDatabaseWriter.end(JdbcBatchBulkDatabaseWriter.java:221)
	at org.jumpmind.symmetric.io.data.writer.NestedDataWriter.end(NestedDataWriter.java:70)
	at org.jumpmind.symmetric.model.ProcessInfoDataWriter.end(ProcessInfoDataWriter.java:91)
	at org.jumpmind.symmetric.io.data.writer.NestedDataWriter.end(NestedDataWriter.java:70)
	at org.jumpmind.symmetric.io.data.DataProcessor.process(DataProcessor.java:120)
	at org.jumpmind.symmetric.service.impl.DataLoaderService$LoadIntoDatabaseOnArrivalListener$2.call(DataLoaderService.java:1109)
	at org.jumpmind.symmetric.service.impl.DataLoaderService$LoadIntoDatabaseOnArrivalListener$2.call(DataLoaderService.java:1082)
	...
```