### PR TITLE
SYM-7327: Extra time for HARD reservations to call releaseConnection

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/transport/ConcurrentConnectionManager.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/transport/ConcurrentConnectionManager.java
@@ -74,21 +74,21 @@ public class ConcurrentConnectionManager implements IConcurrentConnectionManager
         return stats;
     }
 
+    @Override
     public synchronized boolean releaseConnection(String nodeId, String channelId, String poolId) {
         String reservationId = getReservationIdentifier(nodeId, channelId);
-        log.debug("Releasing connection for {} {}", poolId, reservationId);
+
         Map<String, Reservation> reservations = getReservationMap(poolId);
         Reservation reservation = reservations.remove(reservationId);
         if (reservation != null) {
-            logConnectedTimePeriod(reservationId, reservation.createTime, System.currentTimeMillis(),
-                    poolId);
+            logConnectedTimePeriod(reservationId, reservation.createTime, System.currentTimeMillis(),                    poolId);
             return true;
         } else {
-            log.warn("Failed to release connection for {}", reservationId);
             return false;
         }
     }
 
+    @Override
     public synchronized boolean releaseConnection(String nodeId, String poolId) {
         Map<String, Reservation> reservations = getReservationMap(poolId);
         Reservation reservation = reservations.remove(nodeId);
@@ -101,22 +101,27 @@ public class ConcurrentConnectionManager implements IConcurrentConnectionManager
         }
     }
 
+    @Override
     public synchronized void addToWhitelist(String nodeId) {
         whiteList.add(nodeId);
     }
 
+    @Override
     public synchronized void removeFromWhiteList(String nodeId) {
         whiteList.remove(nodeId);
     }
 
+    @Override
     public synchronized String[] getWhiteList() {
         return whiteList.toArray(new String[whiteList.size()]);
     }
 
+    @Override
     public synchronized int getReservationCount(String poolId) {
         return getReservationMap(poolId).size();
     }
 
+    @Override
     public synchronized ReservationStatus reserveConnection(String nodeId, String channelId, String poolId,
             ReservationType reservationRequest, boolean requiresExistingReservation) {
         String reservationId = getReservationIdentifier(nodeId, channelId);
@@ -136,9 +141,11 @@ public class ConcurrentConnectionManager implements IConcurrentConnectionManager
             return ReservationStatus.NOT_FOUND;
         } else if (reservations.size() < maxPoolSize || existingReservation != null || whiteList.contains(nodeId)) {
             if (existingReservation == null || existingReservation.getType() == ReservationType.SOFT) {
-                reservations.put(reservationId, new Reservation(reservationId,
-                        reservationRequest == ReservationType.SOFT ? System.currentTimeMillis()
-                                + timeout : Long.MAX_VALUE, reservationRequest));
+                long reservationExpiration = System.currentTimeMillis() + timeout;
+                if (reservationRequest != ReservationType.SOFT) {
+                    reservationExpiration += timeout; // Allow HARD reservations extra time to call releaseConnection() gracefully
+                }
+                reservations.put(reservationId, new Reservation(reservationId, reservationExpiration, reservationRequest));
                 transportErrorTimeByNode.remove(nodeId);
                 return ReservationStatus.ACCEPTED;
             } else {
@@ -155,10 +162,12 @@ public class ConcurrentConnectionManager implements IConcurrentConnectionManager
         }
     }
 
+    @Override
     public Map<String, Date> getPullReservationsByNodeId() {
         return getReservationsByNodeId("pull");
     }
 
+    @Override
     public Map<String, Date> getPushReservationsByNodeId() {
         return getReservationsByNodeId("push");
     }
@@ -265,6 +274,7 @@ public class ConcurrentConnectionManager implements IConcurrentConnectionManager
         return channelId == null || channelId.equals("0") ? nodeId : nodeId + "-" + channelId;
     }
 
+    @Override
     public Map<String, Map<String, NodeConnectionStatistics>> getNodeConnectionStatisticsByPoolByNodeId() {
         return this.nodeConnectionStatistics;
     }
@@ -302,6 +312,7 @@ public class ConcurrentConnectionManager implements IConcurrentConnectionManager
         }
     }
 
+    @Override
     public Map<String, Map<String, Reservation>> getActiveReservationsByNodeByPool() {
         return activeReservationsByNodeByPool;
     }

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/transport/ConcurrentConnectionManager.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/transport/ConcurrentConnectionManager.java
@@ -77,11 +77,10 @@ public class ConcurrentConnectionManager implements IConcurrentConnectionManager
     @Override
     public synchronized boolean releaseConnection(String nodeId, String channelId, String poolId) {
         String reservationId = getReservationIdentifier(nodeId, channelId);
-
         Map<String, Reservation> reservations = getReservationMap(poolId);
         Reservation reservation = reservations.remove(reservationId);
         if (reservation != null) {
-            logConnectedTimePeriod(reservationId, reservation.createTime, System.currentTimeMillis(),                    poolId);
+            logConnectedTimePeriod(reservationId, reservation.createTime, System.currentTimeMillis(), poolId);
             return true;
         } else {
             return false;

--- a/symmetric-server/src/main/java/org/jumpmind/symmetric/web/NodeConcurrencyInterceptor.java
+++ b/symmetric-server/src/main/java/org/jumpmind/symmetric/web/NodeConcurrencyInterceptor.java
@@ -22,11 +22,6 @@ package org.jumpmind.symmetric.web;
 
 import java.io.IOException;
 
-import jakarta.servlet.ServletException;
-import jakarta.servlet.ServletResponse;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-
 import org.apache.commons.lang3.StringUtils;
 import org.jumpmind.symmetric.model.ChannelMap;
 import org.jumpmind.symmetric.model.NodeSecurity;
@@ -38,6 +33,11 @@ import org.jumpmind.symmetric.transport.IConcurrentConnectionManager.Reservation
 import org.jumpmind.symmetric.transport.IConcurrentConnectionManager.ReservationType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * An intercepter that controls access to this node for pushes and pulls. It is configured within symmetric-web.xml
@@ -57,6 +57,7 @@ public class NodeConcurrencyInterceptor implements IInterceptor {
         this.statisticManager = statisticManager;
     }
 
+    @Override
     public boolean before(HttpServletRequest req, HttpServletResponse resp) throws IOException,
             ServletException {
         String poolId = req.getRequestURI();
@@ -73,8 +74,12 @@ public class NodeConcurrencyInterceptor implements IInterceptor {
                 try {
                     buildSuspendIgnoreResponseHeaders(nodeId, resp);
                 } catch (Exception ex) {
-                    concurrentConnectionManager.releaseConnection(nodeId, threadChannel, poolId);
                     log.error("Error building response headers", ex);
+                    log.debug("Releasing reservation for node={}, pool={}, channel={}", nodeId, poolId, threadChannel);
+                    if (!concurrentConnectionManager.releaseConnection(nodeId, threadChannel, poolId)) {
+                        log.warn("Failed to locate connection reservation (to release it) for node={}, pool={}, channel={}", nodeId, poolId,
+                                threadChannel);
+                    }
                     ServletUtils.sendError(resp, WebConstants.SC_SERVICE_ERROR);
                 }
             } else {
@@ -113,8 +118,12 @@ public class NodeConcurrencyInterceptor implements IInterceptor {
                     buildSuspendIgnoreResponseHeaders(nodeId, resp);
                     return true;
                 } catch (Exception ex) {
-                    concurrentConnectionManager.releaseConnection(nodeId, threadChannel, poolId);
                     log.error("Error building response headers", ex);
+                    log.debug("Releasing reservation for node={}, pool={}, channel={}", nodeId, poolId, threadChannel);
+                    if (!concurrentConnectionManager.releaseConnection(nodeId, threadChannel, poolId)) {
+                        log.warn("Failed to locate connection reservation (to release it) for node={}, pool={}, channel={}", nodeId, poolId,
+                                threadChannel);
+                    }
                     ServletUtils.sendError(resp, WebConstants.SC_SERVICE_ERROR);
                     return false;
                 }
@@ -151,12 +160,16 @@ public class NodeConcurrencyInterceptor implements IInterceptor {
         return nodeId;
     }
 
+    @Override
     public void after(HttpServletRequest req, HttpServletResponse resp) throws IOException,
             ServletException {
         String poolId = req.getRequestURI();
         String nodeId = getNodeId(req);
         String threadChannel = req.getHeader(WebConstants.CHANNEL_QUEUE);
-        concurrentConnectionManager.releaseConnection(nodeId, threadChannel, poolId);
+        log.debug("Releasing reservation for node={}, pool={}, channel={}", nodeId, poolId, threadChannel);
+        if (!concurrentConnectionManager.releaseConnection(nodeId, threadChannel, poolId)) {
+            log.warn("Failed to locate connection reservation (to release it) for node={}, pool={}, channel={}", nodeId, poolId, threadChannel);
+        }
     }
 
     protected void buildSuspendIgnoreResponseHeaders(final String nodeId, final ServletResponse resp) {


### PR DESCRIPTION
Allow HARD reservations extra time to call releaseConnection(), gracefully. 
Move all logging out of the synchronized method, to accelerate execution, to minimize time the lock is held (deadlocks).