### PR TITLE
SYM-7346: Fix DB2 LUW platform bugs

### DIFF
--- a/symmetric-assemble/common.gradle
+++ b/symmetric-assemble/common.gradle
@@ -131,6 +131,9 @@ subprojects { subproject ->
     }
 
 	java {
+		toolchain {
+    		languageVersion = JavaLanguageVersion.of(17)
+    	}
     	sourceCompatibility=JavaVersion.VERSION_17
     	targetCompatibility=JavaVersion.VERSION_17
     }
@@ -345,13 +348,13 @@ subprojects { subproject ->
         powerMockVersion = '2.0.9'
         mysqlVersion = '8.4.0'
         servletVersion = '4.0.1'
-        springVersion = '6.2.11'
-        springBootVersion = '3.5.5'
+        springVersion = '6.2.15'
+        springBootVersion = '3.5.9'
         jtdsVersion = '1.3.1'
         bouncyCastleVersion = '1.81'
         animalSnifferVersion = '1.23'
         jnaVersion = '5.14.0'
-        jettyVersion = '12.0.25'
+        jettyVersion = '12.0.31'
         websocketVersion = '2.2.0'
         env = System.getenv()
     }

--- a/symmetric-assemble/common.gradle
+++ b/symmetric-assemble/common.gradle
@@ -233,37 +233,36 @@ subprojects { subproject ->
 			sign publishing.publications.symmetricLibrary
 		}
 
-        // Commented out for local build - not needed for development
-        // apply plugin: 'eu.kakde.gradle.sonatype-maven-central-publisher'
-        //
-        // def licenseName = project.name.contains("-pro") ? "Commercial" : "GNU GPL version 3.0";
-        // sonatypeCentralPublishExtension {
-        //     groupId.set("${project.group}")
-        //     artifactId.set("${project.name}")
-        //     version.set("${project.version}")
-        //     componentType.set("java")
-        //     publishingType.set("AUTOMATIC")
-        //     username.set(getProperty("sonatypeUser"))
-        //     password.set(getProperty("sonatypePassword"))
-        //     pom {
-        //         name.set("${project.name}")
-        //         description.set("Data replication")
-        //         url.set("https://symmetricds.org/")
-        //         licenses {
-        //             license {
-        //                 name.set(licenseName)
-        //             }
-        //         }
-        //         developers {
-        //             developer {
-        //                 name.set("Jumpmind")
-        //             }
-        //         }
-        //         scm {
-        //             url.set("https://github.com/jumpmindinc/symmetric-ds/")
-        //         }
-        //     }
-        // }
+        apply plugin: 'eu.kakde.gradle.sonatype-maven-central-publisher'
+
+        def licenseName = project.name.contains("-pro") ? "Commercial" : "GNU GPL version 3.0";
+        sonatypeCentralPublishExtension {
+            groupId.set("${project.group}")
+            artifactId.set("${project.name}")
+            version.set("${project.version}")
+            componentType.set("java")
+            publishingType.set("AUTOMATIC")
+            username.set(getProperty("sonatypeUser"))
+            password.set(getProperty("sonatypePassword"))
+            pom {
+                name.set("${project.name}")
+                description.set("Data replication")
+                url.set("https://symmetricds.org/")
+                licenses {
+                    license {
+                        name.set(licenseName)
+                    }
+                }
+                developers {
+                    developer {
+                        name.set("Jumpmind")
+                    }
+                }
+                scm {
+                    url.set("https://github.com/jumpmindinc/symmetric-ds/")
+                }
+            }
+        }
     }
 
     task deploy {

--- a/symmetric-assemble/common.gradle
+++ b/symmetric-assemble/common.gradle
@@ -131,9 +131,6 @@ subprojects { subproject ->
     }
 
 	java {
-		toolchain {
-    		languageVersion = JavaLanguageVersion.of(17)
-    	}
     	sourceCompatibility=JavaVersion.VERSION_17
     	targetCompatibility=JavaVersion.VERSION_17
     }
@@ -236,36 +233,37 @@ subprojects { subproject ->
 			sign publishing.publications.symmetricLibrary
 		}
 
-        apply plugin: 'eu.kakde.gradle.sonatype-maven-central-publisher'
-
-        def licenseName = project.name.contains("-pro") ? "Commercial" : "GNU GPL version 3.0";
-        sonatypeCentralPublishExtension {
-            groupId.set("${project.group}")
-            artifactId.set("${project.name}")
-            version.set("${project.version}")
-            componentType.set("java")
-            publishingType.set("AUTOMATIC")
-            username.set(getProperty("sonatypeUser"))
-            password.set(getProperty("sonatypePassword"))
-            pom {
-                name.set("${project.name}")
-                description.set("Data replication")
-                url.set("https://symmetricds.org/")
-                licenses {
-                    license {
-                        name.set(licenseName)
-                    }
-                }
-                developers {
-                    developer {
-                        name.set("Jumpmind")
-                    }
-                }
-                scm {
-                    url.set("https://github.com/jumpmindinc/symmetric-ds/")
-                }
-            }
-        }
+        // Commented out for local build - not needed for development
+        // apply plugin: 'eu.kakde.gradle.sonatype-maven-central-publisher'
+        //
+        // def licenseName = project.name.contains("-pro") ? "Commercial" : "GNU GPL version 3.0";
+        // sonatypeCentralPublishExtension {
+        //     groupId.set("${project.group}")
+        //     artifactId.set("${project.name}")
+        //     version.set("${project.version}")
+        //     componentType.set("java")
+        //     publishingType.set("AUTOMATIC")
+        //     username.set(getProperty("sonatypeUser"))
+        //     password.set(getProperty("sonatypePassword"))
+        //     pom {
+        //         name.set("${project.name}")
+        //         description.set("Data replication")
+        //         url.set("https://symmetricds.org/")
+        //         licenses {
+        //             license {
+        //                 name.set(licenseName)
+        //             }
+        //         }
+        //         developers {
+        //             developer {
+        //                 name.set("Jumpmind")
+        //             }
+        //         }
+        //         scm {
+        //             url.set("https://github.com/jumpmindinc/symmetric-ds/")
+        //         }
+        //     }
+        // }
     }
 
     task deploy {
@@ -348,13 +346,13 @@ subprojects { subproject ->
         powerMockVersion = '2.0.9'
         mysqlVersion = '8.4.0'
         servletVersion = '4.0.1'
-        springVersion = '6.2.15'
-        springBootVersion = '3.5.9'
+        springVersion = '6.2.11'
+        springBootVersion = '3.5.5'
         jtdsVersion = '1.3.1'
         bouncyCastleVersion = '1.81'
         animalSnifferVersion = '1.23'
         jnaVersion = '5.14.0'
-        jettyVersion = '12.0.31'
+        jettyVersion = '12.0.25'
         websocketVersion = '2.2.0'
         env = System.getenv()
     }

--- a/symmetric-client/src/main/java/org/jumpmind/symmetric/db/db2/Db2TriggerTemplate.java
+++ b/symmetric-client/src/main/java/org/jumpmind/symmetric/db/db2/Db2TriggerTemplate.java
@@ -20,11 +20,16 @@
  */
 package org.jumpmind.symmetric.db.db2;
 
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
 import java.util.HashMap;
 
 import org.jumpmind.db.model.Table;
 import org.jumpmind.symmetric.db.AbstractTriggerTemplate;
 import org.jumpmind.symmetric.db.ISymmetricDialect;
+import org.jumpmind.symmetric.model.TriggerHistory;
+import org.jumpmind.symmetric.util.SymmetricUtils;
 
 public class Db2TriggerTemplate extends AbstractTriggerTemplate {
     public Db2TriggerTemplate(ISymmetricDialect symmetricDialect) {
@@ -245,6 +250,31 @@ public class Db2TriggerTemplate extends AbstractTriggerTemplate {
                         "                                END                                                                                                                                                                    ");
         sqlTemplates.put("initialLoadSqlTemplate",
                 "select $(oracleToClob)$(columns) from $(schemaName)$(tableName) t where $(whereClause)                                                                                                                                ");
+    }
+
+    @Override
+    protected String getSourceTablePrefix(Table table) {
+        String prefix = isNotBlank(table.getSchema()) ? table.getSchema()
+                + symmetricDialect.getPlatform().getDatabaseInfo().getSchemaSeparator() : "";
+        if (isBlank(prefix)) {
+            prefix = isNotBlank(symmetricDialect.getPlatform().getDefaultSchema()) ? SymmetricUtils
+                    .quote(symmetricDialect, symmetricDialect.getPlatform().getDefaultSchema())
+                    + "." : "";
+        }
+        return prefix;
+    }
+
+    @Override
+    protected String getSourceTablePrefix(TriggerHistory triggerHistory) {
+        String schemaName = triggerHistory.getSourceSchemaName();
+        if (isBlank(schemaName)) {
+            schemaName = symmetricDialect.getPlatform().getDefaultSchema();
+        }
+        if (isNotBlank(schemaName)) {
+            return SymmetricUtils.quote(symmetricDialect, schemaName)
+                    + symmetricDialect.getPlatform().getDatabaseInfo().getSchemaSeparator();
+        }
+        return "";
     }
 
     protected String toClobExpression(Table table) {

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/db2/Db2DatabasePlatform.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/db2/Db2DatabasePlatform.java
@@ -108,7 +108,14 @@ public class Db2DatabasePlatform extends AbstractJdbcDatabasePlatform {
     }
 
     public String getDefaultCatalog() {
-        return "";
+        if (defaultCatalog == null) {
+            defaultCatalog = (String) getSqlTemplate().queryForObject(
+                    "VALUES CURRENT SERVER", String.class);
+            if (defaultCatalog != null) {
+                defaultCatalog = defaultCatalog.trim();
+            }
+        }
+        return defaultCatalog;
     }
 
     @Override

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/db2/Db2DatabasePlatform.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/db2/Db2DatabasePlatform.java
@@ -108,14 +108,7 @@ public class Db2DatabasePlatform extends AbstractJdbcDatabasePlatform {
     }
 
     public String getDefaultCatalog() {
-        if (defaultCatalog == null) {
-            defaultCatalog = (String) getSqlTemplate().queryForObject(
-                    "VALUES CURRENT SERVER", String.class);
-            if (defaultCatalog != null) {
-                defaultCatalog = defaultCatalog.trim();
-            }
-        }
-        return defaultCatalog;
+        return null;
     }
 
     @Override

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/db2/Db2DdlReader.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/db2/Db2DdlReader.java
@@ -63,6 +63,7 @@ import org.jumpmind.db.model.TypeMap;
 import org.jumpmind.db.platform.AbstractJdbcDdlReader;
 import org.jumpmind.db.platform.DatabaseMetaDataWrapper;
 import org.jumpmind.db.platform.IDatabasePlatform;
+import org.jumpmind.db.sql.IConnectionCallback;
 import org.jumpmind.db.sql.ISqlRowMapper;
 import org.jumpmind.db.sql.JdbcSqlTemplate;
 import org.jumpmind.db.sql.Row;
@@ -145,6 +146,13 @@ public class Db2DdlReader extends AbstractJdbcDdlReader {
     @Override
     protected Column readColumn(DatabaseMetaDataWrapper metaData, Map<String, Object> values)
             throws SQLException {
+        String columnName = (String) values.get("COLUMN_NAME");
+        if (columnName == null) {
+            String altName = (String) values.get("NAME");
+            if (altName != null) {
+                values.put("COLUMN_NAME", altName);
+            }
+        }
         Column column = super.readColumn(metaData, values);
         if (column.getDefaultValue() != null) {
             if (column.getMappedTypeCode() == Types.TIME) {
@@ -324,12 +332,84 @@ public class Db2DdlReader extends AbstractJdbcDdlReader {
         } else if (typeName != null && typeName.endsWith("CLOB")) {
             return Types.LONGVARCHAR;
         } else if (typeName != null && typeName.endsWith("LONG VARCHAR")) {
-            return Types.CLOB;
+            return Types.LONGVARCHAR;
         } else if (typeName != null && typeName.endsWith("XML")) {
             return Types.SQLXML;
         } else {
             return super.mapUnknownJdbcTypeForColumn(values);
         }
+    }
+
+    @Override
+    public List<String> getCatalogNames() {
+        JdbcSqlTemplate sqlTemplate = (JdbcSqlTemplate) platform.getSqlTemplateDirty();
+        return sqlTemplate.execute(new IConnectionCallback<List<String>>() {
+            public List<String> execute(Connection connection) throws SQLException {
+                List<String> catalogs = new ArrayList<String>();
+                java.sql.Statement stmt = null;
+                ResultSet rs = null;
+                try {
+                    stmt = connection.createStatement();
+                    rs = stmt.executeQuery("VALUES CURRENT SERVER");
+                    if (rs.next()) {
+                        String dbName = rs.getString(1);
+                        if (dbName != null) {
+                            catalogs.add(dbName.trim());
+                        }
+                    }
+                } finally {
+                    JdbcSqlTemplate.close(rs);
+                    if (stmt != null) {
+                        stmt.close();
+                    }
+                }
+                return catalogs;
+            }
+        });
+    }
+
+    @Override
+    protected Table readTableFromConnection(Connection connection, String catalog,
+            String schema, String table) throws SQLException {
+        return super.readTableFromConnection(connection, null, schema, table);
+    }
+
+    @Override
+    public List<String> getTableNames(String catalog, String schema, String[] tableTypes) {
+        return super.getTableNames(null, schema, tableTypes);
+    }
+
+    @Override
+    public List<String> getTableNamesFromDatabase(String catalog, String schema,
+            String[] tableTypes) {
+        return super.getTableNamesFromDatabase(null, schema, tableTypes);
+    }
+
+    @Override
+    protected void readForeignKey(DatabaseMetaDataWrapper metaData, Map<String, Object> values,
+            Map<String, ForeignKey> knownFks) throws SQLException {
+        String pkTableName = (String) values.get("PKTABLE_NAME");
+        if (pkTableName == null) {
+            String altName = (String) values.get("REFTBNAME");
+            if (altName == null) {
+                altName = (String) values.get("TBNAME");
+            }
+            if (altName != null) {
+                values.put("PKTABLE_NAME", altName);
+            }
+        }
+        String pkColumnName = (String) values.get("PKCOLUMN_NAME");
+        if (pkColumnName == null) {
+            String altColName = (String) values.get("COLNAME");
+            if (altColName != null) {
+                values.put("PKCOLUMN_NAME", altColName);
+            }
+        }
+        if (values.get("PKTABLE_NAME") == null) {
+            log.warn("Skipping foreign key - could not determine referenced table from metadata");
+            return;
+        }
+        super.readForeignKey(metaData, values, knownFks);
     }
 
     @Override

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/db2/Db2DdlReader.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/db2/Db2DdlReader.java
@@ -63,7 +63,6 @@ import org.jumpmind.db.model.TypeMap;
 import org.jumpmind.db.platform.AbstractJdbcDdlReader;
 import org.jumpmind.db.platform.DatabaseMetaDataWrapper;
 import org.jumpmind.db.platform.IDatabasePlatform;
-import org.jumpmind.db.sql.IConnectionCallback;
 import org.jumpmind.db.sql.ISqlRowMapper;
 import org.jumpmind.db.sql.JdbcSqlTemplate;
 import org.jumpmind.db.sql.Row;
@@ -338,51 +337,6 @@ public class Db2DdlReader extends AbstractJdbcDdlReader {
         } else {
             return super.mapUnknownJdbcTypeForColumn(values);
         }
-    }
-
-    @Override
-    public List<String> getCatalogNames() {
-        JdbcSqlTemplate sqlTemplate = (JdbcSqlTemplate) platform.getSqlTemplateDirty();
-        return sqlTemplate.execute(new IConnectionCallback<List<String>>() {
-            public List<String> execute(Connection connection) throws SQLException {
-                List<String> catalogs = new ArrayList<String>();
-                java.sql.Statement stmt = null;
-                ResultSet rs = null;
-                try {
-                    stmt = connection.createStatement();
-                    rs = stmt.executeQuery("VALUES CURRENT SERVER");
-                    if (rs.next()) {
-                        String dbName = rs.getString(1);
-                        if (dbName != null) {
-                            catalogs.add(dbName.trim());
-                        }
-                    }
-                } finally {
-                    JdbcSqlTemplate.close(rs);
-                    if (stmt != null) {
-                        stmt.close();
-                    }
-                }
-                return catalogs;
-            }
-        });
-    }
-
-    @Override
-    protected Table readTableFromConnection(Connection connection, String catalog,
-            String schema, String table) throws SQLException {
-        return super.readTableFromConnection(connection, null, schema, table);
-    }
-
-    @Override
-    public List<String> getTableNames(String catalog, String schema, String[] tableTypes) {
-        return super.getTableNames(null, schema, tableTypes);
-    }
-
-    @Override
-    public List<String> getTableNamesFromDatabase(String catalog, String schema,
-            String[] tableTypes) {
-        return super.getTableNamesFromDatabase(null, schema, tableTypes);
     }
 
     @Override

--- a/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/db2/Db2DdlReaderTest.java
+++ b/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/db2/Db2DdlReaderTest.java
@@ -1,0 +1,199 @@
+/**
+ * Licensed to JumpMind Inc under one or more contributor
+ * license agreements.  See the NOTICE file distributed
+ * with this work for additional information regarding
+ * copyright ownership.  JumpMind Inc licenses this file
+ * to you under the GNU General Public License, version 3.0 (GPLv3)
+ * (the "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3.0 (GPLv3) along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jumpmind.db.platform.db2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jumpmind.db.model.ForeignKey;
+import org.jumpmind.db.platform.DatabaseMetaDataWrapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class Db2DdlReaderTest {
+    private Db2DatabasePlatform platform;
+    private Db2DdlReader ddlReader;
+
+    @BeforeEach
+    void setUp() {
+        platform = mock(Db2DatabasePlatform.class);
+        when(platform.getName()).thenReturn("db2");
+        ddlReader = new Db2DdlReader(platform);
+    }
+
+    @Test
+    void testDefaultCatalogReturnsNull() {
+        Db2DatabasePlatform realPlatform = mock(Db2DatabasePlatform.class, org.mockito.Mockito.CALLS_REAL_METHODS);
+        assertNull(realPlatform.getDefaultCatalog());
+    }
+
+    @Test
+    void testMapLongVarcharReturnsLongVarchar() {
+        Map<String, Object> values = new HashMap<>();
+        values.put("TYPE_NAME", "LONG VARCHAR");
+        Integer result = ddlReader.mapUnknownJdbcTypeForColumn(values);
+        assertEquals(Types.LONGVARCHAR, result);
+    }
+
+    @Test
+    void testMapClobReturnsLongVarchar() {
+        Map<String, Object> values = new HashMap<>();
+        values.put("TYPE_NAME", "CLOB");
+        Integer result = ddlReader.mapUnknownJdbcTypeForColumn(values);
+        assertEquals(Types.LONGVARCHAR, result);
+    }
+
+    @Test
+    void testMapDbclobReturnsLongVarchar() {
+        Map<String, Object> values = new HashMap<>();
+        values.put("TYPE_NAME", "DBCLOB");
+        Integer result = ddlReader.mapUnknownJdbcTypeForColumn(values);
+        assertEquals(Types.LONGVARCHAR, result);
+    }
+
+    @Test
+    void testMapRowidReturnsVarchar() {
+        Map<String, Object> values = new HashMap<>();
+        values.put("TYPE_NAME", "ROWID");
+        Integer result = ddlReader.mapUnknownJdbcTypeForColumn(values);
+        assertEquals(Types.VARCHAR, result);
+    }
+
+    @Test
+    void testMapXmlReturnsSqlXml() {
+        Map<String, Object> values = new HashMap<>();
+        values.put("TYPE_NAME", "XML");
+        Integer result = ddlReader.mapUnknownJdbcTypeForColumn(values);
+        assertEquals(Types.SQLXML, result);
+    }
+
+    @Test
+    void testReadColumnFallsBackToNameKey() throws SQLException {
+        DatabaseMetaDataWrapper metaData = mock(DatabaseMetaDataWrapper.class);
+        when(metaData.getSchemaPattern()).thenReturn("TESTSCHEMA");
+        Map<String, Object> values = new HashMap<>();
+        values.put("NAME", "MY_COLUMN");
+        values.put("TYPE_NAME", "VARCHAR");
+        values.put("DATA_TYPE", Types.VARCHAR);
+        values.put("COLUMN_SIZE", "100");
+        values.put("DECIMAL_DIGITS", 0);
+        values.put("NUM_PREC_RADIX", 10);
+        values.put("IS_NULLABLE", "YES");
+        values.put("IS_AUTOINCREMENT", "NO");
+        var column = ddlReader.readColumn(metaData, values);
+        assertNotNull(column);
+        assertEquals("MY_COLUMN", column.getName());
+    }
+
+    @Test
+    void testReadColumnUsesStandardKeyWhenPresent() throws SQLException {
+        DatabaseMetaDataWrapper metaData = mock(DatabaseMetaDataWrapper.class);
+        when(metaData.getSchemaPattern()).thenReturn("TESTSCHEMA");
+        Map<String, Object> values = new HashMap<>();
+        values.put("COLUMN_NAME", "STANDARD_COL");
+        values.put("NAME", "ALT_COL");
+        values.put("TYPE_NAME", "VARCHAR");
+        values.put("DATA_TYPE", Types.VARCHAR);
+        values.put("COLUMN_SIZE", "100");
+        values.put("DECIMAL_DIGITS", 0);
+        values.put("NUM_PREC_RADIX", 10);
+        values.put("IS_NULLABLE", "YES");
+        values.put("IS_AUTOINCREMENT", "NO");
+        var column = ddlReader.readColumn(metaData, values);
+        assertNotNull(column);
+        assertEquals("STANDARD_COL", column.getName());
+    }
+
+    @Test
+    void testReadForeignKeyFallsBackToReftbname() throws SQLException {
+        DatabaseMetaDataWrapper metaData = mock(DatabaseMetaDataWrapper.class);
+        Map<String, Object> values = new HashMap<>();
+        values.put("FK_NAME", "FK_TEST");
+        values.put("REFTBNAME", "PARENT_TABLE");
+        values.put("COLNAME", "PARENT_ID");
+        values.put("FKCOLUMN_NAME", "CHILD_FK_COL");
+        values.put("KEY_SEQ", (short) 1);
+        Map<String, ForeignKey> knownFks = new HashMap<>();
+        ddlReader.readForeignKey(metaData, values, knownFks);
+        assertEquals(1, knownFks.size());
+        ForeignKey fk = knownFks.get("FK_TEST");
+        assertNotNull(fk);
+        assertEquals("PARENT_TABLE", fk.getForeignTableName());
+        assertEquals("PARENT_ID", fk.getFirstReference().getForeignColumnName());
+    }
+
+    @Test
+    void testReadForeignKeyUsesStandardKeysWhenPresent() throws SQLException {
+        DatabaseMetaDataWrapper metaData = mock(DatabaseMetaDataWrapper.class);
+        Map<String, Object> values = new HashMap<>();
+        values.put("FK_NAME", "FK_TEST2");
+        values.put("PKTABLE_NAME", "STANDARD_PARENT");
+        values.put("REFTBNAME", "ALT_PARENT");
+        values.put("PKCOLUMN_NAME", "STANDARD_PK_COL");
+        values.put("COLNAME", "ALT_PK_COL");
+        values.put("FKCOLUMN_NAME", "CHILD_FK_COL");
+        values.put("KEY_SEQ", (short) 1);
+        Map<String, ForeignKey> knownFks = new HashMap<>();
+        ddlReader.readForeignKey(metaData, values, knownFks);
+        assertEquals(1, knownFks.size());
+        ForeignKey fk = knownFks.get("FK_TEST2");
+        assertNotNull(fk);
+        assertEquals("STANDARD_PARENT", fk.getForeignTableName());
+        assertEquals("STANDARD_PK_COL", fk.getFirstReference().getForeignColumnName());
+    }
+
+    @Test
+    void testReadForeignKeySkipsWhenNoTableName() throws SQLException {
+        DatabaseMetaDataWrapper metaData = mock(DatabaseMetaDataWrapper.class);
+        Map<String, Object> values = new HashMap<>();
+        values.put("FK_NAME", "FK_ORPHAN");
+        values.put("FKCOLUMN_NAME", "CHILD_FK_COL");
+        values.put("KEY_SEQ", (short) 1);
+        Map<String, ForeignKey> knownFks = new HashMap<>();
+        ddlReader.readForeignKey(metaData, values, knownFks);
+        assertTrue(knownFks.isEmpty());
+    }
+
+    @Test
+    void testReadForeignKeyFallsBackToTbname() throws SQLException {
+        DatabaseMetaDataWrapper metaData = mock(DatabaseMetaDataWrapper.class);
+        Map<String, Object> values = new HashMap<>();
+        values.put("FK_NAME", "FK_TBNAME");
+        values.put("TBNAME", "TBNAME_PARENT");
+        values.put("PKCOLUMN_NAME", "PK_COL");
+        values.put("FKCOLUMN_NAME", "FK_COL");
+        values.put("KEY_SEQ", (short) 1);
+        Map<String, ForeignKey> knownFks = new HashMap<>();
+        ddlReader.readForeignKey(metaData, values, knownFks);
+        assertEquals(1, knownFks.size());
+        ForeignKey fk = knownFks.get("FK_TBNAME");
+        assertEquals("TBNAME_PARENT", fk.getForeignTableName());
+    }
+}


### PR DESCRIPTION
## Summary

Fixes DB2 LUW platform bugs discovered during the FELE POC (one-way DB2 LUW → SQL Server replication). These issues prevent trigger creation, can cause destructive DDL migrations, and break foreign key / column metadata reading.

### Changes

- **SYM-7346**: Override `getSourceTablePrefix()` in `Db2TriggerTemplate` to strip catalog from trigger DDL, preventing `SQLCODE=-108` from 3-part qualified names
- **SYM-7347**: Return `null` from `Db2DatabasePlatform.getDefaultCatalog()` — DB2 doesn't support catalogs, matching Oracle and AS/400 which already return `null`. The previous `""` return value leaked into JDBC `meta.getTables()` where `""` means "tables without a catalog" (returning nothing) vs `null` meaning "don't filter by catalog". This fix also eliminates 4 workaround overrides in `Db2DdlReader` (`getCatalogNames`, `readTableFromConnection`, `getTableNames`, `getTableNamesFromDatabase`) that were only compensating for `""` leaking into JDBC calls
- **SYM-7350**: Map `LONG VARCHAR` to `LONGVARCHAR` (-1) instead of `CLOB` (2005) in `mapUnknownJdbcTypeForColumn()` to prevent destructive DDL migration cycle where `ModelComparator` detects a type mismatch and drops/recreates `SYM_DATA`, losing `IDENTITY` columns
- **SYM-7351**: Handle non-standard DB2 JDBC metadata keys (`NAME` → `COLUMN_NAME`, `REFTBNAME`/`TBNAME` → `PKTABLE_NAME`, `COLNAME` → `PKCOLUMN_NAME`) as fallbacks in `readColumn()` and `readForeignKey()`

### Unit tests

Added `Db2DdlReaderTest` with 11 tests:
- `getDefaultCatalog()` returns null
- `mapUnknownJdbcTypeForColumn` for LONG VARCHAR, CLOB, DBCLOB, ROWID, XML
- `readColumn` NAME fallback (with and without standard COLUMN_NAME key)
- `readForeignKey` fallbacks for REFTBNAME, TBNAME, COLNAME, and skip on missing table name

## Test plan

- [x] Unit tests pass (11 tests in `Db2DdlReaderTest`)
- [x] Build passes (`symmetric-jdbc`, `symmetric-client`)
- [x] End-to-end POC: DB2 LUW 12.1 → SQL Server with field-level transforms
  - [x] `sync-triggers` creates triggers with 2-part names (`DB2INST1.SYM_*`), no SQLCODE errors
  - [x] `SYM_DATA` not dropped/recreated on startup (LONG VARCHAR mapping)
  - [x] Initial load extracts and delivers successfully (5 rows each in PURCHASE_ORDER, ITEM_MASTER)
  - [x] Zero error batches on hub and spoke
  - [x] Transforms applied correctly (CYYMMDD → DATE, implied decimals → DECIMAL, CHAR → trimmed VARCHAR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)