### PR TITLE
SYM-7313: Made the Deploy Wizard automatically roll back failed deployments, preventing the user from getting stuck in the Diagram

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/IConfigurationService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/IConfigurationService.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+import org.jumpmind.db.sql.ISqlTransaction;
 import org.jumpmind.symmetric.model.Channel;
 import org.jumpmind.symmetric.model.NodeChannels;
 import org.jumpmind.symmetric.model.NodeChannel;
@@ -43,13 +44,21 @@ public interface IConfigurationService {
 
     public void saveNodeGroup(NodeGroup group);
 
+    public void saveNodeGroup(ISqlTransaction transaction, NodeGroup group);
+
     public void saveNodeGroupLink(NodeGroupLink link);
+
+    public void saveNodeGroupLink(ISqlTransaction transaction, NodeGroupLink link);
 
     public void renameNodeGroupLink(String oldSourceId, String oldTargetId, NodeGroupLink link);
 
     public void deleteNodeGroup(String nodeGroupId);
 
+    public void deleteNodeGroup(ISqlTransaction transaction, String nodeGroupId);
+
     public void deleteNodeGroupLink(NodeGroupLink link);
+
+    public void deleteNodeGroupLink(ISqlTransaction transaction, NodeGroupLink link);
 
     public void deleteAllNodeGroupLinks();
 

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/IDataLoaderService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/IDataLoaderService.java
@@ -70,6 +70,8 @@ public interface IDataLoaderService {
 
     public void delete(ConflictNodeGroupLink settings);
 
+    public void delete(ISqlTransaction transaction, ConflictNodeGroupLink settings);
+
     public void deleteAllConflicts();
 
     public void save(ConflictNodeGroupLink settings);

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/IFileSyncService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/IFileSyncService.java
@@ -57,6 +57,8 @@ public interface IFileSyncService {
 
     public void deleteFileTriggerRouter(FileTriggerRouter fileTriggerRouter);
 
+    public void deleteFileTriggerRouter(ISqlTransaction transaction, FileTriggerRouter fileTriggerRouter);
+
     public void deleteAllFileTriggerRouters();
 
     public void deleteFileTrigger(FileTrigger fileTrigger);

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/ITransformService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/ITransformService.java
@@ -23,6 +23,7 @@ package org.jumpmind.symmetric.service;
 import java.util.List;
 import java.util.Map;
 
+import org.jumpmind.db.sql.ISqlTransaction;
 import org.jumpmind.symmetric.io.data.transform.IColumnTransform;
 import org.jumpmind.symmetric.io.data.transform.TransformColumn;
 import org.jumpmind.symmetric.io.data.transform.TransformPoint;
@@ -49,11 +50,15 @@ public interface ITransformService {
 
     public void saveTransformTable(TransformTableNodeGroupLink transformTable, boolean saveTransformColumns);
 
+    public void saveTransformTable(ISqlTransaction transaction, TransformTableNodeGroupLink transformTable, boolean saveTransformColumns);
+
     public void saveTransformTableAsCopy(String originalId, TransformTableNodeGroupLink transformTable);
 
     public void renameTransformTable(String oldId, TransformTableNodeGroupLink transformTable);
 
     public void deleteTransformTable(String transformTableId);
+
+    public void deleteTransformTable(ISqlTransaction transaction, String transformTableId);
 
     public void deleteAllTransformTables();
 

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/ITriggerRouterService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/ITriggerRouterService.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.jumpmind.db.model.Table;
+import org.jumpmind.db.sql.ISqlTransaction;
 import org.jumpmind.symmetric.cache.TriggerRouterRoutersCache;
 import org.jumpmind.symmetric.config.ITriggerCreationListener;
 import org.jumpmind.symmetric.io.data.DataEventType;
@@ -130,13 +131,19 @@ public interface ITriggerRouterService {
 
     public void deleteRouter(Router router);
 
+    public void deleteRouter(ISqlTransaction transaction, Router router);
+
     public void deleteAllRouters();
 
     public void saveRouter(Router router);
 
+    public void saveRouter(ISqlTransaction transaction, Router router);
+
     public Router saveRouterAsCopy(Router router);
 
     public void renameRouter(String oldId, Router router);
+
+    public void renameRouter(ISqlTransaction transaction, String oldId, Router router);
 
     public List<TriggerRouter> getAllTriggerRoutersForCurrentNode(String sourceNodeGroupId);
 
@@ -149,6 +156,8 @@ public interface ITriggerRouterService {
 
     public void saveTrigger(Trigger trigger);
 
+    public void saveTrigger(ISqlTransaction transaction, Trigger trigger);
+
     public void insertTriggers(Collection<Trigger> triggers);
 
     public void updateTriggers(Collection<Trigger> triggers);
@@ -158,6 +167,8 @@ public interface ITriggerRouterService {
     public void renameTrigger(String oldId, Trigger trigger);
 
     public void deleteTrigger(Trigger trigger);
+
+    public void deleteTrigger(ISqlTransaction transaction, Trigger trigger);
 
     public void deleteTriggers(Collection<Trigger> triggers);
 
@@ -219,6 +230,8 @@ public interface ITriggerRouterService {
 
     public void deleteTriggerRouter(TriggerRouter triggerRouter);
 
+    public void deleteTriggerRouter(ISqlTransaction transaction, TriggerRouter triggerRouter);
+
     public void deleteTriggerRouter(String triggerId, String routerId);
 
     public void deleteTriggerRouters(Collection<TriggerRouter> triggerRouters);
@@ -226,6 +239,8 @@ public interface ITriggerRouterService {
     public void deleteAllTriggerRouters();
 
     public void saveTriggerRouter(TriggerRouter triggerRouter, boolean updateTriggerRouterTableOnly);
+
+    public void saveTriggerRouter(ISqlTransaction transaction, TriggerRouter triggerRouter, boolean updateTriggerRouterTableOnly);
 
     public void saveTriggerRouter(TriggerRouter triggerRouter);
 

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/ConfigurationService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/ConfigurationService.java
@@ -214,6 +214,22 @@ public class ConfigurationService extends AbstractService implements IConfigurat
     }
 
     @Override
+    public void saveNodeGroupLink(ISqlTransaction transaction, NodeGroupLink link) {
+        link.setLastUpdateTime(new Date());
+        if (transaction.prepareAndExecute(getSql("updateNodeGroupLinkSql"), link.getDataEventAction().name(),
+                link.isSyncConfigEnabled() ? 1 : 0, link.isSyncSqlEnabled() ? 1 : 0, link.isReversible() ? 1 : 0,
+                link.getLastUpdateTime(),
+                link.getLastUpdateBy(), link.getSourceNodeGroupId(), link.getTargetNodeGroupId()) <= 0) {
+            link.setCreateTime(new Date());
+            transaction.prepareAndExecute(getSql("insertNodeGroupLinkSql"), link.getDataEventAction().name(),
+                    link.getSourceNodeGroupId(), link.getTargetNodeGroupId(),
+                    link.isSyncConfigEnabled() ? 1 : 0, link.isSyncSqlEnabled() ? 1 : 0, link.isReversible() ? 1 : 0,
+                    link.getLastUpdateTime(),
+                    link.getLastUpdateBy(), link.getCreateTime());
+        }
+    }
+
+    @Override
     public void renameNodeGroupLink(String oldSourceId, String oldTargetId, NodeGroupLink link) {
         saveNodeGroupLink(link);
         ISqlTransaction transaction = null;
@@ -277,13 +293,35 @@ public class ConfigurationService extends AbstractService implements IConfigurat
     }
 
     @Override
+    public void saveNodeGroup(ISqlTransaction transaction, NodeGroup group) {
+        group.setLastUpdateTime(new Date());
+        if (transaction.prepareAndExecute(getSql("updateNodeGroupSql"), group.getDescription(),
+                group.getLastUpdateTime(), group.getLastUpdateBy(), group.getNodeGroupId()) <= 0) {
+            group.setCreateTime(new Date());
+            transaction.prepareAndExecute(getSql("insertNodeGroupSql"), group.getDescription(),
+                    group.getNodeGroupId(), group.getLastUpdateTime(), group.getLastUpdateBy(),
+                    group.getCreateTime());
+        }
+    }
+
+    @Override
     public void deleteNodeGroup(String nodeGroupId) {
         sqlTemplate.update(getSql("deleteNodeGroupSql"), nodeGroupId);
     }
 
     @Override
+    public void deleteNodeGroup(ISqlTransaction transaction, String nodeGroupId) {
+        transaction.prepareAndExecute(getSql("deleteNodeGroupSql"), nodeGroupId);
+    }
+
+    @Override
     public void deleteNodeGroupLink(NodeGroupLink link) {
         deleteNodeGroupLink(link.getSourceNodeGroupId(), link.getTargetNodeGroupId());
+    }
+
+    @Override
+    public void deleteNodeGroupLink(ISqlTransaction transaction, NodeGroupLink link) {
+        transaction.prepareAndExecute(getSql("deleteNodeGroupLinkSql"), link.getSourceNodeGroupId(), link.getTargetNodeGroupId());
     }
 
     private void deleteNodeGroupLink(String sourceId, String targetId) {

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/DataLoaderService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/DataLoaderService.java
@@ -837,6 +837,11 @@ public class DataLoaderService extends AbstractService implements IDataLoaderSer
         delete(settings.getConflictId());
     }
 
+    @Override
+    public void delete(ISqlTransaction transaction, ConflictNodeGroupLink settings) {
+        transaction.prepareAndExecute(getSql("deleteConflictSettingsSql"), settings.getConflictId());
+    }
+
     private void delete(String id) {
         sqlTemplate.update(getSql("deleteConflictSettingsSql"), id);
     }

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/FileSyncService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/FileSyncService.java
@@ -505,6 +505,12 @@ public class FileSyncService extends AbstractOfflineDetectorService implements I
     }
 
     @Override
+    public void deleteFileTriggerRouter(ISqlTransaction transaction, FileTriggerRouter fileTriggerRouter) {
+        transaction.prepareAndExecute(getSql("deleteFileTriggerRouterSql"), fileTriggerRouter
+                .getFileTrigger().getTriggerId(), fileTriggerRouter.getRouter().getRouterId());
+    }
+
+    @Override
     public void deleteFileTrigger(FileTrigger fileTrigger) {
         deleteFileTrigger(fileTrigger.getTriggerId());
     }

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/TransformService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/TransformService.java
@@ -515,6 +515,44 @@ public class TransformService extends AbstractService implements ITransformServi
     }
 
     @Override
+    public void saveTransformTable(ISqlTransaction transaction, TransformTableNodeGroupLink transformTable, boolean saveTransformColumns) {
+        transformTable.setLastUpdateTime(new Date());
+        if (transaction.prepareAndExecute(getSql("updateTransformTableSql"), transformTable
+                .getNodeGroupLink().getSourceNodeGroupId(), transformTable.getNodeGroupLink()
+                        .getTargetNodeGroupId(), transformTable.getSourceCatalogName(), transformTable
+                                .getSourceSchemaName(), transformTable.getSourceTableName(), transformTable
+                                        .getTargetCatalogName(), transformTable.getTargetSchemaName(), transformTable
+                                                .getTargetTableName(), transformTable.getTransformPoint().toString(),
+                transformTable.isUpdateFirst() ? 1 : 0, transformTable.getDeleteAction()
+                        .toString(), transformTable.getUpdateAction(), transformTable.getTransformOrder(), transformTable
+                                .getColumnPolicy().toString(), transformTable.getLastUpdateTime(),
+                transformTable.getLastUpdateBy(), transformTable.getTransformId()) == 0) {
+            transformTable.setCreateTime(new Date());
+            transaction.prepareAndExecute(getSql("insertTransformTableSql"), transformTable
+                    .getNodeGroupLink().getSourceNodeGroupId(), transformTable
+                            .getNodeGroupLink().getTargetNodeGroupId(), transformTable
+                                    .getSourceCatalogName(), transformTable.getSourceSchemaName(),
+                    transformTable.getSourceTableName(), transformTable.getTargetCatalogName(),
+                    transformTable.getTargetSchemaName(), transformTable.getTargetTableName(),
+                    transformTable.getTransformPoint().toString(), transformTable
+                            .isUpdateFirst() ? 1 : 0, transformTable.getDeleteAction()
+                                    .toString(), transformTable.getUpdateAction(), transformTable.getTransformOrder(), transformTable
+                                            .getColumnPolicy().toString(), transformTable.getLastUpdateTime(),
+                    transformTable.getLastUpdateBy(), transformTable.getCreateTime(),
+                    transformTable.getTransformId());
+        }
+        if (saveTransformColumns) {
+            deleteTransformColumns(transaction, transformTable.getTransformId());
+            List<TransformColumn> columns = transformTable.getTransformColumns();
+            if (columns != null) {
+                for (TransformColumn transformColumn : columns) {
+                    saveTransformColumn(transaction, transformColumn);
+                }
+            }
+        }
+    }
+
+    @Override
     public void saveTransformTableAsCopy(String originalId, TransformTableNodeGroupLink transformTable) {
         String newId = transformTable.getTransformId();
         List<TransformTableNodeGroupLink> transformTables = sqlTemplate
@@ -599,6 +637,13 @@ public class TransformService extends AbstractService implements ITransformServi
             close(transaction);
             clearCache();
         }
+    }
+
+    @Override
+    public void deleteTransformTable(ISqlTransaction transaction, String transformTableId) {
+        deleteTransformColumns(transaction, transformTableId);
+        transaction.prepareAndExecute(getSql("deleteTransformTableSql"),
+                (Object) transformTableId);
     }
 
     @Override

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/TriggerRouterService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/TriggerRouterService.java
@@ -196,6 +196,11 @@ public class TriggerRouterService extends AbstractService implements ITriggerRou
         deleteTrigger(trigger.getTriggerId());
     }
 
+    @Override
+    public void deleteTrigger(ISqlTransaction transaction, Trigger trigger) {
+        transaction.prepareAndExecute(getSql("deleteTriggerSql"), (Object) trigger.getTriggerId());
+    }
+
     private void deleteTrigger(String id) {
         sqlTemplate.update(getSql("deleteTriggerSql"), (Object) id);
     }
@@ -1140,6 +1145,12 @@ public class TriggerRouterService extends AbstractService implements ITriggerRou
     }
 
     @Override
+    public void deleteTriggerRouter(ISqlTransaction transaction, TriggerRouter triggerRouter) {
+        transaction.prepareAndExecute(getSql("deleteTriggerRouterSql"), (Object) triggerRouter.getTrigger()
+                .getTriggerId(), triggerRouter.getRouter().getRouterId());
+    }
+
+    @Override
     public void deleteTriggerRouters(Collection<TriggerRouter> triggerRouters) {
         ISqlTransaction transaction = null;
         try {
@@ -1194,6 +1205,21 @@ public class TriggerRouterService extends AbstractService implements ITriggerRou
                     getTriggerRouterSqlTypes());
         }
         clearCache();
+    }
+
+    @Override
+    public void saveTriggerRouter(ISqlTransaction transaction, TriggerRouter triggerRouter, boolean updateTriggerRouterTableOnly) {
+        if (!updateTriggerRouterTableOnly) {
+            saveTrigger(transaction, triggerRouter.getTrigger());
+            saveRouter(transaction, triggerRouter.getRouter());
+        }
+        triggerRouter.setLastUpdateTime(new Date());
+        if (0 >= transaction.prepareAndExecute(getSql("updateTriggerRouterSql"), getTriggerRouterSqlValues(triggerRouter),
+                getTriggerRouterSqlTypes())) {
+            triggerRouter.setCreateTime(triggerRouter.getLastUpdateTime());
+            transaction.prepareAndExecute(getSql("insertTriggerRouterSql"), getTriggerRouterSqlValues(triggerRouter),
+                    getTriggerRouterSqlTypes());
+        }
     }
 
     public void renameTriggerRouter(String oldTriggerId, String oldRouterId, TriggerRouter triggerRouter) {
@@ -1341,6 +1367,45 @@ public class TriggerRouterService extends AbstractService implements ITriggerRou
         clearCache();
     }
 
+    @Override
+    public void saveRouter(ISqlTransaction transaction, Router router) {
+        router.setLastUpdateTime(new Date());
+        router.nullOutBlankFields();
+        if (0 >= transaction.prepareAndExecute(
+                getSql("updateRouterSql"),
+                new Object[] { router.getTargetCatalogName(), router.getTargetSchemaName(),
+                        router.getTargetTableName(),
+                        router.getNodeGroupLink().getSourceNodeGroupId(),
+                        router.getNodeGroupLink().getTargetNodeGroupId(), router.getRouterType(),
+                        router.getRouterExpression(), router.isSyncOnUpdate() ? 1 : 0,
+                        router.isSyncOnInsert() ? 1 : 0, router.isSyncOnDelete() ? 1 : 0,
+                        router.isUseSourceCatalogSchema() ? 1 : 0,
+                        router.getLastUpdateBy(), router.getLastUpdateTime(),
+                        router.getRouterId() }, new int[] {
+                                Types.VARCHAR, Types.VARCHAR, Types.VARCHAR, Types.VARCHAR, Types.VARCHAR,
+                                Types.VARCHAR, Types.VARCHAR, Types.SMALLINT, Types.SMALLINT,
+                                Types.SMALLINT, Types.SMALLINT, Types.VARCHAR, Types.TIMESTAMP,
+                                Types.VARCHAR })) {
+            router.setCreateTime(router.getLastUpdateTime());
+            transaction.prepareAndExecute(
+                    getSql("insertRouterSql"),
+                    new Object[] { router.getTargetCatalogName(), router.getTargetSchemaName(),
+                            router.getTargetTableName(),
+                            router.getNodeGroupLink().getSourceNodeGroupId(),
+                            router.getNodeGroupLink().getTargetNodeGroupId(),
+                            router.getRouterType(), router.getRouterExpression(),
+                            router.isSyncOnUpdate() ? 1 : 0, router.isSyncOnInsert() ? 1 : 0,
+                            router.isSyncOnDelete() ? 1 : 0, router.isUseSourceCatalogSchema() ? 1 : 0,
+                            router.getCreateTime(),
+                            router.getLastUpdateBy(), router.getLastUpdateTime(), router.getRouterId() },
+                    new int[] {
+                            Types.VARCHAR, Types.VARCHAR, Types.VARCHAR, Types.VARCHAR,
+                            Types.VARCHAR, Types.VARCHAR, Types.VARCHAR, Types.SMALLINT,
+                            Types.SMALLINT, Types.SMALLINT, Types.SMALLINT, Types.TIMESTAMP, Types.VARCHAR,
+                            Types.TIMESTAMP, Types.VARCHAR });
+        }
+    }
+
     public Router saveRouterAsCopy(Router router) {
         String newId = router.getRouterId();
         List<Router> routers = sqlTemplate.query(
@@ -1363,6 +1428,25 @@ public class TriggerRouterService extends AbstractService implements ITriggerRou
         deleteRouter(oldId);
     }
 
+    @Override
+    public void renameRouter(ISqlTransaction transaction, String oldId, Router router) {
+        saveRouter(transaction, router);
+        List<TriggerRouter> triggerRouters = transaction.query(
+                getTriggerRouterSql("selectTriggerRoutersByRouterIdSql"),
+                new TriggerRouterMapper(), new Object[] { oldId }, null);
+        if (triggerRouters != null && !triggerRouters.isEmpty()) {
+            String oldRouterId = triggerRouters.get(0).getRouterId();
+            for (TriggerRouter triggerRouter : triggerRouters) {
+                triggerRouter.setRouterId(router.getRouterId());
+                saveTriggerRouter(transaction, triggerRouter, true);
+            }
+            transaction.prepareAndExecute(getSql("updateTriggerRouterIdSql1"), router.getRouterId(), oldRouterId);
+            transaction.prepareAndExecute(getSql("deleteTriggerRoutersByRouterIdSql"), oldRouterId);
+        }
+        transaction.prepareAndExecute(getSql("updateFileTriggerRouterSql"), router.getRouterId(), oldId);
+        transaction.prepareAndExecute(getSql("deleteRouterSql"), (Object) oldId);
+    }
+
     public boolean isRouterBeingUsed(String routerId) {
         return sqlTemplate.queryForInt(getSql("countTriggerRoutersByRouterIdSql"), routerId) > 0;
     }
@@ -1373,6 +1457,17 @@ public class TriggerRouterService extends AbstractService implements ITriggerRou
             sqlTemplate.update(getSql("deleteFileTriggerRoutersByRouterSql"), router.getRouterId());
             groupletService.deleteTriggerRouterGroupletsFor(router);
             sqlTemplate.update(getSql("deleteRouterSql"), router.getRouterId());
+        }
+    }
+
+    @Override
+    public void deleteRouter(ISqlTransaction transaction, Router router) {
+        if (router != null) {
+            String routerId = router.getRouterId();
+            transaction.prepareAndExecute(getSql("deleteTriggerRoutersByRouterSql"), routerId);
+            transaction.prepareAndExecute(getSql("deleteFileTriggerRoutersByRouterSql"), routerId);
+            transaction.prepareAndExecute(getSql("deleteTriggerRouterGroupletByRouterSql"), routerId);
+            transaction.prepareAndExecute(getSql("deleteRouterSql"), routerId);
         }
     }
 
@@ -1393,6 +1488,16 @@ public class TriggerRouterService extends AbstractService implements ITriggerRou
             sqlTemplate.update(getSql("insertTriggerSql"), getTriggerSqlValues(trigger), getTriggerSqlTypes());
         }
         clearCache();
+    }
+
+    @Override
+    public void saveTrigger(ISqlTransaction transaction, Trigger trigger) {
+        trigger.setLastUpdateTime(new Date());
+        trigger.nullOutBlankFields();
+        if (0 >= transaction.prepareAndExecute(getSql("updateTriggerSql"), getTriggerSqlValues(trigger), getTriggerSqlTypes())) {
+            trigger.setCreateTime(trigger.getLastUpdateTime());
+            transaction.prepareAndExecute(getSql("insertTriggerSql"), getTriggerSqlValues(trigger), getTriggerSqlTypes());
+        }
     }
 
     public void saveTriggerAsCopy(String originalId, Trigger trigger) {

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/TriggerRouterServiceSqlMap.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/TriggerRouterServiceSqlMap.java
@@ -222,6 +222,7 @@ public class TriggerRouterServiceSqlMap extends AbstractSqlMap {
         
         putSql("updateTriggerRouterIdSql0", "update $(trigger_router_grouplet) set trigger_id=? where trigger_id=?");
         putSql("updateTriggerRouterIdSql1", "update $(trigger_router_grouplet) set router_id=? where router_id=?");
+        putSql("deleteTriggerRouterGroupletByRouterSql", "delete from $(trigger_router_grouplet) where router_id=?");
 
         putSql("updateFileTriggerRouterSql", "update $(file_trigger_router) set router_id=? where router_id=?");
         putSql("deleteFileTriggerRoutersByRouterSql", "delete from $(file_trigger_router) where router_id=?");

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/util/ModuleManager.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/util/ModuleManager.java
@@ -129,6 +129,37 @@ public class ModuleManager {
         return dirName;
     }
 
+    public void checkAvailability(String moduleId) throws ModuleException {
+        checkModuleValid(moduleId, false);
+        List<MavenArtifact> artifacts = resolveArtifacts(moduleId);
+        for (MavenArtifact artifact : artifacts) {
+            if (new File(buildFileName(modulesDir, artifact)).exists()) {
+                continue;
+            }
+            boolean reachable = false;
+            String lastError = null;
+            for (String repo : repos) {
+                String urlString = buildUrl(repo, artifact);
+                try {
+                    HttpURLConnection conn = getHttpUrlConnection(urlString, WebConstants.METHOD_HEAD);
+                    if (conn.getResponseCode() == HttpURLConnection.HTTP_OK) {
+                        reachable = true;
+                        break;
+                    } else {
+                        lastError = "HTTP " + conn.getResponseCode() + " for " + urlString;
+                    }
+                } catch (IOException e) {
+                    lastError = e.getClass().getName() + ": " + e.getMessage() + " for " + urlString;
+                }
+            }
+            if (!reachable) {
+                logAndThrow("Module " + moduleId + " is not available for download. "
+                        + "Please check your internet connection and firewall settings. "
+                        + "(" + artifact.toFileName() + ": " + lastError + ")");
+            }
+        }
+    }
+
     public void install(String moduleId) throws ModuleException {
         install(moduleId, null);
     }

--- a/symmetric-server/src/main/java/org/jumpmind/symmetric/web/SymmetricEngineHolder.java
+++ b/symmetric-server/src/main/java/org/jumpmind/symmetric/web/SymmetricEngineHolder.java
@@ -196,10 +196,15 @@ public class SymmetricEngineHolder {
     }
 
     public ISymmetricEngine install(Properties passedInProperties) throws Exception {
-        return install(passedInProperties, null);
+        return install(passedInProperties, null, true, true);
     }
 
     public ISymmetricEngine install(Properties passedInProperties, IDatabaseInstallStatementListener listener) throws Exception {
+        return install(passedInProperties, listener, true, true);
+    }
+
+    public ISymmetricEngine install(Properties passedInProperties, IDatabaseInstallStatementListener listener, boolean startJobs,
+            boolean createConfig) throws Exception {
         ITypedPropertiesFactory factory = PropertiesUtil.createTypedPropertiesFactory(null, passedInProperties);
         TypedProperties properties = factory.reload(passedInProperties);
         String password = properties.getProperty(BasicDataSourcePropertyConstants.DB_POOL_PASSWORD);
@@ -245,7 +250,7 @@ public class SymmetricEngineHolder {
         ISymmetricEngine engine = null;
         try {
             String registrationUrl = properties.getProperty(ParameterConstants.REGISTRATION_URL);
-            if (StringUtils.isNotBlank(registrationUrl)) {
+            if (createConfig && StringUtils.isNotBlank(registrationUrl)) {
                 Collection<ServerSymmetricEngine> all = new ArrayList<ServerSymmetricEngine>(getEngines().values());
                 for (ISymmetricEngine currentEngine : all) {
                     if (currentEngine.getParameterService().getSyncUrl().equals(registrationUrl)) {
@@ -303,7 +308,7 @@ public class SymmetricEngineHolder {
                 if (listener != null) {
                     engine.getExtensionService().addExtensionPoint(listener);
                 }
-                engine.start();
+                engine.start(startJobs);
             } else {
                 FileUtils.deleteQuietly(symmetricProperties);
                 log.warn("The engine could not be created.  It will not be started");


### PR DESCRIPTION
- Made it possible to pass an `ISqlTransaction` object to many service methods used to make configuration changes
- Added a method to `ModuleManager` to check if it's possible to install a module
- Made it possible to prevent the `SymmetricEngineHolder` from starting a new engine's jobs
- Made it possible to prevent the `SymmetricEngineHolder` from making configuration changes or opening registration for a new engine

I used Claude to write the majority of this code.

I decided not to include unit tests for now in order to get these PRs created as soon as possible, but I'm open to adding some. If there's anything specific that you'd like to see unit tests for, let me know.