### PR TITLE
SYM-7372: Quote reserved keyword 'day' column in demo sample SQL for H2 2.x

### DIFF
--- a/symmetric-assemble/src/asciidoc/manage/node-send.ad
+++ b/symmetric-assemble/src/asciidoc/manage/node-send.ad
@@ -47,7 +47,7 @@ A "SQL" event runs SQL you specify at the target nodes.
 [source, sql]
 ----
 insert into sym_data (node_list, table_name, event_type, row_data, trigger_hist_id, channel_id, create_time)
-select '00001', source_table_name, 'S', '"delete from sale_transaction where day = ''2012-12-01''"', trigger_hist_id, 'reload', current_timestamp
+select '00001', source_table_name, 'S', '"delete from sale_transaction where ""day"" = ''2012-12-01''"', trigger_hist_id, 'reload', current_timestamp
 from sym_trigger_hist where source_table_name = 'sale_transaction' and inactive_time is null;
 ----
 

--- a/symmetric-assemble/src/asciidoc/tutorials/demo.ad
+++ b/symmetric-assemble/src/asciidoc/tutorials/demo.ad
@@ -162,7 +162,7 @@ Open an interactive SQL session with the store node database and add a new sale 
 
 [source, SQL]
 ----
-insert into sale_transaction (tran_id, store_id, workstation, day, seq) 
+insert into sale_transaction (tran_id, store_id, workstation, "day", seq)
 	values (1000, '001', '3', '2014-03-21', 100);
 	
 insert into sale_return_line_item (tran_id, item_id, price, quantity) 

--- a/symmetric-server/src/main/deploy/samples/insert_sample.sql
+++ b/symmetric-server/src/main/deploy/samples/insert_sample.sql
@@ -29,7 +29,7 @@ insert into item_selling_price (item_id, store_id, price, cost) values (11000001
 insert into item_selling_price (item_id, store_id, price, cost) values (11000001, '002',0.30, 0.20);
 
 -- Sales transactions and line items
-insert into sale_transaction (tran_id, store_id, workstation, day, seq) 
+insert into sale_transaction (tran_id, store_id, workstation, "day", seq)
 values (900, '001', '3', '2012-12-01', 90);
 insert into sale_return_line_item (tran_id, item_id, price, quantity, returned_quantity)
 values (900, 11000001, 0.20, 1, 0);


### PR DESCRIPTION
## Summary
- Quote the `day` column name with double quotes in `insert_sample.sql`, `demo.ad`, and `node-send.ad`
- H2 2.x treats `day` as a reserved keyword, causing the demo `INSERT INTO sale_transaction` statements to fail
- Double-quoted identifiers are ANSI SQL standard and compatible across database platforms

## Files changed
- `symmetric-server/src/main/deploy/samples/insert_sample.sql` — quote `day` in INSERT
- `symmetric-assemble/src/asciidoc/tutorials/demo.ad` — quote `day` in SQL example
- `symmetric-assemble/src/asciidoc/manage/node-send.ad` — quote `day` in SQL event example

## Test plan
- [ ] Run the demo setup against H2 2.x: `dbimport --engine corp-000 insert_sample.sql` completes without error
- [ ] Verify the demo tutorial SQL examples work when typed manually against H2 2.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)