### PR TITLE
SYM-7373: Enable auto.reload in demo corp properties for automatic initial load

### DIFF
--- a/symmetric-server/src/main/deploy/samples/corp-000.properties
+++ b/symmetric-server/src/main/deploy/samples/corp-000.properties
@@ -90,5 +90,8 @@ job.pull.period.time.ms=10000
 # If this is false, accept the registration requests using "symadmin open-registration" command.
 auto.registration=true
 
+# Automatically send an initial load to a node after it registers.
+auto.reload=true
+
 # When this node sends an initial load of data to another node, first send table create scripts.
 initial.load.create.first=true


### PR DESCRIPTION
## Summary
- Add `auto.reload=true` to `corp-000.properties` sample configuration
- The demo tutorial states "The store nodes were pre-configured to do an initial load after registration" but `auto.reload` was not set (defaults to `false`), so no automatic initial load occurred after registration

## Files changed
- `symmetric-server/src/main/deploy/samples/corp-000.properties` — add `auto.reload=true`

## Test plan
- [ ] Run the demo setup and verify store nodes automatically receive an initial load after registering with the corp node
- [ ] Verify the demo tutorial flow works end-to-end without manually running `reload-node`

🤖 Generated with [Claude Code](https://claude.com/claude-code)