### PR TITLE
SYM-7147: Prevented config import from replacing a valid license key with an invalid license key

### DIFF
--- a/symmetric-client/src/main/java/org/jumpmind/symmetric/SymmetricAdmin.java
+++ b/symmetric-client/src/main/java/org/jumpmind/symmetric/SymmetricAdmin.java
@@ -84,6 +84,7 @@ import org.jumpmind.symmetric.common.ParameterConstants;
 import org.jumpmind.symmetric.common.ServerConstants;
 import org.jumpmind.symmetric.common.TableConstants;
 import org.jumpmind.symmetric.db.ISymmetricDialect;
+import org.jumpmind.symmetric.ext.IConfigImportInterceptor;
 import org.jumpmind.symmetric.io.data.DbExportUtils;
 import org.jumpmind.symmetric.model.AbstractBatch.Status;
 import org.jumpmind.symmetric.model.IncomingBatch;
@@ -464,8 +465,9 @@ public class SymmetricAdmin extends AbstractCommandLauncher {
         String fileName = popArg(args, "file name");
         try {
             File configFile = new File(fileName);
+            String content = FileUtils.readFileToString(configFile, Charset.defaultCharset());
             if (fileName.toLowerCase().endsWith(".csv")) {
-                String content = FileUtils.readFileToString(configFile, Charset.defaultCharset());
+                content = interceptImport(content, true);
                 IDataLoaderService service = getSymmetricEngine().getDataLoaderService();
                 List<IncomingBatch> batches = service.loadDataBatch(content);
                 for (IncomingBatch batch : batches) {
@@ -475,8 +477,8 @@ public class SymmetricAdmin extends AbstractCommandLauncher {
                     }
                 }
             } else if (fileName.toLowerCase().endsWith(".sql")) {
-                URL url = configFile.toURI().toURL();
-                SqlScript script = new SqlScript(url, getSymmetricEngine().getDatabasePlatform().getSqlTemplate());
+                content = interceptImport(content, false);
+                SqlScript script = new SqlScript(content, getSymmetricEngine().getDatabasePlatform().getSqlTemplate(), true, null);
                 script.execute();
             } else {
                 System.err.println("ERROR: Expected a .csv or .sql file.");
@@ -485,6 +487,11 @@ public class SymmetricAdmin extends AbstractCommandLauncher {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private String interceptImport(String content, boolean isCsv) {
+        IConfigImportInterceptor interceptor = getSymmetricEngine().getExtensionService().getExtensionPoint(IConfigImportInterceptor.class);
+        return interceptor != null ? interceptor.interceptImport(content, isCsv) : content;
     }
 
     private void exportConfig(CommandLine line, List<String> args) {

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/ext/IConfigImportInterceptor.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/ext/IConfigImportInterceptor.java
@@ -1,0 +1,27 @@
+/**
+ * Licensed to JumpMind Inc under one or more contributor
+ * license agreements.  See the NOTICE file distributed
+ * with this work for additional information regarding
+ * copyright ownership.  JumpMind Inc licenses this file
+ * to you under the GNU General Public License, version 3.0 (GPLv3)
+ * (the "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3.0 (GPLv3) along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jumpmind.symmetric.ext;
+
+import org.jumpmind.extension.IExtensionPoint;
+
+public interface IConfigImportInterceptor extends IExtensionPoint {
+    String interceptImport(String content, boolean isCsv);
+}


### PR DESCRIPTION
I manually cherry-picked these changes to 3.15 because `SymmetricAdmin.importConfig()` has a slightly different implementation in this earlier version.

Original PR: https://github.com/jumpmindinc/symmetric-ds/pull/623