### PR TITLE
SYM-7099: Put indexes and foreign keys in separate batches when an initial load defers constraints so that tables don't need sorted in foreign key order

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/extract/SelectFromSymDataSource.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/extract/SelectFromSymDataSource.java
@@ -345,7 +345,7 @@ public class SelectFromSymDataSource extends SelectFromSource {
         if (excludeForeignKeys || deferConstraints) {
             copyTargetTable.removeAllForeignKeys();
         }
-        if (excludeIndexes || deferConstraints) {
+        if (excludeIndexes || (deferConstraints && !sendSchemaExcludeForeignKeys)) {
             copyTargetTable.removeAllIndexes();
         }
         if (includeTriggerDdl) {

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/DataExtractorService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/DataExtractorService.java
@@ -1052,7 +1052,8 @@ public class DataExtractorService extends AbstractService implements IDataExtrac
                     if (extractRequest != null && extractRequest.getStatus() != ExtractStatus.OK) {
                         sqlTemplate.update(getSql("updateExtractRequestStatus"), ExtractStatus.OK.name(), new Date(),
                                 currentBatch.getExtractRowCount(), currentBatch.getExtractMillis(), extractRequest.getRequestId());
-                        checkSendDeferredConstraints(extractRequest, null, targetNode);
+                        checkSendDeferredIndexes(extractRequest, null, targetNode);
+                        checkSendDeferredForeignKeys(extractRequest.getLoadId(), targetNode);
                     }
                 }
             }
@@ -2034,7 +2035,7 @@ public class DataExtractorService extends AbstractService implements IDataExtrac
                             processInfo, channel, isRestarted);
                     extractOutgoingBatch(processInfo, targetNode, multiBatchStagingWriter,
                             firstBatch, false, false, ExtractMode.FOR_SYM_CLIENT, new ClusterLockRefreshListener(clusterService));
-                    checkSendDeferredConstraints(request, childRequests, targetNode);
+                    checkSendDeferredIndexes(request, childRequests, targetNode);
                 } else {
                     log.info(
                             "Batches already had an OK status for request {} to extract table {} for batches {} through {} for node {} on queue {}.  Not extracting.",
@@ -2067,6 +2068,7 @@ public class DataExtractorService extends AbstractService implements IDataExtrac
                 } finally {
                     close(transaction);
                 }
+                checkSendDeferredForeignKeys(request.getLoadId(), targetNode);
                 releaseMissedExtractRequests();
                 processInfo.setStatus(ProcessInfo.ProcessStatus.OK);
             } catch (CancellationException ex) {
@@ -2187,7 +2189,7 @@ public class DataExtractorService extends AbstractService implements IDataExtrac
         }
     }
 
-    protected void checkSendDeferredConstraints(ExtractRequest request, List<ExtractRequest> childRequests, Node targetNode) {
+    protected void checkSendDeferredIndexes(ExtractRequest request, List<ExtractRequest> childRequests, Node targetNode) {
         if (parameterService.is(ParameterConstants.INITIAL_LOAD_DEFER_CREATE_CONSTRAINTS, false)) {
             TableReloadRequest reloadRequest = dataService.getTableReloadRequest(request.getLoadId(), request.getTriggerId(), request.getRouterId());
             if ((reloadRequest != null && reloadRequest.isCreateTable()) ||
@@ -2206,14 +2208,16 @@ public class DataExtractorService extends AbstractService implements IDataExtrac
                                 Data data = new Data(history.getSourceTableName(), DataEventType.CREATE, null, null,
                                         history, trigger.getChannelId(), String.valueOf(request.getLoadId()), null);
                                 data.setNodeList(targetNode.getNodeId());
-                                log.info("Deferred create event for load {} table {} on channel {}", request.getLoadId(), history.getSourceTableName(),
-                                        trigger.getChannelId());
+                                data.setOldData(Constants.SEND_SCHEMA_EXCLUDE_FOREIGN_KEYS);
+                                log.info("Deferred create event (indexes only) for load {} table {} on channel {}",
+                                        request.getLoadId(), history.getSourceTableName(), trigger.getChannelId());
                                 dataService.insertData(data);
                                 if (childRequests != null) {
                                     for (ExtractRequest childRequest : childRequests) {
                                         data = new Data(history.getSourceTableName(), DataEventType.CREATE, null, null,
                                                 history, trigger.getChannelId(), String.valueOf(childRequest.getLoadId()), null);
                                         data.setNodeList(childRequest.getNodeId());
+                                        data.setOldData(Constants.SEND_SCHEMA_EXCLUDE_FOREIGN_KEYS);
                                         dataService.insertData(data);
                                     }
                                 }
@@ -2226,6 +2230,53 @@ public class DataExtractorService extends AbstractService implements IDataExtrac
                 if (!success) {
                     log.warn("Unable to send deferred constraints for trigger '{}' router '{}' in load {}",
                             reloadRequest.getTriggerId(), reloadRequest.getRouterId(), reloadRequest.getLoadId());
+                }
+            }
+        }
+    }
+
+    protected void checkSendDeferredForeignKeys(long loadId, Node targetNode) {
+        if (!parameterService.is(ParameterConstants.INITIAL_LOAD_DEFER_CREATE_CONSTRAINTS, false) || sqlTemplateDirty
+                .queryForLong(getSql("countIncompleteExtractRequestsByLoadId"), loadId, engine.getNodeId()) > 0) {
+            return;
+        }
+        for (ExtractRequest request : getTablesForExtractByLoadId(loadId)) {
+            if (request.getParentRequestId() > 0) {
+                continue;
+            }
+            String triggerId = request.getTriggerId();
+            TableReloadRequest reloadRequest = dataService.getTableReloadRequest(loadId, triggerId, request.getRouterId());
+            if ((reloadRequest != null && reloadRequest.isCreateTable()) ||
+                    (reloadRequest == null && parameterService.is(ParameterConstants.INITIAL_LOAD_CREATE_SCHEMA_BEFORE_RELOAD))) {
+                Trigger trigger = triggerRouterService.getTriggerById(triggerId);
+                if (trigger != null) {
+                    Channel channel = configurationService.getChannel(trigger.getReloadChannelId());
+                    if (channel.isFileSyncFlag()) {
+                        continue;
+                    }
+                    List<TriggerHistory> histories = triggerRouterService.getActiveTriggerHistories(trigger);
+                    if (histories != null) {
+                        for (TriggerHistory history : histories) {
+                            if (history.getSourceTableName().equalsIgnoreCase(request.getTableName())) {
+                                Data data = new Data(history.getSourceTableName(), DataEventType.CREATE, null, null,
+                                        history, trigger.getChannelId(), String.valueOf(loadId), null);
+                                data.setNodeList(targetNode.getNodeId());
+                                log.info("Deferred create event (foreign keys) for load {} table {} on channel {}",
+                                        loadId, history.getSourceTableName(), trigger.getChannelId());
+                                dataService.insertData(data);
+                                List<ExtractRequest> childRequests = getExtractChildRequestsForNode(request);
+                                if (childRequests != null) {
+                                    for (ExtractRequest childRequest : childRequests) {
+                                        data = new Data(history.getSourceTableName(), DataEventType.CREATE, null, null,
+                                                history, trigger.getChannelId(), String.valueOf(childRequest.getLoadId()), null);
+                                        data.setNodeList(childRequest.getNodeId());
+                                        dataService.insertData(data);
+                                    }
+                                }
+                                break;
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/DataExtractorService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/DataExtractorService.java
@@ -2220,23 +2220,26 @@ public class DataExtractorService extends AbstractService implements IDataExtrac
             return;
         }
         for (ExtractRequest request : getTablesForExtractByLoadId(loadId)) {
-            if (request.getParentRequestId() > 0 || !isDeferredCreateRequired(request)) {
-                continue;
+            if (request.getParentRequestId() <= 0 && isDeferredCreateRequired(request)) {
+                sendDeferredForeignKeysForRequest(request, loadId, targetNode);
             }
-            Trigger trigger = triggerRouterService.getTriggerById(request.getTriggerId());
-            if (trigger == null || configurationService.getChannel(trigger.getReloadChannelId()).isFileSyncFlag()) {
-                continue;
-            }
-            TriggerHistory history = findMatchingHistory(trigger, request.getTableName());
-            if (history == null) {
-                continue;
-            }
-            log.info("Deferred create event (foreign keys) for load {} table {} on channel {}",
-                    loadId, history.getSourceTableName(), trigger.getChannelId());
-            insertDeferredCreateData(history, trigger.getChannelId(), loadId, targetNode.getNodeId(), null);
-            insertDeferredCreateDataForChildren(getExtractChildRequestsForNode(request), history,
-                    trigger.getChannelId(), null);
         }
+    }
+
+    private void sendDeferredForeignKeysForRequest(ExtractRequest request, long loadId, Node targetNode) {
+        Trigger trigger = triggerRouterService.getTriggerById(request.getTriggerId());
+        if (trigger == null || configurationService.getChannel(trigger.getReloadChannelId()).isFileSyncFlag()) {
+            return;
+        }
+        TriggerHistory history = findMatchingHistory(trigger, request.getTableName());
+        if (history == null) {
+            return;
+        }
+        log.info("Deferred create event (foreign keys) for load {} table {} on channel {}",
+                loadId, history.getSourceTableName(), trigger.getChannelId());
+        insertDeferredCreateData(history, trigger.getChannelId(), loadId, targetNode.getNodeId(), null);
+        insertDeferredCreateDataForChildren(getExtractChildRequestsForNode(request), history,
+                trigger.getChannelId(), null);
     }
 
     private boolean isDeferredCreateRequired(ExtractRequest request) {

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/DataExtractorService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/DataExtractorService.java
@@ -2190,49 +2190,28 @@ public class DataExtractorService extends AbstractService implements IDataExtrac
     }
 
     protected void checkSendDeferredIndexes(ExtractRequest request, List<ExtractRequest> childRequests, Node targetNode) {
-        if (parameterService.is(ParameterConstants.INITIAL_LOAD_DEFER_CREATE_CONSTRAINTS, false)) {
-            TableReloadRequest reloadRequest = dataService.getTableReloadRequest(request.getLoadId(), request.getTriggerId(), request.getRouterId());
-            if ((reloadRequest != null && reloadRequest.isCreateTable()) ||
-                    (reloadRequest == null && parameterService.is(ParameterConstants.INITIAL_LOAD_CREATE_SCHEMA_BEFORE_RELOAD))) {
-                boolean success = false;
-                Trigger trigger = triggerRouterService.getTriggerById(request.getTriggerId());
-                if (trigger != null) {
-                    Channel channel = configurationService.getChannel(trigger.getReloadChannelId());
-                    if (channel.isFileSyncFlag()) {
-                        return;
-                    }
-                    List<TriggerHistory> histories = triggerRouterService.getActiveTriggerHistories(trigger);
-                    if (histories != null && histories.size() > 0) {
-                        for (TriggerHistory history : histories) {
-                            if (history.getSourceTableName().equalsIgnoreCase(request.getTableName())) {
-                                Data data = new Data(history.getSourceTableName(), DataEventType.CREATE, null, null,
-                                        history, trigger.getChannelId(), String.valueOf(request.getLoadId()), null);
-                                data.setNodeList(targetNode.getNodeId());
-                                data.setOldData(Constants.SEND_SCHEMA_EXCLUDE_FOREIGN_KEYS);
-                                log.info("Deferred create event (indexes only) for load {} table {} on channel {}",
-                                        request.getLoadId(), history.getSourceTableName(), trigger.getChannelId());
-                                dataService.insertData(data);
-                                if (childRequests != null) {
-                                    for (ExtractRequest childRequest : childRequests) {
-                                        data = new Data(history.getSourceTableName(), DataEventType.CREATE, null, null,
-                                                history, trigger.getChannelId(), String.valueOf(childRequest.getLoadId()), null);
-                                        data.setNodeList(childRequest.getNodeId());
-                                        data.setOldData(Constants.SEND_SCHEMA_EXCLUDE_FOREIGN_KEYS);
-                                        dataService.insertData(data);
-                                    }
-                                }
-                                success = true;
-                                break;
-                            }
-                        }
-                    }
-                }
-                if (!success) {
-                    log.warn("Unable to send deferred constraints for trigger '{}' router '{}' in load {}",
-                            reloadRequest.getTriggerId(), reloadRequest.getRouterId(), reloadRequest.getLoadId());
-                }
-            }
+        if (!parameterService.is(ParameterConstants.INITIAL_LOAD_DEFER_CREATE_CONSTRAINTS, false) || !isDeferredCreateRequired(request)) {
+            return;
         }
+        Trigger trigger = triggerRouterService.getTriggerById(request.getTriggerId());
+        if (trigger == null) {
+            logDeferredConstraintWarning(request);
+            return;
+        }
+        if (configurationService.getChannel(trigger.getReloadChannelId()).isFileSyncFlag()) {
+            return;
+        }
+        TriggerHistory history = findMatchingHistory(trigger, request.getTableName());
+        if (history == null) {
+            logDeferredConstraintWarning(request);
+            return;
+        }
+        log.info("Deferred create event (indexes only) for load {} table {} on channel {}",
+                request.getLoadId(), history.getSourceTableName(), trigger.getChannelId());
+        insertDeferredCreateData(history, trigger.getChannelId(), request.getLoadId(), targetNode.getNodeId(),
+                Constants.SEND_SCHEMA_EXCLUDE_FOREIGN_KEYS);
+        insertDeferredCreateDataForChildren(childRequests, history, trigger.getChannelId(),
+                Constants.SEND_SCHEMA_EXCLUDE_FOREIGN_KEYS);
     }
 
     protected void checkSendDeferredForeignKeys(long loadId, Node targetNode) {
@@ -2241,44 +2220,67 @@ public class DataExtractorService extends AbstractService implements IDataExtrac
             return;
         }
         for (ExtractRequest request : getTablesForExtractByLoadId(loadId)) {
-            if (request.getParentRequestId() > 0) {
+            if (request.getParentRequestId() > 0 || !isDeferredCreateRequired(request)) {
                 continue;
             }
-            String triggerId = request.getTriggerId();
-            TableReloadRequest reloadRequest = dataService.getTableReloadRequest(loadId, triggerId, request.getRouterId());
-            if ((reloadRequest != null && reloadRequest.isCreateTable()) ||
-                    (reloadRequest == null && parameterService.is(ParameterConstants.INITIAL_LOAD_CREATE_SCHEMA_BEFORE_RELOAD))) {
-                Trigger trigger = triggerRouterService.getTriggerById(triggerId);
-                if (trigger != null) {
-                    Channel channel = configurationService.getChannel(trigger.getReloadChannelId());
-                    if (channel.isFileSyncFlag()) {
-                        continue;
-                    }
-                    List<TriggerHistory> histories = triggerRouterService.getActiveTriggerHistories(trigger);
-                    if (histories != null) {
-                        for (TriggerHistory history : histories) {
-                            if (history.getSourceTableName().equalsIgnoreCase(request.getTableName())) {
-                                Data data = new Data(history.getSourceTableName(), DataEventType.CREATE, null, null,
-                                        history, trigger.getChannelId(), String.valueOf(loadId), null);
-                                data.setNodeList(targetNode.getNodeId());
-                                log.info("Deferred create event (foreign keys) for load {} table {} on channel {}",
-                                        loadId, history.getSourceTableName(), trigger.getChannelId());
-                                dataService.insertData(data);
-                                List<ExtractRequest> childRequests = getExtractChildRequestsForNode(request);
-                                if (childRequests != null) {
-                                    for (ExtractRequest childRequest : childRequests) {
-                                        data = new Data(history.getSourceTableName(), DataEventType.CREATE, null, null,
-                                                history, trigger.getChannelId(), String.valueOf(childRequest.getLoadId()), null);
-                                        data.setNodeList(childRequest.getNodeId());
-                                        dataService.insertData(data);
-                                    }
-                                }
-                                break;
-                            }
-                        }
-                    }
+            Trigger trigger = triggerRouterService.getTriggerById(request.getTriggerId());
+            if (trigger == null || configurationService.getChannel(trigger.getReloadChannelId()).isFileSyncFlag()) {
+                continue;
+            }
+            TriggerHistory history = findMatchingHistory(trigger, request.getTableName());
+            if (history == null) {
+                continue;
+            }
+            log.info("Deferred create event (foreign keys) for load {} table {} on channel {}",
+                    loadId, history.getSourceTableName(), trigger.getChannelId());
+            insertDeferredCreateData(history, trigger.getChannelId(), loadId, targetNode.getNodeId(), null);
+            insertDeferredCreateDataForChildren(getExtractChildRequestsForNode(request), history,
+                    trigger.getChannelId(), null);
+        }
+    }
+
+    private boolean isDeferredCreateRequired(ExtractRequest request) {
+        TableReloadRequest reloadRequest = dataService.getTableReloadRequest(request.getLoadId(), request.getTriggerId(), request.getRouterId());
+        return (reloadRequest != null && reloadRequest.isCreateTable()) ||
+                (reloadRequest == null && parameterService.is(ParameterConstants.INITIAL_LOAD_CREATE_SCHEMA_BEFORE_RELOAD));
+    }
+
+    private TriggerHistory findMatchingHistory(Trigger trigger, String tableName) {
+        List<TriggerHistory> histories = triggerRouterService.getActiveTriggerHistories(trigger);
+        if (histories != null) {
+            for (TriggerHistory history : histories) {
+                if (history.getSourceTableName().equalsIgnoreCase(tableName)) {
+                    return history;
                 }
             }
+        }
+        return null;
+    }
+
+    private void insertDeferredCreateData(TriggerHistory history, String channelId, long loadId, String nodeId, String oldData) {
+        Data data = new Data(history.getSourceTableName(), DataEventType.CREATE, null, null, history, channelId,
+                String.valueOf(loadId), null);
+        data.setNodeList(nodeId);
+        if (oldData != null) {
+            data.setOldData(oldData);
+        }
+        dataService.insertData(data);
+    }
+
+    private void insertDeferredCreateDataForChildren(List<ExtractRequest> childRequests, TriggerHistory history,
+            String channelId, String oldData) {
+        if (childRequests != null) {
+            for (ExtractRequest childRequest : childRequests) {
+                insertDeferredCreateData(history, channelId, childRequest.getLoadId(), childRequest.getNodeId(), oldData);
+            }
+        }
+    }
+
+    private void logDeferredConstraintWarning(ExtractRequest request) {
+        TableReloadRequest reloadRequest = dataService.getTableReloadRequest(request.getLoadId(), request.getTriggerId(), request.getRouterId());
+        if (reloadRequest != null) {
+            log.warn("Unable to send deferred constraints for trigger '{}' router '{}' in load {}",
+                    reloadRequest.getTriggerId(), reloadRequest.getRouterId(), reloadRequest.getLoadId());
         }
     }
 

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/DataExtractorServiceSqlMap.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/DataExtractorServiceSqlMap.java
@@ -95,6 +95,8 @@ public class DataExtractorServiceSqlMap extends AbstractSqlMap {
 
         putSql("cancelExtractRequests", "update $(extract_request) set status=?, last_update_time=?, loaded_time=? where load_id = ? and source_node_id = ? and (status != ? or loaded_time is null)");
 
+        putSql("countIncompleteExtractRequestsByLoadId", "select count(*) from $(extract_request) where load_id = ? and source_node_id = ? and parent_request_id = 0 and status != 'OK'");
+
         putSql("selectTablesForExtractByLoadId", "select * from $(extract_request) where load_id = ? and source_node_id = ? order by request_id");
     
         putSql("selectTablesForExtractByLoadIdAndNodeId", "select * from $(extract_request) where load_id = ? and node_id = ? order by request_id");

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/DataService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/DataService.java
@@ -1114,7 +1114,8 @@ public class DataService extends AbstractService implements IDataService {
                                         .getActiveTriggerHistories(new Trigger(reloadRequest.getTriggerId(), null)));
                             }
                         }
-                        boolean sortByFk = true;
+                        boolean sortByFk = !(isFullLoad && parameterService.is(ParameterConstants.INITIAL_LOAD_DEFER_CREATE_CONSTRAINTS, false) &&
+                                reloadRequests != null && reloadRequests.size() > 0 && reloadRequests.get(0).isCreateTable());
                         Map<Integer, List<TriggerRouter>> triggerRoutersByHistoryId = triggerRouterService
                                 .fillTriggerRoutersByHistIdAndSortHist(sourceNode.getNodeGroupId(),
                                         targetNode.getNodeGroupId(), targetNode.getExternalId(), triggerHistories, triggerRouters, sortByFk);
@@ -1470,7 +1471,12 @@ public class DataService extends AbstractService implements IDataService {
             Map<Integer, List<TriggerRouter>> triggerRoutersByHistoryId, boolean transactional,
             ISqlTransaction transaction, Map<String, TableReloadRequest> reloadRequests) throws InterruptedException {
         int createEventsSent = 0;
+        boolean deferConstraints = parameterService.is(ParameterConstants.INITIAL_LOAD_DEFER_CREATE_CONSTRAINTS, false);
         if (reloadRequests != null && reloadRequests.size() > 0) {
+            if (deferConstraints) {
+                createEventsSent += insertDropForeignKeyEventsForReload(targetNode, loadId, createBy,
+                        triggerHistories, triggerRoutersByHistoryId, transactional, transaction, reloadRequests, true);
+            }
             for (TriggerHistory triggerHistory : triggerHistories) {
                 List<TriggerRouter> triggerRouters = triggerRoutersByHistoryId.get(triggerHistory
                         .getTriggerHistoryId());
@@ -1502,6 +1508,10 @@ public class DataService extends AbstractService implements IDataService {
             }
         } else {
             if (parameterService.is(ParameterConstants.INITIAL_LOAD_CREATE_SCHEMA_BEFORE_RELOAD)) {
+                if (deferConstraints) {
+                    createEventsSent += insertDropForeignKeyEventsForReload(targetNode, loadId, createBy,
+                            triggerHistories, triggerRoutersByHistoryId, transactional, transaction, reloadRequests, false);
+                }
                 for (TriggerHistory triggerHistory : triggerHistories) {
                     List<TriggerRouter> triggerRouters = triggerRoutersByHistoryId.get(triggerHistory
                             .getTriggerHistoryId());
@@ -1522,6 +1532,48 @@ public class DataService extends AbstractService implements IDataService {
             }
         }
         return createEventsSent;
+    }
+
+    private int insertDropForeignKeyEventsForReload(Node targetNode, long loadId, String createBy, List<TriggerHistory> triggerHistories,
+            Map<Integer, List<TriggerRouter>> triggerRoutersByHistoryId, boolean transactional, ISqlTransaction transaction,
+            Map<String, TableReloadRequest> reloadRequests, boolean hasReloadRequests) throws InterruptedException {
+        int eventsSent = 0;
+        for (TriggerHistory triggerHistory : triggerHistories) {
+            List<TriggerRouter> triggerRouters = triggerRoutersByHistoryId.get(triggerHistory.getTriggerHistoryId());
+            if (hasReloadRequests) {
+                TableReloadRequest currentRequest = reloadRequests.get(ParameterConstants.ALL + ParameterConstants.ALL);
+                boolean fullLoad = currentRequest != null;
+                for (TriggerRouter triggerRouter : triggerRouters) {
+                    if (!fullLoad) {
+                        currentRequest = reloadRequests.get(triggerRouter.getTriggerId() + triggerRouter.getRouterId());
+                    }
+                    if (triggerRouter.getInitialLoadOrder() > -1 && currentRequest != null && currentRequest.isCreateTable()
+                            && engine.getGroupletService().isTargetEnabled(triggerRouter, targetNode)
+                            && !triggerHistory.getSourceTableNameLowerCase().startsWith(symmetricDialect.getTablePrefix().toLowerCase() + "_")) {
+                        insertCreateEvent(transaction, targetNode, triggerHistory, triggerRouter.getTrigger().getReloadChannelId(), true,
+                                loadId, createBy, false, true, false, Status.LS, null, null);
+                        eventsSent++;
+                        if (!transactional) {
+                            transaction.commit();
+                        }
+                    }
+                    checkInterrupted();
+                }
+            } else {
+                for (TriggerRouter triggerRouter : triggerRouters) {
+                    if (triggerRouter.getInitialLoadOrder() >= 0 && engine.getGroupletService().isTargetEnabled(triggerRouter, targetNode)) {
+                        insertCreateEvent(transaction, targetNode, triggerHistory, triggerRouter.getRouter().getRouterId(), true,
+                                loadId, createBy, false, true, false, Status.LS, null, null);
+                        eventsSent++;
+                        if (!transactional) {
+                            transaction.commit();
+                        }
+                        checkInterrupted();
+                    }
+                }
+            }
+        }
+        return eventsSent;
     }
 
     private int insertDeleteBatchesForReload(Node targetNode, long loadId, String createBy,

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/DataService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/DataService.java
@@ -1115,7 +1115,7 @@ public class DataService extends AbstractService implements IDataService {
                             }
                         }
                         boolean sortByFk = !(isFullLoad && parameterService.is(ParameterConstants.INITIAL_LOAD_DEFER_CREATE_CONSTRAINTS, false) &&
-                                reloadRequests != null && reloadRequests.size() > 0 && reloadRequests.get(0).isCreateTable());
+                                reloadRequests != null && !reloadRequests.isEmpty() && reloadRequests.get(0).isCreateTable());
                         Map<Integer, List<TriggerRouter>> triggerRoutersByHistoryId = triggerRouterService
                                 .fillTriggerRoutersByHistIdAndSortHist(sourceNode.getNodeGroupId(),
                                         targetNode.getNodeGroupId(), targetNode.getExternalId(), triggerHistories, triggerRouters, sortByFk);
@@ -1475,7 +1475,7 @@ public class DataService extends AbstractService implements IDataService {
         if (reloadRequests != null && reloadRequests.size() > 0) {
             if (deferConstraints) {
                 createEventsSent += insertDropForeignKeyEventsForReload(targetNode, loadId, createBy,
-                        triggerHistories, triggerRoutersByHistoryId, transactional, transaction, reloadRequests, true);
+                        triggerHistories, triggerRoutersByHistoryId, transaction, reloadRequests);
             }
             for (TriggerHistory triggerHistory : triggerHistories) {
                 List<TriggerRouter> triggerRouters = triggerRoutersByHistoryId.get(triggerHistory
@@ -1510,7 +1510,7 @@ public class DataService extends AbstractService implements IDataService {
             if (parameterService.is(ParameterConstants.INITIAL_LOAD_CREATE_SCHEMA_BEFORE_RELOAD)) {
                 if (deferConstraints) {
                     createEventsSent += insertDropForeignKeyEventsForReload(targetNode, loadId, createBy,
-                            triggerHistories, triggerRoutersByHistoryId, transactional, transaction, reloadRequests, false);
+                            triggerHistories, triggerRoutersByHistoryId, transaction, reloadRequests);
                 }
                 for (TriggerHistory triggerHistory : triggerHistories) {
                     List<TriggerRouter> triggerRouters = triggerRoutersByHistoryId.get(triggerHistory
@@ -1535,45 +1535,43 @@ public class DataService extends AbstractService implements IDataService {
     }
 
     private int insertDropForeignKeyEventsForReload(Node targetNode, long loadId, String createBy, List<TriggerHistory> triggerHistories,
-            Map<Integer, List<TriggerRouter>> triggerRoutersByHistoryId, boolean transactional, ISqlTransaction transaction,
-            Map<String, TableReloadRequest> reloadRequests, boolean hasReloadRequests) throws InterruptedException {
+            Map<Integer, List<TriggerRouter>> triggerRoutersByHistoryId, ISqlTransaction transaction,
+            Map<String, TableReloadRequest> reloadRequests) throws InterruptedException {
+        boolean hasReloadRequests = reloadRequests != null && !reloadRequests.isEmpty();
+        boolean transactional = parameterService.is(ParameterConstants.DATA_RELOAD_IS_BATCH_INSERT_TRANSACTIONAL);
         int eventsSent = 0;
         for (TriggerHistory triggerHistory : triggerHistories) {
             List<TriggerRouter> triggerRouters = triggerRoutersByHistoryId.get(triggerHistory.getTriggerHistoryId());
-            if (hasReloadRequests) {
-                TableReloadRequest currentRequest = reloadRequests.get(ParameterConstants.ALL + ParameterConstants.ALL);
-                boolean fullLoad = currentRequest != null;
-                for (TriggerRouter triggerRouter : triggerRouters) {
-                    if (!fullLoad) {
-                        currentRequest = reloadRequests.get(triggerRouter.getTriggerId() + triggerRouter.getRouterId());
-                    }
-                    if (triggerRouter.getInitialLoadOrder() > -1 && currentRequest != null && currentRequest.isCreateTable()
-                            && engine.getGroupletService().isTargetEnabled(triggerRouter, targetNode)
-                            && !triggerHistory.getSourceTableNameLowerCase().startsWith(symmetricDialect.getTablePrefix().toLowerCase() + "_")) {
-                        insertCreateEvent(transaction, targetNode, triggerHistory, triggerRouter.getTrigger().getReloadChannelId(), true,
-                                loadId, createBy, false, true, false, Status.LS, null, null);
-                        eventsSent++;
-                        if (!transactional) {
-                            transaction.commit();
-                        }
-                    }
-                    checkInterrupted();
-                }
-            } else {
-                for (TriggerRouter triggerRouter : triggerRouters) {
-                    if (triggerRouter.getInitialLoadOrder() >= 0 && engine.getGroupletService().isTargetEnabled(triggerRouter, targetNode)) {
-                        insertCreateEvent(transaction, targetNode, triggerHistory, triggerRouter.getRouter().getRouterId(), true,
-                                loadId, createBy, false, true, false, Status.LS, null, null);
-                        eventsSent++;
-                        if (!transactional) {
-                            transaction.commit();
-                        }
-                        checkInterrupted();
+            for (TriggerRouter triggerRouter : triggerRouters) {
+                if (shouldSendDropFkEvent(triggerRouter, triggerHistory, targetNode, reloadRequests, hasReloadRequests)) {
+                    String channelId = hasReloadRequests ? triggerRouter.getTrigger().getReloadChannelId() : triggerRouter.getRouter().getRouterId();
+                    insertCreateEvent(transaction, targetNode, triggerHistory, channelId, true,
+                            loadId, createBy, false, true, false, Status.LS, null, null);
+                    eventsSent++;
+                    if (!transactional) {
+                        transaction.commit();
                     }
                 }
+                checkInterrupted();
             }
         }
         return eventsSent;
+    }
+
+    private boolean shouldSendDropFkEvent(TriggerRouter triggerRouter, TriggerHistory triggerHistory, Node targetNode,
+            Map<String, TableReloadRequest> reloadRequests, boolean hasReloadRequests) {
+        if (!engine.getGroupletService().isTargetEnabled(triggerRouter, targetNode)) {
+            return false;
+        }
+        if (hasReloadRequests) {
+            TableReloadRequest currentRequest = reloadRequests.get(ParameterConstants.ALL + ParameterConstants.ALL);
+            if (currentRequest == null) {
+                currentRequest = reloadRequests.get(triggerRouter.getTriggerId() + triggerRouter.getRouterId());
+            }
+            return triggerRouter.getInitialLoadOrder() > -1 && currentRequest != null && currentRequest.isCreateTable()
+                    && !triggerHistory.getSourceTableNameLowerCase().startsWith(symmetricDialect.getTablePrefix().toLowerCase() + "_");
+        }
+        return triggerRouter.getInitialLoadOrder() >= 0;
     }
 
     private int insertDeleteBatchesForReload(Node targetNode, long loadId, String createBy,

--- a/symmetric-core/src/test/java/org/jumpmind/symmetric/extract/SelectFromSymDataSourceTest.java
+++ b/symmetric-core/src/test/java/org/jumpmind/symmetric/extract/SelectFromSymDataSourceTest.java
@@ -1,0 +1,219 @@
+/**
+ * Licensed to JumpMind Inc under one or more contributor
+ * license agreements.  See the NOTICE file distributed
+ * with this work for additional information regarding
+ * copyright ownership.  JumpMind Inc licenses this file
+ * to you under the GNU General Public License, version 3.0 (GPLv3)
+ * (the "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3.0 (GPLv3) along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jumpmind.symmetric.extract;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+
+import org.jumpmind.db.model.Column;
+import org.jumpmind.db.model.ForeignKey;
+import org.jumpmind.db.model.IndexColumn;
+import org.jumpmind.db.model.NonUniqueIndex;
+import org.jumpmind.db.model.Reference;
+import org.jumpmind.db.model.Table;
+import org.jumpmind.db.platform.DatabaseInfo;
+import org.jumpmind.db.platform.IDatabasePlatform;
+import org.jumpmind.db.util.BinaryEncoding;
+import org.jumpmind.symmetric.ISymmetricEngine;
+import org.jumpmind.symmetric.common.Constants;
+import org.jumpmind.symmetric.common.ParameterConstants;
+import org.jumpmind.symmetric.db.ISymmetricDialect;
+import org.jumpmind.symmetric.io.data.DataEventType;
+import org.jumpmind.symmetric.model.Data;
+import org.jumpmind.symmetric.model.Node;
+import org.jumpmind.symmetric.model.OutgoingBatch;
+import org.jumpmind.symmetric.model.ProcessInfo;
+import org.jumpmind.symmetric.model.TriggerHistory;
+import org.jumpmind.symmetric.service.IConfigurationService;
+import org.jumpmind.symmetric.service.IDataService;
+import org.jumpmind.symmetric.service.IExtensionService;
+import org.jumpmind.symmetric.service.INodeService;
+import org.jumpmind.symmetric.service.IParameterService;
+import org.jumpmind.symmetric.service.ITransformService;
+import org.jumpmind.symmetric.service.ITriggerRouterService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class SelectFromSymDataSourceTest {
+    private ISymmetricEngine engine;
+    private IParameterService parameterService;
+    private IDataService dataService;
+    private ITriggerRouterService triggerRouterService;
+    private IDatabasePlatform platform;
+    private ISymmetricDialect symmetricDialect;
+    private OutgoingBatch outgoingBatch;
+    private Node sourceNode;
+    private Node targetNode;
+    private Table tableWithFksAndIndexes;
+
+    @BeforeEach
+    public void setUp() {
+        engine = mock(ISymmetricEngine.class);
+        parameterService = mock(IParameterService.class);
+        dataService = mock(IDataService.class);
+        triggerRouterService = mock(ITriggerRouterService.class);
+        platform = mock(IDatabasePlatform.class);
+        symmetricDialect = mock(ISymmetricDialect.class);
+        IConfigurationService configurationService = mock(IConfigurationService.class);
+        INodeService nodeService = mock(INodeService.class);
+        IExtensionService extensionService = mock(IExtensionService.class);
+        ITransformService transformService = mock(ITransformService.class);
+        when(engine.getParameterService()).thenReturn(parameterService);
+        when(engine.getTransformService()).thenReturn(transformService);
+        when(engine.getTablePrefix()).thenReturn("sym");
+        when(engine.getDataService()).thenReturn(dataService);
+        when(engine.getTriggerRouterService()).thenReturn(triggerRouterService);
+        when(engine.getDatabasePlatform()).thenReturn(platform);
+        when(engine.getSymmetricDialect()).thenReturn(symmetricDialect);
+        when(engine.getConfigurationService()).thenReturn(configurationService);
+        when(engine.getNodeService()).thenReturn(nodeService);
+        when(engine.getExtensionService()).thenReturn(extensionService);
+        when(symmetricDialect.getBinaryEncoding()).thenReturn(BinaryEncoding.HEX);
+        when(symmetricDialect.getName()).thenReturn("H2");
+        when(symmetricDialect.getTargetDialect()).thenReturn(symmetricDialect);
+        when(symmetricDialect.getPlatform()).thenReturn(platform);
+        when(platform.getDatabaseInfo()).thenReturn(new DatabaseInfo());
+        when(triggerRouterService.getTriggerRoutersByTriggerHist(anyString(), anyBoolean())).thenReturn(null);
+        when(parameterService.is(ParameterConstants.CREATE_TABLE_WITHOUT_DEFAULTS, false)).thenReturn(false);
+        when(parameterService.is(ParameterConstants.CREATE_TABLE_WITHOUT_FOREIGN_KEYS, false)).thenReturn(false);
+        when(parameterService.is(ParameterConstants.CREATE_TABLE_WITHOUT_INDEXES, false)).thenReturn(false);
+        when(parameterService.is(ParameterConstants.CREATE_TABLE_WITHOUT_PK_IF_SOURCE_WITHOUT_PK, false)).thenReturn(false);
+        when(parameterService.is(ParameterConstants.CREATE_TABLE_INCLUDE_APPLICATION_TRIGGERS, false)).thenReturn(false);
+        when(parameterService.is(ParameterConstants.MYSQL_TINYINT_DDL_TO_BOOLEAN, false)).thenReturn(false);
+        when(parameterService.is(ParameterConstants.DBDIALECT_SYBASE_ASE_CONVERT_UNITYPES_FOR_SYNC)).thenReturn(false);
+        when(parameterService.is(ParameterConstants.INITIAL_LOAD_DEFER_TABLE_LOGGING, false)).thenReturn(false);
+        sourceNode = new Node("source", "server");
+        targetNode = new Node("target", "client");
+        outgoingBatch = mock(OutgoingBatch.class);
+        when(outgoingBatch.getBatchId()).thenReturn(1L);
+        when(outgoingBatch.getChannelId()).thenReturn("default");
+        when(outgoingBatch.getNodeId()).thenReturn("target");
+        when(outgoingBatch.isCommonFlag()).thenReturn(false);
+        when(outgoingBatch.getLoadId()).thenReturn(0L);
+        when(outgoingBatch.getNodeBatchId()).thenReturn("target-1");
+        tableWithFksAndIndexes = buildTableWithFksAndIndexes();
+        when(platform.getTableFromCache(any(), any(), any(), anyBoolean())).thenReturn(tableWithFksAndIndexes);
+    }
+
+    private Table buildTableWithFksAndIndexes() {
+        Column idCol = new Column("id");
+        idCol.setPrimaryKey(true);
+        Column nameCol = new Column("name");
+        Column refCol = new Column("ref_id");
+        Table table = new Table("test_table");
+        table.addColumn(idCol);
+        table.addColumn(nameCol);
+        table.addColumn(refCol);
+        ForeignKey fk = new ForeignKey("fk_ref", "other_table");
+        fk.addReference(new Reference(refCol, new Column("id")));
+        table.addForeignKey(fk);
+        NonUniqueIndex idx = new NonUniqueIndex("idx_name");
+        idx.addColumn(new IndexColumn(nameCol));
+        table.addIndex(idx);
+        return table;
+    }
+
+    private SelectFromSymDataSource createSource() {
+        return new SelectFromSymDataSource(engine, outgoingBatch, sourceNode, targetNode, new ProcessInfo(), false);
+    }
+
+    private void setColumnsAccordingToTriggerHistory(SelectFromSymDataSource source, Table targetTable) throws Exception {
+        ColumnsAccordingToTriggerHistory mockLookup = mock(ColumnsAccordingToTriggerHistory.class);
+        when(mockLookup.lookup(anyString(), any(TriggerHistory.class), anyBoolean(), anyBoolean(), anyBoolean(),
+                anyBoolean())).thenReturn(targetTable);
+        Field field = SelectFromSymDataSource.class.getDeclaredField("columnsAccordingToTriggerHistory");
+        field.setAccessible(true);
+        field.set(source, mockLookup);
+    }
+
+    @Test
+    public void processCreateEvent_preSetupFkDrop_stripsFksKeepsIndexes() throws Exception {
+        when(outgoingBatch.isLoadFlag()).thenReturn(true);
+        when(parameterService.is(ParameterConstants.INITIAL_LOAD_DEFER_CREATE_CONSTRAINTS, false)).thenReturn(true);
+        SelectFromSymDataSource source = createSource();
+        source.sourceTable = tableWithFksAndIndexes;
+        setColumnsAccordingToTriggerHistory(source, buildTableWithFksAndIndexes());
+        TriggerHistory hist = new TriggerHistory("test_table", "id", "id,name,ref_id");
+        Data data = new Data("test_table", DataEventType.CREATE, "", null, hist, "default", null, null);
+        data.setOldData(Constants.SEND_SCHEMA_EXCLUDE_FOREIGN_KEYS);
+        boolean result = source.processCreateEvent(hist, "router1", data);
+        assertTrue(result);
+        String xml = data.getRowData();
+        assertFalse(xml.contains("foreign-key"), "Phase 1 setup batch should strip foreign keys");
+        assertTrue(xml.contains("index"), "Phase 1 setup batch should keep indexes");
+    }
+
+    @Test
+    public void processCreateEvent_setupBatch_stripsBothFksAndIndexes() throws Exception {
+        when(outgoingBatch.isLoadFlag()).thenReturn(true);
+        when(parameterService.is(ParameterConstants.INITIAL_LOAD_DEFER_CREATE_CONSTRAINTS, false)).thenReturn(true);
+        SelectFromSymDataSource source = createSource();
+        source.sourceTable = tableWithFksAndIndexes;
+        setColumnsAccordingToTriggerHistory(source, buildTableWithFksAndIndexes());
+        TriggerHistory hist = new TriggerHistory("test_table", "id", "id,name,ref_id");
+        Data data = new Data("test_table", DataEventType.CREATE, "", null, hist, "default", null, null);
+        boolean result = source.processCreateEvent(hist, "router1", data);
+        assertTrue(result);
+        String xml = data.getRowData();
+        assertFalse(xml.contains("foreign-key"), "Phase 2 setup batch should strip foreign keys");
+        assertFalse(xml.contains("index"), "Phase 2 setup batch should strip indexes");
+    }
+
+    @Test
+    public void processCreateEvent_phase1Finalize_stripsFksKeepsIndexes() throws Exception {
+        when(outgoingBatch.isLoadFlag()).thenReturn(false);
+        when(parameterService.is(ParameterConstants.INITIAL_LOAD_DEFER_CREATE_CONSTRAINTS, false)).thenReturn(true);
+        SelectFromSymDataSource source = createSource();
+        source.sourceTable = tableWithFksAndIndexes;
+        setColumnsAccordingToTriggerHistory(source, buildTableWithFksAndIndexes());
+        TriggerHistory hist = new TriggerHistory("test_table", "id", "id,name,ref_id");
+        Data data = new Data("test_table", DataEventType.CREATE, "", null, hist, "default", null, null);
+        data.setOldData(Constants.SEND_SCHEMA_EXCLUDE_FOREIGN_KEYS);
+        boolean result = source.processCreateEvent(hist, "router1", data);
+        assertTrue(result);
+        String xml = data.getRowData();
+        assertFalse(xml.contains("foreign-key"), "Phase 1 finalize batch should strip foreign keys");
+        assertTrue(xml.contains("index"), "Phase 1 finalize batch should keep indexes");
+    }
+
+    @Test
+    public void processCreateEvent_phase2Finalize_keepsAll() throws Exception {
+        when(outgoingBatch.isLoadFlag()).thenReturn(false);
+        when(parameterService.is(ParameterConstants.INITIAL_LOAD_DEFER_CREATE_CONSTRAINTS, false)).thenReturn(true);
+        SelectFromSymDataSource source = createSource();
+        source.sourceTable = tableWithFksAndIndexes;
+        setColumnsAccordingToTriggerHistory(source, buildTableWithFksAndIndexes());
+        TriggerHistory hist = new TriggerHistory("test_table", "id", "id,name,ref_id");
+        Data data = new Data("test_table", DataEventType.CREATE, "", null, hist, "default", null, null);
+        boolean result = source.processCreateEvent(hist, "router1", data);
+        assertTrue(result);
+        String xml = data.getRowData();
+        assertTrue(xml.contains("foreign-key"), "Phase 2 finalize batch should keep foreign keys");
+        assertTrue(xml.contains("index"), "Phase 2 finalize batch should keep indexes");
+    }
+}

--- a/symmetric-core/src/test/java/org/jumpmind/symmetric/extract/SelectFromSymDataSourceTest.java
+++ b/symmetric-core/src/test/java/org/jumpmind/symmetric/extract/SelectFromSymDataSourceTest.java
@@ -59,7 +59,7 @@ import org.jumpmind.symmetric.service.ITriggerRouterService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class SelectFromSymDataSourceTest {
+class SelectFromSymDataSourceTest {
     private ISymmetricEngine engine;
     private IParameterService parameterService;
     private IDataService dataService;
@@ -72,7 +72,7 @@ public class SelectFromSymDataSourceTest {
     private Table tableWithFksAndIndexes;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         engine = mock(ISymmetricEngine.class);
         parameterService = mock(IParameterService.class);
         dataService = mock(IDataService.class);
@@ -152,7 +152,7 @@ public class SelectFromSymDataSourceTest {
     }
 
     @Test
-    public void processCreateEvent_preSetupFkDrop_stripsFksKeepsIndexes() throws Exception {
+    void processCreateEvent_preSetupFkDrop_stripsFksKeepsIndexes() throws Exception {
         when(outgoingBatch.isLoadFlag()).thenReturn(true);
         when(parameterService.is(ParameterConstants.INITIAL_LOAD_DEFER_CREATE_CONSTRAINTS, false)).thenReturn(true);
         SelectFromSymDataSource source = createSource();
@@ -169,7 +169,7 @@ public class SelectFromSymDataSourceTest {
     }
 
     @Test
-    public void processCreateEvent_setupBatch_stripsBothFksAndIndexes() throws Exception {
+    void processCreateEvent_setupBatch_stripsBothFksAndIndexes() throws Exception {
         when(outgoingBatch.isLoadFlag()).thenReturn(true);
         when(parameterService.is(ParameterConstants.INITIAL_LOAD_DEFER_CREATE_CONSTRAINTS, false)).thenReturn(true);
         SelectFromSymDataSource source = createSource();
@@ -185,7 +185,7 @@ public class SelectFromSymDataSourceTest {
     }
 
     @Test
-    public void processCreateEvent_phase1Finalize_stripsFksKeepsIndexes() throws Exception {
+    void processCreateEvent_phase1Finalize_stripsFksKeepsIndexes() throws Exception {
         when(outgoingBatch.isLoadFlag()).thenReturn(false);
         when(parameterService.is(ParameterConstants.INITIAL_LOAD_DEFER_CREATE_CONSTRAINTS, false)).thenReturn(true);
         SelectFromSymDataSource source = createSource();
@@ -202,7 +202,7 @@ public class SelectFromSymDataSourceTest {
     }
 
     @Test
-    public void processCreateEvent_phase2Finalize_keepsAll() throws Exception {
+    void processCreateEvent_phase2Finalize_keepsAll() throws Exception {
         when(outgoingBatch.isLoadFlag()).thenReturn(false);
         when(parameterService.is(ParameterConstants.INITIAL_LOAD_DEFER_CREATE_CONSTRAINTS, false)).thenReturn(true);
         SelectFromSymDataSource source = createSource();

--- a/symmetric-core/src/test/java/org/jumpmind/symmetric/service/impl/DataServiceTest.java
+++ b/symmetric-core/src/test/java/org/jumpmind/symmetric/service/impl/DataServiceTest.java
@@ -375,6 +375,149 @@ public class DataServiceTest {
         assertEquals(actualResults, expectedResults);
     }
 
+    @SuppressWarnings("unchecked")
+    @Test
+    void testInsertReloadEventsWithDeferConstraints() throws Exception {
+        Node targetNode = new Node();
+        targetNode.setNodeGroupId("client");
+        targetNode.setExternalId("client");
+        targetNode.setNodeId("client");
+        Node sourceNode = new Node();
+        sourceNode.setExternalId("server");
+        sourceNode.setNodeGroupId("server");
+        sourceNode.setNodeId("server");
+        NodeGroupLink link = new NodeGroupLink("server", "client");
+        Trigger trigger = new Trigger("testTable", "default");
+        Router router = new Router("testRouter", link);
+        TriggerRouter triggerRouter = new TriggerRouter(trigger, router);
+        TableReloadRequest reloadRequestForAll = new TableReloadRequest();
+        reloadRequestForAll.setLoadId(1);
+        reloadRequestForAll.setTriggerId("ALL");
+        reloadRequestForAll.setRouterId("ALL");
+        reloadRequestForAll.setCreateTable(true);
+        Table table = new Table("testTable");
+        Column idCol = new Column("Id");
+        idCol.setPrimaryKey(true);
+        table.addColumn(idCol);
+        table.addColumn(new Column("age"));
+        table.addColumn(new Column("weight"));
+        TableReloadStatus tableReloadStatus = new TableReloadStatus();
+        List<TableReloadRequest> reloadRequestsForAll = new ArrayList<TableReloadRequest>();
+        reloadRequestsForAll.add(reloadRequestForAll);
+        ProcessInfo processInfo = new ProcessInfo();
+        List<TriggerRouter> triggerRouters = new ArrayList<TriggerRouter>();
+        triggerRouters.add(triggerRouter);
+        Map<Integer, ExtractRequest> extractRequests = new HashMap<Integer, ExtractRequest>();
+        ExtractRequest extractRequest = new ExtractRequest();
+        extractRequest.setEndBatchId(2L);
+        extractRequest.setLoadId(0);
+        extractRequest.setNodeId("server");
+        extractRequest.setParentRequestId(0);
+        extractRequest.setRequestId(1);
+        extractRequest.setStartBatchId(0);
+        extractRequest.setTriggerRouter(triggerRouter);
+        extractRequests.put(0, extractRequest);
+        Map<Integer, List<TriggerRouter>> triggerRouterByHist = new HashMap<Integer, List<TriggerRouter>>();
+        triggerRouterByHist.put(0, triggerRouters);
+        List<TriggerHistory> triggerHistories = new ArrayList<TriggerHistory>();
+        TriggerHistory triggerHistory = new TriggerHistory("testTable", "Id", "Id,age,weight");
+        triggerHistory.setTriggerId("testTable");
+        triggerHistories.add(triggerHistory);
+        Map<String, Channel> channelMap = new HashMap<String, Channel>();
+        Channel channel = new Channel("default", 0);
+        channelMap.put("default", channel);
+        Set<TriggerRouter> triggerRouterSet = new HashSet<TriggerRouter>();
+        Trigger triggerForSet = new Trigger("sym_node_security", "default");
+        Router routerForSet = new Router("routerForSet", link);
+        TriggerRouter triggerRouterForSet = new TriggerRouter(triggerForSet, routerForSet);
+        TriggerHistory triggerHist = new TriggerHistory("sym_node_security", "NODE_ID",
+                "NODE_ID,NODE_PASSWORD,REGISTRATION_ENABLED,REGISTRATION_TIME,REGISTRATION_NOT_BEFORE,REGISTRATION_NOT_AFTER,INITIAL_LOAD_ENABLED,INITIAL_LOAD_TIME,INITIAL_LOAD_END_TIME,INITIAL_LOAD_ID,INITIAL_LOAD_CREATE_BY,REV_INITIAL_LOAD_ENABLED,REV_INITIAL_LOAD_TIME,REV_INITIAL_LOAD_ID,REV_INITIAL_LOAD_CREATE_BY,FAILED_LOGINS,CREATED_AT_NODE_ID");
+        triggerHist.setTriggerId("sym_node_security");
+        triggerRouterSet.add(triggerRouterForSet);
+        IReloadGenerator reloadGenerator = mock(IReloadGenerator.class);
+        IClusterService clusterService = mock(IClusterService.class);
+        INodeService nodeService = mock(INodeService.class);
+        TriggerRouterService triggerRouterService = mock(TriggerRouterService.class);
+        IInitialLoadService initialLoadService = mock(IInitialLoadService.class);
+        NodeSecurity nodeSecurity = mock(NodeSecurity.class);
+        ISequenceService sequenceService = mock(ISequenceService.class);
+        IDataExtractorService dataExtractorService = mock(IDataExtractorService.class);
+        IConfigurationService configurationService = mock(IConfigurationService.class);
+        IGroupletService groupletService = mock(IGroupletService.class);
+        ITransformService transformService = mock(ITransformService.class);
+        IOutgoingBatchService outgoingBatchService = mock(IOutgoingBatchService.class);
+        IStatisticManager statisticManager = mock(IStatisticManager.class);
+        IPurgeService purgeService = mock(IPurgeService.class);
+        when(engine.getClusterService()).thenReturn(clusterService);
+        when(clusterService.lock(ClusterConstants.SYNC_TRIGGERS)).thenReturn(true);
+        when(engine.getNodeService()).thenReturn(nodeService);
+        when(nodeService.findIdentity()).thenReturn(sourceNode);
+        when(nodeService.findNodeSecurity(ArgumentMatchers.anyString())).thenReturn(nodeSecurity);
+        when(engine.getTriggerRouterService()).thenReturn(triggerRouterService);
+        when(parameterService.is(ParameterConstants.DATA_RELOAD_IS_BATCH_INSERT_TRANSACTIONAL)).thenReturn(true);
+        when(parameterService.is(ParameterConstants.INITIAL_LOAD_DEFER_CREATE_CONSTRAINTS, false)).thenReturn(true);
+        when(engine.getNodeId()).thenReturn("server");
+        when(engine.getInitialLoadService()).thenReturn(initialLoadService);
+        doNothing().when(initialLoadService).cancelLoad(ArgumentMatchers.any());
+        when(engine.getDatabasePlatform()).thenReturn(platform);
+        when(sqlTemplate.startSqlTransaction()).thenReturn(sqlTransaction);
+        when(sqlTransaction.prepareAndExecute(ArgumentMatchers.anyString(), (JdbcSqlTransaction) ArgumentMatchers.any())).thenReturn(1);
+        when(reloadGenerator.getActiveTriggerHistories(targetNode)).thenReturn(triggerHistories);
+        when(platform.getSqlTemplate()).thenReturn(sqlTemplate);
+        when(platform.supportsMultiThreadedTransactions()).thenReturn(false);
+        when(engine.getSequenceService()).thenReturn(sequenceService);
+        when(sequenceService.nextVal(ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(1L);
+        when(nodeSecurity.getInitialLoadCreateBy()).thenReturn("test user");
+        when(triggerRouterService.getActiveTriggerHistories((Trigger) ArgumentMatchers.any())).thenReturn(triggerHistories);
+        when(triggerRouterService.fillTriggerRoutersByHistIdAndSortHist(ArgumentMatchers.anyString(),
+                ArgumentMatchers.anyString(), ArgumentMatchers.anyString(), ArgumentMatchers.anyList(), ArgumentMatchers.anyList(),
+                ArgumentMatchers.anyBoolean())).thenReturn(triggerRouterByHist);
+        when(engine.getConfigurationService()).thenReturn(configurationService);
+        when(configurationService.getChannels(false)).thenReturn(channelMap);
+        when(engine.getConfigurationService().getChannels(false)).thenReturn(channelMap);
+        when(engine.getGroupletService()).thenReturn(groupletService);
+        when(groupletService.isTargetEnabled(triggerRouter, targetNode)).thenReturn(true);
+        when(engine.getDataExtractorService()).thenReturn(dataExtractorService);
+        when(symmetricDialect.getTargetDialect()).thenReturn(symmetricDialect);
+        when(symmetricDialect.getTablePrefix()).thenReturn("sym");
+        when(platform.getTableFromCache(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.anyBoolean())).thenReturn(
+                table);
+        doNothing().when(dataExtractorService).releaseMissedExtractRequests();
+        when(triggerRouterService.getRouterById(ArgumentMatchers.anyString(), ArgumentMatchers.anyBoolean())).thenReturn(router);
+        when(engine.getTransformService()).thenReturn(transformService);
+        when(transformService.findTransformsFor(ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(null);
+        when(engine.getOutgoingBatchService()).thenReturn(outgoingBatchService);
+        doNothing().when(outgoingBatchService).insertOutgoingBatch(ArgumentMatchers.any(), ArgumentMatchers.any());
+        when(engine.getStatisticManager()).thenReturn(statisticManager);
+        doNothing().when(statisticManager).incrementNodesLoaded(1);
+        when(sqlTransaction.prepareAndExecute(ArgumentMatchers.anyString(), ArgumentMatchers.any(Object[].class))).thenReturn(1);
+        when(sqlTransaction.prepareAndExecute(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(1);
+        when(sqlTemplate.queryForObject(ArgumentMatchers.anyString(), (ISqlRowMapper<TableReloadStatus>) ArgumentMatchers.any(), ArgumentMatchers.anyLong(),
+                ArgumentMatchers.anyString())).thenReturn(tableReloadStatus);
+        when(dataExtractorService.requestExtractRequest(sqlTransaction, targetNode.getNodeId(), channel.getQueue(), triggerRouter, -1, -1, 1, table.getName(),
+                0, 0)).thenReturn(extractRequest);
+        // Full load mocks (same as scenario 1)
+        doNothing().when(outgoingBatchService).markAllAsSentForNode(targetNode.getNodeId(), false);
+        doReturn(triggerRouterSet).when(triggerRouterService).getTriggerRouterForTableForCurrentNode(ArgumentMatchers.any(), ArgumentMatchers.any(),
+                ArgumentMatchers.anyString(), ArgumentMatchers.anyBoolean());
+        doReturn(triggerHist).when(triggerRouterService).getNewestTriggerHistoryForTrigger(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers
+                .any(), ArgumentMatchers.any());
+        when(engine.getTriggerRouterService()
+                .findTriggerHistoryForGenericSync()).thenReturn(triggerHistory);
+        when(engine.getTriggerRouterService().getTriggerById("testTable", false)).thenReturn(trigger);
+        when(engine.getPurgeService()).thenReturn(purgeService);
+        doNothing().when(purgeService).purgeAllIncomingEventsForNode(ArgumentMatchers.anyString());
+        Map<Integer, ExtractRequest> actualResults = dataService.insertReloadEvents(targetNode, false, reloadRequestsForAll, processInfo, triggerRouters,
+                extractRequests, reloadGenerator);
+        Map<Integer, ExtractRequest> expectedResults = new HashMap<Integer, ExtractRequest>();
+        expectedResults.put(0, extractRequest);
+        assertEquals(actualResults, expectedResults);
+        // Verify sortByFk=false when deferConstraints is true and createTable is true
+        verify(triggerRouterService).fillTriggerRoutersByHistIdAndSortHist(
+                ArgumentMatchers.anyString(), ArgumentMatchers.anyString(), ArgumentMatchers.anyString(),
+                ArgumentMatchers.anyList(), ArgumentMatchers.anyList(), ArgumentMatchers.eq(false));
+    }
+
     @ParameterizedTest
     @CsvSource({ "" + 0 + "", "" + 1 + "", "" + 2 + "" })
     void testSendSQL(int scenario) throws Exception {

--- a/symmetric-core/src/test/java/org/jumpmind/symmetric/service/impl/DataServiceTest.java
+++ b/symmetric-core/src/test/java/org/jumpmind/symmetric/service/impl/DataServiceTest.java
@@ -377,7 +377,7 @@ public class DataServiceTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    void testInsertReloadEventsWithDeferConstraints() throws Exception {
+    void testInsertReloadEventsWithDeferConstraints() {
         Node targetNode = new Node();
         targetNode.setNodeGroupId("client");
         targetNode.setExternalId("client");


### PR DESCRIPTION
Claude told me it would be impractical to create unit tests for `DataExtractorService.checkSendDeferredForeignKeys()` and `DataExtractorService.checkSendDeferredIndexes()` because "the mocking burden is disproportionate to the value". I decided to not have it create any unit tests for these methods, but let me know if I should.