### PR TITLE
SYM-7418: Add MySQL SET data type support for DDL read/write

### DIFF
--- a/symmetric-db/src/main/java/org/jumpmind/db/platform/mysql/MySqlDdlBuilder.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/platform/mysql/MySqlDdlBuilder.java
@@ -482,13 +482,15 @@ public class MySqlDdlBuilder extends AbstractDdlBuilder {
             sqlType = "DATETIME(" + column.getScale() + ")";
         }
         PlatformColumn pc = column.getPlatformColumns() == null ? null : column.getPlatformColumns().get(DatabaseNamesConstants.MYSQL);
-        if (pc != null && ("ENUM".equalsIgnoreCase(column.getJdbcTypeName()) || "ENUM".equalsIgnoreCase(pc.getType()))) {
+        if (pc != null && ("ENUM".equalsIgnoreCase(column.getJdbcTypeName()) || "ENUM".equalsIgnoreCase(pc.getType())
+                || "SET".equalsIgnoreCase(column.getJdbcTypeName()) || "SET".equalsIgnoreCase(pc.getType()))) {
             String[] enumValues = pc.getEnumValues();
             if (enumValues != null && enumValues.length > 0) {
-                // Redo the enum, specifying the values returned from the database in the enumValues field
+                // Redo the enum/set, specifying the values returned from the database in the enumValues field
                 // instead of the size of the column
+                String typeName = "SET".equalsIgnoreCase(column.getJdbcTypeName()) || "SET".equalsIgnoreCase(pc.getType()) ? "SET" : "ENUM";
                 StringBuilder tmpSqlType = new StringBuilder();
-                tmpSqlType.append("ENUM");
+                tmpSqlType.append(typeName);
                 tmpSqlType.append("(");
                 boolean appendComma = false;
                 for (String s : enumValues) {

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/mysql/MySqlDdlReader.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/mysql/MySqlDdlReader.java
@@ -135,8 +135,9 @@ public class MySqlDdlReader extends AbstractJdbcDdlReader {
                     }
                 }
             }
-            if (columnType != null && columnType.toLowerCase().startsWith("enum(")) {
-                String[] parsedEnums = columnType.substring(5, columnType.length() - 1).split(",");
+            if (columnType != null && (columnType.toLowerCase().startsWith("enum(") || columnType.toLowerCase().startsWith("set("))) {
+                int prefixLength = columnType.toLowerCase().startsWith("enum(") ? 5 : 4;
+                String[] parsedEnums = columnType.substring(prefixLength, columnType.length() - 1).split(",");
                 for (int i = 0; i < parsedEnums.length; i++) {
                     parsedEnums[i] = StringUtils.unwrap(parsedEnums[i], "'");
                 }

--- a/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/mysql/MySqlDdlTypesTest.java
+++ b/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/mysql/MySqlDdlTypesTest.java
@@ -35,7 +35,7 @@ public class MySqlDdlTypesTest extends AbstractDdlTypesTest {
                 "integer", "smallint", "decimal", "numeric",
                 "float", "real", "double precision",
                 "date", "time", "datetime", "timestamp", // "year",
-                "char", "varchar(100)", "text", "enum('small','medium','large')", // "set('a','b','c')",
+                "char", "varchar(100)", "text", "enum('small','medium','large')", "set('a','b','c')",
                 "tinytext", "mediumtext",
                 "binary", "varbinary(100)", "blob", "tinyblob", "mediumblob",
                 "json"


### PR DESCRIPTION
The MySQL SET data type was not handled during DDL generation, causing CREATE events to produce invalid SQL (e.g., SET(26) instead of SET('val1','val2')). This broke initial loads between MySQL instances when tables contained SET columns.