### PR TITLE
SYM-7437: Extend ntypes to sym_file_snapshot for Unicode file names

### DIFF
--- a/symmetric-client/src/main/java/org/jumpmind/symmetric/db/mssql/MsSqlSymmetricDialect.java
+++ b/symmetric-client/src/main/java/org/jumpmind/symmetric/db/mssql/MsSqlSymmetricDialect.java
@@ -92,6 +92,13 @@ public class MsSqlSymmetricDialect extends AbstractSymmetricDialect implements I
             setColumnToNtext(symTable.getColumnWithName("row_data"));
             setColumnToNtext(symTable.getColumnWithName("old_data"));
             setColumnToNtext(symTable.getColumnWithName("pk_data"));
+            // SYM-7437: extend ntypes to sym_file_snapshot for Unicode file names
+            Table fileSnapshotTable = db.findTable(
+                    TableConstants.getTableName(getTablePrefix(), TableConstants.SYM_FILE_SNAPSHOT));
+            if (fileSnapshotTable != null) {
+                setColumnToNvarchar(fileSnapshotTable.getColumnWithName("file_name"));
+                setColumnToNvarchar(fileSnapshotTable.getColumnWithName("relative_dir"));
+            }
         }
         if (parameterService.is(ParameterConstants.MSSQL_USE_VARCHAR_FOR_LOB_IN_SYNC)) {
             for (Table table : db.getTables()) {
@@ -107,6 +114,10 @@ public class MsSqlSymmetricDialect extends AbstractSymmetricDialect implements I
 
     protected void setColumnToNtext(Column column) {
         column.setMappedType(TypeMap.LONGNVARCHAR);
+    }
+
+    protected void setColumnToNvarchar(Column column) {
+        column.setMappedType(TypeMap.NVARCHAR);
     }
 
     protected void setColumnToVarChar(Column column, boolean forceNtype) {

--- a/symmetric-client/src/test/java/org/jumpmind/symmetric/db/mssql/MsSqlSymmetricDialectTest.java
+++ b/symmetric-client/src/test/java/org/jumpmind/symmetric/db/mssql/MsSqlSymmetricDialectTest.java
@@ -1,0 +1,109 @@
+package org.jumpmind.symmetric.db.mssql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.sql.Types;
+
+import org.jumpmind.db.model.Column;
+import org.jumpmind.db.model.Database;
+import org.jumpmind.db.model.Table;
+import org.jumpmind.db.model.TypeMap;
+import org.jumpmind.db.platform.DatabaseInfo;
+import org.jumpmind.db.platform.IDatabasePlatform;
+import org.jumpmind.db.platform.IDdlBuilder;
+import org.jumpmind.db.sql.ISqlTemplate;
+import org.jumpmind.symmetric.common.ParameterConstants;
+import org.jumpmind.symmetric.common.TableConstants;
+import org.jumpmind.symmetric.service.IParameterService;
+import org.jumpmind.symmetric.service.impl.ParameterService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class MsSqlSymmetricDialectTest {
+    private MsSqlSymmetricDialect dialect;
+    private IParameterService parameterService;
+    private IDatabasePlatform platform;
+    private ISqlTemplate sqlTemplate;
+
+    @BeforeEach
+    void setup() {
+        parameterService = mock(ParameterService.class);
+        platform = mock(IDatabasePlatform.class);
+        sqlTemplate = mock(ISqlTemplate.class);
+        IDdlBuilder ddlBuilder = mock(IDdlBuilder.class);
+        when(platform.getSqlTemplate()).thenReturn(sqlTemplate);
+        when(platform.getDdlBuilder()).thenReturn(ddlBuilder);
+        when(ddlBuilder.getDatabaseInfo()).thenReturn(new DatabaseInfo());
+        when(sqlTemplate.queryForInt(MsSqlSymmetricDialect.SQL_NOCOUNT)).thenReturn(0);
+        when(parameterService.getTablePrefix()).thenReturn("sym");
+        dialect = new MsSqlSymmetricDialect(parameterService, platform);
+    }
+
+    @Test
+    void testReadSymmetricSchemaFromXml_ntypesEnabled_setsFileSnapshotColumnsToNvarchar() {
+        when(parameterService.is(ParameterConstants.MSSQL_USE_NTYPES_FOR_SYNC)).thenReturn(true);
+        when(parameterService.is(eq(ParameterConstants.MSSQL_USE_VARCHAR_FOR_LOB_IN_SYNC))).thenReturn(false);
+        when(parameterService.getString(ParameterConstants.AUTO_CONFIGURE_EXTRA_TABLES)).thenReturn(null);
+        Database db = buildDatabaseWithSymTables();
+        when(platform.readDatabaseFromXml(anyString(), eq(true))).thenReturn(db);
+        Database result = dialect.readSymmetricSchemaFromXml();
+        Table fileSnapshot = result.findTable(
+                TableConstants.getTableName("sym", TableConstants.SYM_FILE_SNAPSHOT));
+        assertEquals(TypeMap.NVARCHAR, fileSnapshot.getColumnWithName("file_name").getMappedType());
+        assertEquals(TypeMap.NVARCHAR, fileSnapshot.getColumnWithName("relative_dir").getMappedType());
+    }
+
+    @Test
+    void testReadSymmetricSchemaFromXml_ntypesEnabled_setsSymDataColumnsToNtext() {
+        when(parameterService.is(ParameterConstants.MSSQL_USE_NTYPES_FOR_SYNC)).thenReturn(true);
+        when(parameterService.is(eq(ParameterConstants.MSSQL_USE_VARCHAR_FOR_LOB_IN_SYNC))).thenReturn(false);
+        when(parameterService.getString(ParameterConstants.AUTO_CONFIGURE_EXTRA_TABLES)).thenReturn(null);
+        Database db = buildDatabaseWithSymTables();
+        when(platform.readDatabaseFromXml(anyString(), eq(true))).thenReturn(db);
+        Database result = dialect.readSymmetricSchemaFromXml();
+        Table symData = result.findTable(
+                TableConstants.getTableName("sym", TableConstants.SYM_DATA));
+        assertEquals(TypeMap.LONGNVARCHAR, symData.getColumnWithName("row_data").getMappedType());
+        assertEquals(TypeMap.LONGNVARCHAR, symData.getColumnWithName("old_data").getMappedType());
+        assertEquals(TypeMap.LONGNVARCHAR, symData.getColumnWithName("pk_data").getMappedType());
+    }
+
+    @Test
+    void testReadSymmetricSchemaFromXml_ntypesDisabled_leavesColumnsAsVarchar() {
+        when(parameterService.is(ParameterConstants.MSSQL_USE_NTYPES_FOR_SYNC)).thenReturn(false);
+        when(parameterService.is(eq(ParameterConstants.MSSQL_USE_VARCHAR_FOR_LOB_IN_SYNC))).thenReturn(false);
+        when(parameterService.getString(ParameterConstants.AUTO_CONFIGURE_EXTRA_TABLES)).thenReturn(null);
+        Database db = buildDatabaseWithSymTables();
+        when(platform.readDatabaseFromXml(anyString(), eq(true))).thenReturn(db);
+        Database result = dialect.readSymmetricSchemaFromXml();
+        Table fileSnapshot = result.findTable(
+                TableConstants.getTableName("sym", TableConstants.SYM_FILE_SNAPSHOT));
+        assertEquals(TypeMap.VARCHAR, fileSnapshot.getColumnWithName("file_name").getMappedType());
+        assertEquals(TypeMap.VARCHAR, fileSnapshot.getColumnWithName("relative_dir").getMappedType());
+        Table symData = result.findTable(
+                TableConstants.getTableName("sym", TableConstants.SYM_DATA));
+        assertEquals(TypeMap.LONGVARCHAR, symData.getColumnWithName("row_data").getMappedType());
+    }
+
+    private Database buildDatabaseWithSymTables() {
+        Database db = new Database();
+        Table symData = new Table(TableConstants.getTableName("sym", TableConstants.SYM_DATA));
+        symData.addColumn(new Column("data_id", false, Types.BIGINT, 0, 0));
+        symData.addColumn(new Column("row_data", false, Types.LONGVARCHAR, 0, 0));
+        symData.addColumn(new Column("old_data", false, Types.LONGVARCHAR, 0, 0));
+        symData.addColumn(new Column("pk_data", false, Types.LONGVARCHAR, 0, 0));
+        db.addTable(symData);
+        Table fileSnapshot = new Table(
+                TableConstants.getTableName("sym", TableConstants.SYM_FILE_SNAPSHOT));
+        fileSnapshot.addColumn(new Column("trigger_id", false, Types.VARCHAR, 50, 0));
+        fileSnapshot.addColumn(new Column("router_id", false, Types.VARCHAR, 50, 0));
+        fileSnapshot.addColumn(new Column("relative_dir", false, Types.VARCHAR, 255, 0));
+        fileSnapshot.addColumn(new Column("file_name", false, Types.VARCHAR, 260, 0));
+        db.addTable(fileSnapshot);
+        return db;
+    }
+}

--- a/symmetric-client/src/test/java/org/jumpmind/symmetric/db/mssql/MsSqlSymmetricDialectTest.java
+++ b/symmetric-client/src/test/java/org/jumpmind/symmetric/db/mssql/MsSqlSymmetricDialectTest.java
@@ -27,44 +27,37 @@ class MsSqlSymmetricDialectTest {
     private MsSqlSymmetricDialect dialect;
     private IParameterService parameterService;
     private IDatabasePlatform platform;
-    private ISqlTemplate sqlTemplate;
 
     @BeforeEach
     void setup() {
         parameterService = mock(ParameterService.class);
         platform = mock(IDatabasePlatform.class);
-        sqlTemplate = mock(ISqlTemplate.class);
+        ISqlTemplate sqlTemplate = mock(ISqlTemplate.class);
         IDdlBuilder ddlBuilder = mock(IDdlBuilder.class);
         when(platform.getSqlTemplate()).thenReturn(sqlTemplate);
         when(platform.getDdlBuilder()).thenReturn(ddlBuilder);
         when(ddlBuilder.getDatabaseInfo()).thenReturn(new DatabaseInfo());
         when(sqlTemplate.queryForInt(MsSqlSymmetricDialect.SQL_NOCOUNT)).thenReturn(0);
         when(parameterService.getTablePrefix()).thenReturn("sym");
+        when(parameterService.is(ParameterConstants.MSSQL_USE_VARCHAR_FOR_LOB_IN_SYNC)).thenReturn(false);
+        when(parameterService.getString(ParameterConstants.AUTO_CONFIGURE_EXTRA_TABLES)).thenReturn(null);
         dialect = new MsSqlSymmetricDialect(parameterService, platform);
     }
 
-    @Test
-    void testReadSymmetricSchemaFromXml_ntypesEnabled_setsFileSnapshotColumnsToNvarchar() {
-        when(parameterService.is(ParameterConstants.MSSQL_USE_NTYPES_FOR_SYNC)).thenReturn(true);
-        when(parameterService.is(eq(ParameterConstants.MSSQL_USE_VARCHAR_FOR_LOB_IN_SYNC))).thenReturn(false);
-        when(parameterService.getString(ParameterConstants.AUTO_CONFIGURE_EXTRA_TABLES)).thenReturn(null);
+    private Database readSchemaWithNtypes(boolean ntypesEnabled) {
+        when(parameterService.is(ParameterConstants.MSSQL_USE_NTYPES_FOR_SYNC)).thenReturn(ntypesEnabled);
         Database db = buildDatabaseWithSymTables();
         when(platform.readDatabaseFromXml(anyString(), eq(true))).thenReturn(db);
-        Database result = dialect.readSymmetricSchemaFromXml();
+        return dialect.readSymmetricSchemaFromXml();
+    }
+
+    @Test
+    void testReadSymmetricSchemaFromXml_ntypesEnabled_convertsColumnsToNtypes() {
+        Database result = readSchemaWithNtypes(true);
         Table fileSnapshot = result.findTable(
                 TableConstants.getTableName("sym", TableConstants.SYM_FILE_SNAPSHOT));
         assertEquals(TypeMap.NVARCHAR, fileSnapshot.getColumnWithName("file_name").getMappedType());
         assertEquals(TypeMap.NVARCHAR, fileSnapshot.getColumnWithName("relative_dir").getMappedType());
-    }
-
-    @Test
-    void testReadSymmetricSchemaFromXml_ntypesEnabled_setsSymDataColumnsToNtext() {
-        when(parameterService.is(ParameterConstants.MSSQL_USE_NTYPES_FOR_SYNC)).thenReturn(true);
-        when(parameterService.is(eq(ParameterConstants.MSSQL_USE_VARCHAR_FOR_LOB_IN_SYNC))).thenReturn(false);
-        when(parameterService.getString(ParameterConstants.AUTO_CONFIGURE_EXTRA_TABLES)).thenReturn(null);
-        Database db = buildDatabaseWithSymTables();
-        when(platform.readDatabaseFromXml(anyString(), eq(true))).thenReturn(db);
-        Database result = dialect.readSymmetricSchemaFromXml();
         Table symData = result.findTable(
                 TableConstants.getTableName("sym", TableConstants.SYM_DATA));
         assertEquals(TypeMap.LONGNVARCHAR, symData.getColumnWithName("row_data").getMappedType());
@@ -74,12 +67,7 @@ class MsSqlSymmetricDialectTest {
 
     @Test
     void testReadSymmetricSchemaFromXml_ntypesDisabled_leavesColumnsAsVarchar() {
-        when(parameterService.is(ParameterConstants.MSSQL_USE_NTYPES_FOR_SYNC)).thenReturn(false);
-        when(parameterService.is(eq(ParameterConstants.MSSQL_USE_VARCHAR_FOR_LOB_IN_SYNC))).thenReturn(false);
-        when(parameterService.getString(ParameterConstants.AUTO_CONFIGURE_EXTRA_TABLES)).thenReturn(null);
-        Database db = buildDatabaseWithSymTables();
-        when(platform.readDatabaseFromXml(anyString(), eq(true))).thenReturn(db);
-        Database result = dialect.readSymmetricSchemaFromXml();
+        Database result = readSchemaWithNtypes(false);
         Table fileSnapshot = result.findTable(
                 TableConstants.getTableName("sym", TableConstants.SYM_FILE_SNAPSHOT));
         assertEquals(TypeMap.VARCHAR, fileSnapshot.getColumnWithName("file_name").getMappedType());

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/FileSyncService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/FileSyncService.java
@@ -582,11 +582,7 @@ public class FileSyncService extends AbstractOfflineDetectorService implements I
         }
     }
 
-    /**
-     * SYM-7437: Returns Types.NVARCHAR when mssql.use.ntypes.for.sync is enabled
-     * on MSSQL, otherwise Types.VARCHAR. This ensures file_name and relative_dir
-     * parameters are bound as NVARCHAR to preserve Unicode characters.
-     */
+    // SYM-7437: NVARCHAR when ntypes enabled, preserves Unicode file paths on Latin1 collation
     private int getFilePathJdbcType() {
         if (parameterService.is(ParameterConstants.MSSQL_USE_NTYPES_FOR_SYNC)) {
             return Types.NVARCHAR;

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/FileSyncService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/FileSyncService.java
@@ -582,9 +582,22 @@ public class FileSyncService extends AbstractOfflineDetectorService implements I
         }
     }
 
+    /**
+     * SYM-7437: Returns Types.NVARCHAR when mssql.use.ntypes.for.sync is enabled
+     * on MSSQL, otherwise Types.VARCHAR. This ensures file_name and relative_dir
+     * parameters are bound as NVARCHAR to preserve Unicode characters.
+     */
+    private int getFilePathJdbcType() {
+        if (parameterService.is(ParameterConstants.MSSQL_USE_NTYPES_FOR_SYNC)) {
+            return Types.NVARCHAR;
+        }
+        return Types.VARCHAR;
+    }
+
     public void save(ISqlTransaction sqlTransaction, FileSnapshot snapshot) {
         snapshot.setLastUpdateTime(new Date());
-        if (0 >= executeUpdate(sqlTransaction, snapshot)) {
+        int filePathType = getFilePathJdbcType();
+        if (0 >= executeUpdate(sqlTransaction, snapshot, filePathType)) {
             snapshot.setCreateTime(snapshot.getLastUpdateTime());
             sqlTransaction.prepareAndExecute(
                     getSql("insertFileSnapshotSql"),
@@ -597,18 +610,18 @@ public class FileSyncService extends AbstractOfflineDetectorService implements I
                             snapshot.getRelativeDir(), snapshot.getFileName(), snapshot.getExternalFileData() }, new int[] {
                                     Types.VARCHAR, Types.NUMERIC, Types.NUMERIC, Types.NUMERIC,
                                     Types.TIMESTAMP, Types.TIMESTAMP, Types.VARCHAR, Types.VARCHAR, Types.VARCHAR, Types.VARCHAR,
-                                    Types.VARCHAR, Types.VARCHAR, Types.VARCHAR, Types.VARCHAR });
+                                    Types.VARCHAR, filePathType, filePathType, Types.VARCHAR });
         }
         // now that we have captured an update, delete the row for cleanup
         if (snapshot.getLastEventType() == LastEventType.DELETE) {
             sqlTransaction.prepareAndExecute(getSql("deleteFileSnapshotSql"), new Object[] {
                     snapshot.getTriggerId(), snapshot.getRouterId(), snapshot.getRelativeDir(),
                     snapshot.getFileName() }, new int[] { Types.VARCHAR, Types.VARCHAR,
-                            Types.VARCHAR, Types.VARCHAR });
+                            filePathType, filePathType });
         }
     }
 
-    private int executeUpdate(ISqlTransaction sqlTransaction, FileSnapshot snapshot) {
+    private int executeUpdate(ISqlTransaction sqlTransaction, FileSnapshot snapshot, int filePathType) {
         if (snapshot.getLastEventType().equals(LastEventType.CREATE)) {
             return 0;
         }
@@ -621,7 +634,7 @@ public class FileSyncService extends AbstractOfflineDetectorService implements I
                         snapshot.getTriggerId(), snapshot.getRouterId(), snapshot.getRelativeDir(),
                         snapshot.getFileName() }, new int[] { Types.VARCHAR, Types.NUMERIC,
                                 Types.NUMERIC, Types.NUMERIC, Types.TIMESTAMP, Types.VARCHAR, Types.VARCHAR, Types.VARCHAR,
-                                Types.VARCHAR, Types.VARCHAR, Types.VARCHAR, Types.VARCHAR });
+                                Types.VARCHAR, Types.VARCHAR, filePathType, filePathType });
     }
 
     @Override

--- a/symmetric-core/src/test/java/org/jumpmind/symmetric/service/impl/FileSyncServiceTest.java
+++ b/symmetric-core/src/test/java/org/jumpmind/symmetric/service/impl/FileSyncServiceTest.java
@@ -1,0 +1,103 @@
+package org.jumpmind.symmetric.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.Types;
+
+import org.jumpmind.db.platform.DatabaseInfo;
+import org.jumpmind.db.platform.IDatabasePlatform;
+import org.jumpmind.db.sql.ISqlTemplate;
+import org.jumpmind.db.sql.ISqlTransaction;
+import org.jumpmind.symmetric.AbstractSymmetricEngine;
+import org.jumpmind.symmetric.ISymmetricEngine;
+import org.jumpmind.symmetric.cache.ICacheManager;
+import org.jumpmind.symmetric.common.ParameterConstants;
+import org.jumpmind.symmetric.db.AbstractSymmetricDialect;
+import org.jumpmind.symmetric.db.ISymmetricDialect;
+import org.jumpmind.symmetric.model.FileSnapshot;
+import org.jumpmind.symmetric.model.FileSnapshot.LastEventType;
+import org.jumpmind.symmetric.service.IExtensionService;
+import org.jumpmind.symmetric.service.IParameterService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class FileSyncServiceTest {
+    private FileSyncService fileSyncService;
+    private IParameterService parameterService;
+    private ISqlTransaction sqlTransaction;
+    private IDatabasePlatform platform;
+
+    @BeforeEach
+    void setUp() {
+        ISqlTemplate sqlTemplate = mock(ISqlTemplate.class);
+        sqlTransaction = mock(ISqlTransaction.class);
+        platform = mock(IDatabasePlatform.class);
+        when(platform.getDatabaseInfo()).thenReturn(new DatabaseInfo());
+        when(platform.getSqlTemplate()).thenReturn(sqlTemplate);
+        when(platform.getSqlTemplateDirty()).thenReturn(sqlTemplate);
+        ISymmetricDialect symmetricDialect = mock(AbstractSymmetricDialect.class);
+        when(symmetricDialect.getPlatform()).thenReturn(platform);
+        parameterService = mock(ParameterService.class);
+        when(parameterService.getTablePrefix()).thenReturn("sym");
+        IExtensionService extensionService = mock(ExtensionService.class);
+        ICacheManager cacheManager = mock(ICacheManager.class);
+        ISymmetricEngine engine = mock(AbstractSymmetricEngine.class);
+        when(engine.getParameterService()).thenReturn(parameterService);
+        when(engine.getSymmetricDialect()).thenReturn(symmetricDialect);
+        when(engine.getExtensionService()).thenReturn(extensionService);
+        when(engine.getCacheManager()).thenReturn(cacheManager);
+        fileSyncService = new FileSyncService(engine);
+    }
+
+    @Test
+    void testSave_ntypesEnabled_usesNvarcharForFilePathColumns() {
+        when(parameterService.is(ParameterConstants.MSSQL_USE_NTYPES_FOR_SYNC)).thenReturn(true);
+        FileSnapshot snapshot = createTestSnapshot(LastEventType.CREATE);
+        fileSyncService.save(sqlTransaction, snapshot);
+        ArgumentCaptor<int[]> typesCaptor = ArgumentCaptor.forClass(int[].class);
+        verify(sqlTransaction).prepareAndExecute(anyString(), any(Object[].class), typesCaptor.capture());
+        int[] types = typesCaptor.getValue();
+        // INSERT: 14 params — relative_dir at index 11, file_name at index 12
+        assertArrayEquals(new int[] {
+                Types.VARCHAR, Types.NUMERIC, Types.NUMERIC, Types.NUMERIC,
+                Types.TIMESTAMP, Types.TIMESTAMP, Types.VARCHAR, Types.VARCHAR, Types.VARCHAR, Types.VARCHAR,
+                Types.VARCHAR, Types.NVARCHAR, Types.NVARCHAR, Types.VARCHAR
+        }, types, "INSERT types should use NVARCHAR for relative_dir (11) and file_name (12)");
+    }
+
+    @Test
+    void testSave_ntypesDisabled_usesVarcharForFilePathColumns() {
+        when(parameterService.is(ParameterConstants.MSSQL_USE_NTYPES_FOR_SYNC)).thenReturn(false);
+        FileSnapshot snapshot = createTestSnapshot(LastEventType.CREATE);
+        fileSyncService.save(sqlTransaction, snapshot);
+        ArgumentCaptor<int[]> typesCaptor = ArgumentCaptor.forClass(int[].class);
+        verify(sqlTransaction).prepareAndExecute(anyString(), any(Object[].class), typesCaptor.capture());
+        int[] types = typesCaptor.getValue();
+        assertArrayEquals(new int[] {
+                Types.VARCHAR, Types.NUMERIC, Types.NUMERIC, Types.NUMERIC,
+                Types.TIMESTAMP, Types.TIMESTAMP, Types.VARCHAR, Types.VARCHAR, Types.VARCHAR, Types.VARCHAR,
+                Types.VARCHAR, Types.VARCHAR, Types.VARCHAR, Types.VARCHAR
+        }, types, "INSERT types should use VARCHAR for all columns when ntypes disabled");
+    }
+
+    private FileSnapshot createTestSnapshot(LastEventType eventType) {
+        FileSnapshot snapshot = new FileSnapshot();
+        snapshot.setTriggerId("test-trigger");
+        snapshot.setRouterId("test-router");
+        snapshot.setRelativeDir(".");
+        snapshot.setFileName("测试.txt");
+        snapshot.setLastEventType(eventType);
+        snapshot.setCrc32Checksum(12345L);
+        snapshot.setFileSize(100L);
+        snapshot.setFileModifiedTime(1000L);
+        snapshot.setChannelId("filesync");
+        snapshot.setReloadChannelId("reload");
+        return snapshot;
+    }
+}


### PR DESCRIPTION
## Summary

- **MsSqlSymmetricDialect**: When `mssql.use.ntypes.for.sync=true`, convert `sym_file_snapshot.file_name` and `sym_file_snapshot.relative_dir` to NVARCHAR in `readSymmetricSchemaFromXml()`. New `setColumnToNvarchar()` helper.
- **FileSyncService**: Bind `file_name` and `relative_dir` as `Types.NVARCHAR` (instead of `Types.VARCHAR`) in INSERT/UPDATE/DELETE operations when ntypes is enabled, via `getFilePathJdbcType()` helper.
- **Tests**: `MsSqlSymmetricDialectTest` (2 tests) and `FileSyncServiceTest` (2 tests) verify column type conversion and JDBC parameter binding for both enabled/disabled states.

## Context

On SQL Server with `Latin1_General_CI_AS` collation, `sym_file_snapshot.file_name` (VARCHAR) corrupts Chinese/Unicode filenames to `????`, causing `UniqueKeyException` when multiple files collapse to the same key (e.g. `数据文件.txt` and `配置文件.txt` both become `????.txt`). Same issue affects `sym_data.row_data` for NVARCHAR source columns.

The existing `mssql.use.ntypes.for.sync` parameter already handled `sym_data` columns but not `sym_file_snapshot`. This PR extends coverage to file sync.

Validated in Docker lab (2x MSSQL 2022, Latin1_General_CI_AS, file sync with Chinese filenames). See Jira comment on SYM-7437 for full before/after evidence.

## Test plan

- [x] `MsSqlSymmetricDialectTest` — schema conversion (ntypes enabled/disabled)
- [x] `FileSyncServiceTest` — JDBC type arrays (NVARCHAR at correct positions)
- [x] Docker lab reproduction: `????` in `sym_file_snapshot.file_name` + `UniqueKeyException`
- [x] Docker lab verification: Chinese filenames preserved after fix, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)