### PR TITLE
SYM-7450: Use OBJECT_ID() for SQL Server estimated row count

### DIFF
--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/mssql/MsSql2008DatabasePlatform.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/mssql/MsSql2008DatabasePlatform.java
@@ -24,6 +24,7 @@ import javax.sql.DataSource;
 
 import org.apache.commons.lang3.StringUtils;
 import org.jumpmind.db.model.Table;
+import org.jumpmind.db.platform.DatabaseInfo;
 import org.jumpmind.db.platform.DatabaseNamesConstants;
 import org.jumpmind.db.platform.IDdlBuilder;
 import org.jumpmind.db.platform.PermissionResult;
@@ -55,18 +56,17 @@ public class MsSql2008DatabasePlatform extends MsSql2005DatabasePlatform {
 
     @Override
     public long getEstimatedRowCount(Table table) {
-        String catalog = StringUtils.isNotBlank(table.getCatalog()) ? table.getCatalog() : "";
-        if (catalog.length() > 0) {
-            if (getDdlBuilder().isDelimitedIdentifierModeOn()) {
-                catalog = getDdlBuilder().getDatabaseInfo().getDelimiterToken() + catalog + getDdlBuilder().getDatabaseInfo().getDelimiterToken();
-            }
-            catalog = catalog + ".";
+        DatabaseInfo dbInfo = getDatabaseInfo();
+        String quote = getDdlBuilder().isDelimitedIdentifierModeOn() ? dbInfo.getDelimiterToken() : "";
+        String qualifiedName = table.getQualifiedTableName(quote, dbInfo.getCatalogSeparator(), dbInfo.getSchemaSeparator());
+        String catalogPrefix = "";
+        if (StringUtils.isNotBlank(table.getCatalog())) {
+            catalogPrefix = (quote.length() > 0 ? quote + table.getCatalog() + quote : table.getCatalog()) + ".";
         }
-        return getSqlTemplateDirty().queryForLong("select sum(p.rows) from " + catalog + "sys.tables t inner join " +
-                catalog + "sys.partitions p on t.object_id = p.object_id and p.index_id IN (0, 1) inner join " + catalog
-                + "sys.schemas s on t.schema_id = s.schema_id " +
-                "where t.name = ? and s.name = ?",
-                table.getName(), table.getSchema());
+        return getSqlTemplateDirty().queryForLong(
+                "SELECT ISNULL(SUM(rows), -1) FROM " + catalogPrefix + "sys.partitions " +
+                "WHERE object_id = OBJECT_ID(?) AND index_id IN (0, 1)",
+                qualifiedName);
     }
 
     @Override

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/mssql/MsSql2008DatabasePlatform.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/mssql/MsSql2008DatabasePlatform.java
@@ -65,7 +65,7 @@ public class MsSql2008DatabasePlatform extends MsSql2005DatabasePlatform {
         }
         return getSqlTemplateDirty().queryForLong(
                 "SELECT ISNULL(SUM(rows), -1) FROM " + catalogPrefix + "sys.partitions " +
-                "WHERE object_id = OBJECT_ID(?) AND index_id IN (0, 1)",
+                        "WHERE object_id = OBJECT_ID(?) AND index_id IN (0, 1)",
                 qualifiedName);
     }
 

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/mssql/MsSql2008DatabasePlatform.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/mssql/MsSql2008DatabasePlatform.java
@@ -65,7 +65,7 @@ public class MsSql2008DatabasePlatform extends MsSql2005DatabasePlatform {
         }
         return getSqlTemplateDirty().queryForLong(
                 "SELECT ISNULL(SUM(rows), -1) FROM " + catalogPrefix + "sys.partitions " +
-                        "WHERE object_id = OBJECT_ID(?) AND index_id IN (0, 1)",
+                        "WHERE object_id = OBJECT_ID(?) AND index_id IN (0,1)",
                 qualifiedName);
     }
 

--- a/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/mssql/MsSql2008DatabasePlatformTest.java
+++ b/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/mssql/MsSql2008DatabasePlatformTest.java
@@ -1,0 +1,130 @@
+/**
+ * Licensed to JumpMind Inc under one or more contributor
+ * license agreements.  See the NOTICE file distributed
+ * with this work for additional information regarding
+ * copyright ownership.  JumpMind Inc licenses this file
+ * to you under the GNU General Public License, version 3.0 (GPLv3)
+ * (the "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3.0 (GPLv3) along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jumpmind.db.platform.mssql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.jumpmind.db.model.Table;
+import org.jumpmind.db.sql.ISqlTemplate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * Unit tests for {@link MsSql2008DatabasePlatform#getEstimatedRowCount(Table)}
+ */
+@DisplayName("MsSql2008DatabasePlatform")
+class MsSql2008DatabasePlatformTest {
+    private MsSql2008DatabasePlatform platform;
+    private ISqlTemplate sqlTemplateDirty;
+    private MsSql2008DdlBuilder ddlBuilder;
+
+    @BeforeEach
+    void setUp() {
+        platform = mock(MsSql2008DatabasePlatform.class);
+        sqlTemplateDirty = mock(ISqlTemplate.class);
+        ddlBuilder = new MsSql2008DdlBuilder();
+        when(platform.getSqlTemplateDirty()).thenReturn(sqlTemplateDirty);
+        when(platform.getDdlBuilder()).thenReturn(ddlBuilder);
+        when(platform.getDatabaseInfo()).thenReturn(ddlBuilder.getDatabaseInfo());
+        when(platform.getEstimatedRowCount(org.mockito.ArgumentMatchers.any(Table.class))).thenCallRealMethod();
+    }
+
+    @Test
+    @DisplayName("getEstimatedRowCount with catalog, schema, and default delimited mode quotes all identifiers")
+    void testEstimatedRowCountWithCatalogAndSchema() {
+        Table table = new Table("Pack");
+        table.setCatalog("AutoCribNet");
+        table.setSchema("11498");
+        when(sqlTemplateDirty.queryForLong(anyString(), anyString())).thenReturn(42L);
+        long result = platform.getEstimatedRowCount(table);
+        assertEquals(42L, result);
+        ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> paramCaptor = ArgumentCaptor.forClass(String.class);
+        verify(sqlTemplateDirty).queryForLong(sqlCaptor.capture(), paramCaptor.capture());
+        assertEquals("SELECT ISNULL(SUM(rows), -1) FROM \"AutoCribNet\".sys.partitions "
+                + "WHERE object_id = OBJECT_ID(?) AND index_id IN (0, 1)", sqlCaptor.getValue());
+        assertEquals("\"AutoCribNet\".\"11498\".\"Pack\"", paramCaptor.getValue());
+    }
+
+    @Test
+    @DisplayName("getEstimatedRowCount without catalog omits catalog prefix from sys.partitions")
+    void testEstimatedRowCountWithoutCatalog() {
+        Table table = new Table("Users");
+        table.setSchema("dbo");
+        when(sqlTemplateDirty.queryForLong(anyString(), anyString())).thenReturn(100L);
+        long result = platform.getEstimatedRowCount(table);
+        assertEquals(100L, result);
+        ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> paramCaptor = ArgumentCaptor.forClass(String.class);
+        verify(sqlTemplateDirty).queryForLong(sqlCaptor.capture(), paramCaptor.capture());
+        assertEquals("SELECT ISNULL(SUM(rows), -1) FROM sys.partitions "
+                + "WHERE object_id = OBJECT_ID(?) AND index_id IN (0, 1)", sqlCaptor.getValue());
+        assertEquals("\"dbo\".\"Users\"", paramCaptor.getValue());
+    }
+
+    @Test
+    @DisplayName("getEstimatedRowCount without catalog or schema uses just quoted table name")
+    void testEstimatedRowCountTableOnly() {
+        Table table = new Table("Items");
+        when(sqlTemplateDirty.queryForLong(anyString(), anyString())).thenReturn(0L);
+        long result = platform.getEstimatedRowCount(table);
+        assertEquals(0L, result);
+        ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> paramCaptor = ArgumentCaptor.forClass(String.class);
+        verify(sqlTemplateDirty).queryForLong(sqlCaptor.capture(), paramCaptor.capture());
+        assertEquals("SELECT ISNULL(SUM(rows), -1) FROM sys.partitions "
+                + "WHERE object_id = OBJECT_ID(?) AND index_id IN (0, 1)", sqlCaptor.getValue());
+        assertEquals("\"Items\"", paramCaptor.getValue());
+    }
+
+    @Test
+    @DisplayName("getEstimatedRowCount with delimited mode off produces unquoted names")
+    void testEstimatedRowCountUnquoted() {
+        Table table = new Table("Pack");
+        table.setCatalog("AutoCribNet");
+        table.setSchema("11498");
+        ddlBuilder.setDelimitedIdentifierModeOn(false);
+        when(sqlTemplateDirty.queryForLong(anyString(), anyString())).thenReturn(7L);
+        long result = platform.getEstimatedRowCount(table);
+        assertEquals(7L, result);
+        ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> paramCaptor = ArgumentCaptor.forClass(String.class);
+        verify(sqlTemplateDirty).queryForLong(sqlCaptor.capture(), paramCaptor.capture());
+        assertEquals("SELECT ISNULL(SUM(rows), -1) FROM AutoCribNet.sys.partitions "
+                + "WHERE object_id = OBJECT_ID(?) AND index_id IN (0, 1)", sqlCaptor.getValue());
+        assertEquals("AutoCribNet.11498.Pack", paramCaptor.getValue());
+    }
+
+    @Test
+    @DisplayName("getEstimatedRowCount returns -1 when table not found")
+    void testEstimatedRowCountTableNotFound() {
+        Table table = new Table("NoSuchTable");
+        when(sqlTemplateDirty.queryForLong(anyString(), anyString())).thenReturn(-1L);
+        long result = platform.getEstimatedRowCount(table);
+        assertEquals(-1L, result);
+    }
+}

--- a/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/mssql/MsSql2008DatabasePlatformTest.java
+++ b/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/mssql/MsSql2008DatabasePlatformTest.java
@@ -33,11 +33,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
-/**
- * Unit tests for {@link MsSql2008DatabasePlatform#getEstimatedRowCount(Table)}
- */
-@DisplayName("MsSql2008DatabasePlatform")
 class MsSql2008DatabasePlatformTest {
+    private static final String CATALOG_NAME = "dbCatalog";
+    private static final String SCHEMA_NAME = "dbSchema";
+    private static final String TABLE_NAME = "dbTable";
     private MsSql2008DatabasePlatform platform;
     private ISqlTemplate sqlTemplateDirty;
     private MsSql2008DdlBuilder ddlBuilder;
@@ -56,25 +55,25 @@ class MsSql2008DatabasePlatformTest {
     @Test
     @DisplayName("getEstimatedRowCount with catalog, schema, and default delimited mode quotes all identifiers")
     void testEstimatedRowCountWithCatalogAndSchema() {
-        Table table = new Table("Pack");
-        table.setCatalog("AutoCribNet");
-        table.setSchema("11498");
+        Table table = new Table(TABLE_NAME);
+        table.setCatalog(CATALOG_NAME);
+        table.setSchema(SCHEMA_NAME);
         when(sqlTemplateDirty.queryForLong(anyString(), anyString())).thenReturn(42L);
         long result = platform.getEstimatedRowCount(table);
         assertEquals(42L, result);
         ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<String> paramCaptor = ArgumentCaptor.forClass(String.class);
         verify(sqlTemplateDirty).queryForLong(sqlCaptor.capture(), paramCaptor.capture());
-        assertEquals("SELECT ISNULL(SUM(rows), -1) FROM \"AutoCribNet\".sys.partitions "
-                + "WHERE object_id = OBJECT_ID(?) AND index_id IN (0, 1)", sqlCaptor.getValue());
-        assertEquals("\"AutoCribNet\".\"11498\".\"Pack\"", paramCaptor.getValue());
+        assertEquals("SELECT ISNULL(SUM(rows), -1) FROM \"" + CATALOG_NAME + "\".sys.partitions " // Catalog is significant for the sys.partitions view
+                + "WHERE object_id = OBJECT_ID(?) AND index_id IN (0,1)", sqlCaptor.getValue());
+        assertEquals("\"" + CATALOG_NAME + "\".\"" + SCHEMA_NAME + "\".\"" + TABLE_NAME + "\"", paramCaptor.getValue());
     }
 
     @Test
     @DisplayName("getEstimatedRowCount without catalog omits catalog prefix from sys.partitions")
     void testEstimatedRowCountWithoutCatalog() {
-        Table table = new Table("Users");
-        table.setSchema("dbo");
+        Table table = new Table(TABLE_NAME);
+        table.setSchema(SCHEMA_NAME);
         when(sqlTemplateDirty.queryForLong(anyString(), anyString())).thenReturn(100L);
         long result = platform.getEstimatedRowCount(table);
         assertEquals(100L, result);
@@ -82,14 +81,14 @@ class MsSql2008DatabasePlatformTest {
         ArgumentCaptor<String> paramCaptor = ArgumentCaptor.forClass(String.class);
         verify(sqlTemplateDirty).queryForLong(sqlCaptor.capture(), paramCaptor.capture());
         assertEquals("SELECT ISNULL(SUM(rows), -1) FROM sys.partitions "
-                + "WHERE object_id = OBJECT_ID(?) AND index_id IN (0, 1)", sqlCaptor.getValue());
-        assertEquals("\"dbo\".\"Users\"", paramCaptor.getValue());
+                + "WHERE object_id = OBJECT_ID(?) AND index_id IN (0,1)", sqlCaptor.getValue());
+        assertEquals("\"" + SCHEMA_NAME + "\".\"" + TABLE_NAME + "\"", paramCaptor.getValue());
     }
 
     @Test
     @DisplayName("getEstimatedRowCount without catalog or schema uses just quoted table name")
     void testEstimatedRowCountTableOnly() {
-        Table table = new Table("Items");
+        Table table = new Table(TABLE_NAME);
         when(sqlTemplateDirty.queryForLong(anyString(), anyString())).thenReturn(0L);
         long result = platform.getEstimatedRowCount(table);
         assertEquals(0L, result);
@@ -97,16 +96,16 @@ class MsSql2008DatabasePlatformTest {
         ArgumentCaptor<String> paramCaptor = ArgumentCaptor.forClass(String.class);
         verify(sqlTemplateDirty).queryForLong(sqlCaptor.capture(), paramCaptor.capture());
         assertEquals("SELECT ISNULL(SUM(rows), -1) FROM sys.partitions "
-                + "WHERE object_id = OBJECT_ID(?) AND index_id IN (0, 1)", sqlCaptor.getValue());
-        assertEquals("\"Items\"", paramCaptor.getValue());
+                + "WHERE object_id = OBJECT_ID(?) AND index_id IN (0,1)", sqlCaptor.getValue());
+        assertEquals("\"" + TABLE_NAME + "\"", paramCaptor.getValue());
     }
 
     @Test
     @DisplayName("getEstimatedRowCount with delimited mode off produces unquoted names")
     void testEstimatedRowCountUnquoted() {
-        Table table = new Table("Pack");
-        table.setCatalog("AutoCribNet");
-        table.setSchema("11498");
+        Table table = new Table(TABLE_NAME);
+        table.setCatalog(CATALOG_NAME);
+        table.setSchema(SCHEMA_NAME);
         ddlBuilder.setDelimitedIdentifierModeOn(false);
         when(sqlTemplateDirty.queryForLong(anyString(), anyString())).thenReturn(7L);
         long result = platform.getEstimatedRowCount(table);
@@ -114,15 +113,15 @@ class MsSql2008DatabasePlatformTest {
         ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<String> paramCaptor = ArgumentCaptor.forClass(String.class);
         verify(sqlTemplateDirty).queryForLong(sqlCaptor.capture(), paramCaptor.capture());
-        assertEquals("SELECT ISNULL(SUM(rows), -1) FROM AutoCribNet.sys.partitions "
-                + "WHERE object_id = OBJECT_ID(?) AND index_id IN (0, 1)", sqlCaptor.getValue());
-        assertEquals("AutoCribNet.11498.Pack", paramCaptor.getValue());
+        assertEquals("SELECT ISNULL(SUM(rows), -1) FROM " + CATALOG_NAME + ".sys.partitions "
+                + "WHERE object_id = OBJECT_ID(?) AND index_id IN (0,1)", sqlCaptor.getValue());
+        assertEquals(CATALOG_NAME + "." + SCHEMA_NAME + "." + TABLE_NAME, paramCaptor.getValue());
     }
 
     @Test
     @DisplayName("getEstimatedRowCount returns -1 when table not found")
     void testEstimatedRowCountTableNotFound() {
-        Table table = new Table("NoSuchTable");
+        Table table = new Table(TABLE_NAME + "_non_existant");
         when(sqlTemplateDirty.queryForLong(anyString(), anyString())).thenReturn(-1L);
         long result = platform.getEstimatedRowCount(table);
         assertEquals(-1L, result);


### PR DESCRIPTION
## Summary

- Replace slow 3-way JOIN on `sys.tables`/`sys.partitions`/`sys.schemas` with a single `OBJECT_ID()` lookup in `MsSql2008DatabasePlatform.getEstimatedRowCount()`
- Use `Table.getQualifiedTableName()` for consistent identifier quoting
- Return `-1` via `ISNULL()` when table not found, so the caller falls back to `count(*)`

## Problem

During initial load queue processing, `getEstimatedRowCount()` is called once per table. On SQL Server databases with many schemas, the 3-way JOIN takes **110–184 seconds per table**. With 72 tables this means 2+ hours of sequential row count queries, freezing the UI and blocking all other SymmetricDS operations (routing, batch monitoring, node security).

Customer (AutoCrib/Snap-on) confirmed the `OBJECT_ID()` alternative runs instantly on their database.

## Test plan

- [ ] Deploy patched build to AutoCrib dev environment (DEV41SYNC)
- [ ] Trigger an initial load for node 11498 (72 tables)
- [ ] Verify row count queries complete in <1 second per table (check logs for absence of "Long Running" messages)
- [ ] Verify UI remains responsive during load creation
- [ ] Verify estimated row counts match actual table sizes

Jira: [SYM-7450](https://jumpmind.atlassian.net/browse/SYM-7450)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SYM-7450]: https://jumpmind.atlassian.net/browse/SYM-7450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ