### PR TITLE
SYM-7441: Added Refresh Analytics job and table heat map report

### DIFF
--- a/symmetric-assemble/src/asciidoc/manage/jobs.ad
+++ b/symmetric-assemble/src/asciidoc/manage/jobs.ad
@@ -141,6 +141,8 @@ See <<File Synchronization>> and <<Pull Threads>> for more details.
 
 The Initial Load Extract Job processes <<EXTRACT_REQUEST>>s.  See <<Initial Load Extract In Background>> for more details.
 
+ifdef::pro[]
+
 ==== Compare Job
 
 The Compare Job processes <<COMPARE_REQUEST>>s.  If it finds uncompleted requests, it will keep the job running
@@ -148,3 +150,9 @@ The Compare Job processes <<COMPARE_REQUEST>>s.  If it finds uncompleted request
 instead waiting for the next scheduled job interval.
 It uses a number of threads from a pool on each server (compare.thread.per.server.count) to service requests in parallel.
 Each request uses multiple threads, but less than the entire pool size by default (compare.queue.per.request.count).
+
+==== Refresh Analytics Job
+
+The Refresh Analytics Job is responsible for analyzing raw metrics and generating report data. It records reports to the <<ANALYTICS_REPORT>> table. Reports are displayed under the Analytics tab.
+
+endif::pro[]

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/ClusterConstants.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/ClusterConstants.java
@@ -50,6 +50,7 @@ public class ClusterConstants {
     public static final String COMPARE = "Compare";
     public static final String DATA_REFRESH = "Data Refresh";
     public static final String LOG_MINER = "Log Miner";
+    public static final String REFRESH_ANALYTICS = "Refresh Analytics";
     public static final String FILE_SYNC_SHARED = "FILE_SYNC_SHARED";
     public static final String TYPE_CLUSTER = "CLUSTER";
     public static final String TYPE_EXCLUSIVE = "EXCLUSIVE";


### PR DESCRIPTION
When documenting the Refresh Analytics job, I noticed that the documentation for the SymmetricDS Pro Compare job is present in the open-source user guide, so this PR also fixes that issue.