### PR TITLE
SYM-7547: Switched UUID to varchar in Postgres

### DIFF
--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/mysql/MySqlDdlReader.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/mysql/MySqlDdlReader.java
@@ -185,7 +185,7 @@ public class MySqlDdlReader extends AbstractJdbcDdlReader {
                 return convertTextToLob ? Types.BLOB : Types.LONGVARCHAR;
             }
             return super.mapUnknownJdbcTypeForColumn(values);
-        } else if (type != null && type == Types.OTHER && "UUID".equalsIgnoreCase("UUID")) {
+        } else if (type != null && type == Types.OTHER && typeName != null && typeName.equalsIgnoreCase("UUID")) {
             return Types.VARCHAR;
         } else if (type != null && type == Types.OTHER) {
             return Types.LONGVARCHAR;

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/postgresql/PostgreSqlDdlReader.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/postgresql/PostgreSqlDdlReader.java
@@ -212,6 +212,8 @@ public class PostgreSqlDdlReader extends AbstractJdbcDdlReader {
             return ColumnTypes.TIMETZ;
         } else if (PostgreSqlDatabasePlatform.isBlobStoredByReference(typeName)) {
             return Types.BLOB;
+        } else if (typeName != null && typeName.equalsIgnoreCase("UUID") && type != null && type == Types.OTHER) {
+            return Types.VARCHAR;
         } else if (type != null && (type == Types.STRUCT || type == Types.OTHER)) {
             return Types.LONGVARCHAR;
         } else if (typeName != null && typeName.equalsIgnoreCase("BIT")) {

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/postgresql/PostgreSqlDdlReader.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/postgresql/PostgreSqlDdlReader.java
@@ -212,7 +212,7 @@ public class PostgreSqlDdlReader extends AbstractJdbcDdlReader {
             return ColumnTypes.TIMETZ;
         } else if (PostgreSqlDatabasePlatform.isBlobStoredByReference(typeName)) {
             return Types.BLOB;
-        } else if (typeName != null && typeName.equalsIgnoreCase("UUID") && type != null && type == Types.OTHER) {
+        } else if (typeName != null && typeName.equalsIgnoreCase("UUID") && type == Types.OTHER) {
             return Types.VARCHAR;
         } else if (type != null && (type == Types.STRUCT || type == Types.OTHER)) {
             return Types.LONGVARCHAR;


### PR DESCRIPTION
Modified PostgreSqlDdlReader to mark UUID as varchar to prevent failure when UUID is a PK and Stream lobs is enabled. 
Also caught a bug in MySqlDdlReader.