### PR TITLE
SYM-7537: Mapped OracleTSTZ to Types Varchar to prevent IOOBE on Null

### DIFF
--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/sql/JdbcSqlTemplate.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/sql/JdbcSqlTemplate.java
@@ -1281,7 +1281,9 @@ public class JdbcSqlTemplate extends AbstractSqlTemplate implements ISqlTemplate
     }
 
     protected int verifyArgType(Object arg, int argType) {
-        if (argType == ORACLE_TIMESTAMPTZ || argType == ORACLE_TIMESTAMPLTZ || argType == Types.OTHER || argType == ColumnTypes.MSSQL_SQL_VARIANT) {
+        if (argType == ORACLE_TIMESTAMPTZ || argType == ORACLE_TIMESTAMPLTZ) {
+            return Types.VARCHAR;
+        } else if (argType == Types.OTHER || argType == ColumnTypes.MSSQL_SQL_VARIANT) {
             return SqlTypeValue.TYPE_UNKNOWN;
         } else if ((argType == Types.INTEGER && arg instanceof BigInteger) ||
                 (argType == Types.BIGINT && arg instanceof BigDecimal)) {


### PR DESCRIPTION
Oracle timestamp with time zone would fail with index out of bounds when column contained a null value. 
TimestampTZ was mapped as TYPE_UNKNOWN.
This would hit ps.setNull(i, Types.NULL) inside of the function TO_TIMESTAMP_TZ(?, '...') 
This caused an issue because Types.Null returns a type code of 0. 
Flipping TimestampTZ to map as Types.varchar fixes this issue.
ps.setNull(i, Types.VARCHAR) does not have the same issue when called in a function. 