### PR TITLE
SYM-7638: Add tables for built-in metrics to the support snapshot - workaround

### DIFF
--- a/symmetric-client/src/main/java/org/jumpmind/symmetric/util/SnapshotUtil.java
+++ b/symmetric-client/src/main/java/org/jumpmind/symmetric/util/SnapshotUtil.java
@@ -58,7 +58,6 @@ import javax.management.MBeanServer;
 import javax.management.ObjectName;
 import javax.sql.DataSource;
 
-import org.jumpmind.db.util.IPooledDataSource;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
@@ -74,6 +73,7 @@ import org.jumpmind.db.model.View;
 import org.jumpmind.db.platform.IDatabasePlatform;
 import org.jumpmind.db.sql.ISqlTemplate;
 import org.jumpmind.db.sql.Row;
+import org.jumpmind.db.util.IPooledDataSource;
 import org.jumpmind.exception.IoException;
 import org.jumpmind.extension.IProgressListener;
 import org.jumpmind.symmetric.ISymmetricEngine;
@@ -136,7 +136,8 @@ public class SnapshotUtil {
         File tmpDir = new File(parameterService.getTempDirectory(), dirName);
         tmpDir.mkdirs();
         log.info("Creating snapshot file in " + tmpDir.getAbsolutePath());
-        int stepNumber = 0, totalSteps = 36;
+        int stepNumber = 0;
+        int totalSteps = 37;
         checkpoint(engine, listener, stepNumber++, totalSteps);
         try {
             log.info("Calling beforeSnapshot()");
@@ -331,6 +332,16 @@ public class SnapshotUtil {
             extract(export, 5000, "order by relative_dir, file_name", new File(exportDir, "file_snapshot.csv"),
                     TableConstants.getTableName(tablePrefix, TableConstants.SYM_FILE_SNAPSHOT));
         }
+        log.info("Writing runtime data - metrics");
+        checkpoint(engine, listener, stepNumber++, totalSteps);
+        extract(export, 10000, "order by last_update_time desc", new File(exportDir, "metric_key.csv"), TableConstants.getTableName(tablePrefix,
+                TableConstants.SYM_METRIC_KEY));
+        extract(export, 10000, "order by create_time desc", new File(exportDir, "metric_context.csv"), TableConstants.getTableName(tablePrefix,
+                TableConstants.SYM_METRIC_CONTEXT));
+        extract(export, 10000, "order by interval_start_time desc", new File(exportDir, "metric_stats_float64.csv"), TableConstants.getTableName(tablePrefix,
+                TableConstants.SYM_METRIC_STATS_FLOAT64));
+        extract(export, 10000, "order by interval_start_time desc", new File(exportDir, "metric_stats_int64.csv"), TableConstants.getTableName(tablePrefix,
+                TableConstants.SYM_METRIC_STATS_INT64));
         log.info("Writing runtime data - export config");
         checkpoint(engine, listener, stepNumber++, totalSteps);
         extract(export, new File(exportDir, "channel.csv"), TableConstants.getTableName(tablePrefix, TableConstants.SYM_CHANNEL));

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/common/TableConstants.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/common/TableConstants.java
@@ -96,10 +96,10 @@ public class TableConstants {
     public static final String SYM_COMPARE_STATUS = "compare_status";
     public static final String SYM_COMPARE_TABLE_STATUS = "compare_table_status";
     public static final String SYM_ANALYTICS_REPORT = "analytics_report";
-    public static final String METRIC_KEY = "metric_key";
-    public static final String METRIC_STATS_FLOAT64 = "metric_stats_float64";
-    public static final String METRIC_STATS_INT64 = "metric_stats_int64";
-    public static final String METRIC_CONTEXT = "metric_context";
+    public static final String SYM_METRIC_KEY = "metric_key";
+    public static final String SYM_METRIC_STATS_FLOAT64 = "metric_stats_float64";
+    public static final String SYM_METRIC_STATS_INT64 = "metric_stats_int64";
+    public static final String SYM_METRIC_CONTEXT = "metric_context";
     protected static boolean hasConsoleSchema = TableConstants.class.getResourceAsStream("/console-schema.xml") != null;
     /**
      * Historical list of decommissioned SymmetricDS tables. Used to filter configuration files produced by older versions. See getRemovedConfigTables:
@@ -119,7 +119,7 @@ public class TableConstants {
                 SYM_NODE_HOST_JOB_STATS, SYM_NODE_HOST_STATS, SYM_NODE_IDENTITY, SYM_NODE_SECURITY, SYM_OUTGOING_BATCH, SYM_PARAMETER,
                 SYM_REGISTRATION_REDIRECT, SYM_REGISTRATION_REQUEST, SYM_ROUTER, SYM_SEQUENCE, SYM_TABLE_RELOAD_REQUEST, SYM_TABLE_RELOAD_STATUS,
                 SYM_TRANSFORM_TABLE, SYM_TRANSFORM_COLUMN, SYM_TRIGGER, SYM_TRIGGER_HIST, SYM_TRIGGER_ROUTER, SYM_TRIGGER_ROUTER_GROUPLET, SYM_OUTGOING_ERROR,
-                METRIC_KEY, METRIC_STATS_FLOAT64, METRIC_STATS_INT64, METRIC_CONTEXT);
+                SYM_METRIC_KEY, SYM_METRIC_STATS_FLOAT64, SYM_METRIC_STATS_INT64, SYM_METRIC_CONTEXT);
         if (hasConsoleSchema) {
             tables.addAll(getTablesForConsole(tablePrefix));
         }


### PR DESCRIPTION
Issues with old PR (.launch files got added). This PR is a workaround (just created a new branch and added just the java files)