### PR TITLE
SYM-7651: Updated S3 dependencies

### DIFF
--- a/symmetric-client/src/main/resources/symmetric-modules.properties
+++ b/symmetric-client/src/main/resources/symmetric-modules.properties
@@ -49,10 +49,10 @@ nuodb=org.jumpmind.symmetric.module:nuodb-jdbc:3.3.1
 opensearch=org.opensearch.client:opensearch-rest-client:1.0.0,org.elasticsearch.client:elasticsearch-rest-high-level-client:7.10.2,org.elasticsearch:elasticsearch:7.10.2,org.elasticsearch.client:elasticsearch-rest-client:7.10.2,org.elasticsearch.plugin:mapper-extras-client:7.10.2,org.elasticsearch.plugin:parent-join-client:7.10.2,org.elasticsearch.plugin:aggs-matrix-stats-client:7.10.2,org.elasticsearch.plugin:rank-eval-client:7.10.2,org.elasticsearch.plugin:lang-mustache-client:7.10.2,org.elasticsearch:elasticsearch-core:7.10.2,org.elasticsearch:elasticsearch-secure-sm:7.10.2,org.elasticsearch:elasticsearch-x-content:7.10.2,org.elasticsearch:elasticsearch-geo:7.10.2,org.elasticsearch:elasticsearch-cli:7.10.2,org.elasticsearch:jna:5.5.0,org.apache.lucene:lucene-core:8.7.0, org.apache.httpcomponents:httpasyncclient:4.1.5,org.apache.httpcomponents:httpcore-nio:4.4.16,joda-time:joda-time:2.12.7
 oracle-tools-linux-x64=org.jumpmind.symmetric.module:oracle-tools-linux-x64:23.7:zip
 oracle-tools-windows-x64=org.jumpmind.symmetric.module:oracle-tools-windows-x64:23.7:zip
-redshift=com.amazon.redshift:redshift-jdbc42:2.1.0.27, com.amazonaws:aws-java-sdk-s3:1.12.719, com.amazonaws:aws-java-sdk-redshift:1.12.719, com.amazonaws:aws-java-sdk-kms:1.12.719, software.amazon.ion:ion-java:1.0.3, com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.15.4, joda-time:joda-time:2.12.7, com.amazonaws:jmespath-java:1.12.719, com.amazonaws:aws-java-sdk-core:1.12.719
-s3=com.amazonaws:aws-java-sdk-s3:1.12.719
+redshift=com.amazon.redshift:redshift-jdbc42:2.1.0.27, software.amazon.awssdk:s3:2.46.15
+s3=software.amazon.awssdk:s3:2.46.15
 singlestore=com.singlestore:singlestore-jdbc-client:1.0.2
-snowflake=net.snowflake:snowflake-jdbc:3.13.34, com.microsoft.azure:azure-storage:8.6.6, com.microsoft.azure:azure-keyvault-core:1.2.6, com.amazonaws:aws-java-sdk-s3:1.12.719, com.amazonaws:aws-java-sdk-kms:1.12.719, software.amazon.ion:ion-java:1.5.1, com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.15.4, joda-time:joda-time:2.12.7, com.amazonaws:jmespath-java:1.12.719, com.amazonaws:aws-java-sdk-core:1.12.719
+snowflake=net.snowflake:snowflake-jdbc:3.13.34, com.microsoft.azure:azure-storage:8.6.6, com.microsoft.azure:azure-keyvault-core:1.2.6, software.amazon.awssdk:s3:2.46.15
 #missing
 sparksql=org.apache.hive:hive-jdbc:4.0.1:standalone
 sqlite=org.xerial:sqlite-jdbc:3.45.3.0


### PR DESCRIPTION
I used Claude to analyze the module dependencies and found that many of them are no longer needed after upgrading to version 2 of the AWS SDK. I was unable to test this change because I don't have access to Redshift or Snowflake.