### PR TITLE
SYM-7740: Add unit tests for utility classes in symmetric-util 

### DIFF
--- a/symmetric-util/src/test/java/org/jumpmind/properties/SortedPropertiesTest.java
+++ b/symmetric-util/src/test/java/org/jumpmind/properties/SortedPropertiesTest.java
@@ -1,0 +1,83 @@
+/**
+ * Licensed to JumpMind Inc under one or more contributor
+ * license agreements.  See the NOTICE file distributed
+ * with this work for additional information regarding
+ * copyright ownership.  JumpMind Inc licenses this file
+ * to you under the GNU General Public License, version 3.0 (GPLv3)
+ * (the "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3.0 (GPLv3) along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jumpmind.properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class SortedPropertiesTest {
+
+    /** Drain keys() into a list so order can be asserted. */
+    private static List<String> keysOf(SortedProperties props) {
+        List<String> keys = new ArrayList<>();
+        Enumeration<?> e = props.keys();
+        while (e.hasMoreElements()) {
+            keys.add((String) e.nextElement());
+        }
+        return keys;
+    }
+
+    @Test
+    void testKeys_sortedOrderRegardlessOfInsertionOrder() {
+        SortedProperties props = new SortedProperties();
+        props.setProperty("charlie", "3");
+        props.setProperty("alpha", "1");
+        props.setProperty("bravo", "2");
+        assertEquals(List.of("alpha", "bravo", "charlie"), keysOf(props));
+    }
+
+    @Test
+    void testKeys_caseSensitiveLexicographicSort() {
+        // Uppercase sorts before lowercase (ASCII order), so "Apple" precedes "banana".
+        SortedProperties props = new SortedProperties();
+        props.setProperty("banana", "1");
+        props.setProperty("Apple", "2");
+        props.setProperty("cherry", "3");
+        assertEquals(List.of("Apple", "banana", "cherry"), keysOf(props));
+    }
+
+    @Test
+    void testKeys_numericKeysSortLexicographicallyNotNumerically() {
+        // "10" comes before "2" because comparison is character-by-character on strings.
+        SortedProperties props = new SortedProperties();
+        props.setProperty("2", "a");
+        props.setProperty("10", "b");
+        props.setProperty("1", "c");
+        assertEquals(List.of("1", "10", "2"), keysOf(props));
+    }
+
+    @Test
+    void testKeys_singleKey() {
+        SortedProperties props = new SortedProperties();
+        props.setProperty("only", "1");
+        assertEquals(List.of("only"), keysOf(props));
+    }
+
+    @Test
+    void testKeys_emptyReturnsNoKeys() {
+        assertEquals(List.of(), keysOf(new SortedProperties()));
+    }
+}

--- a/symmetric-util/src/test/java/org/jumpmind/properties/SortedPropertiesTest.java
+++ b/symmetric-util/src/test/java/org/jumpmind/properties/SortedPropertiesTest.java
@@ -29,7 +29,6 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class SortedPropertiesTest {
-
     /** Drain keys() into a list so order can be asserted. */
     private static List<String> keysOf(SortedProperties props) {
         List<String> keys = new ArrayList<>();

--- a/symmetric-util/src/test/java/org/jumpmind/properties/TypedPropertiesTest.java
+++ b/symmetric-util/src/test/java/org/jumpmind/properties/TypedPropertiesTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertNull;
 
 import java.util.Properties;
 
-import org.jumpmind.properties.TypedProperties;
 import org.junit.jupiter.api.Test;
 
 class TypedPropertiesTest {

--- a/symmetric-util/src/test/java/org/jumpmind/properties/TypedPropertiesTest.java
+++ b/symmetric-util/src/test/java/org/jumpmind/properties/TypedPropertiesTest.java
@@ -1,4 +1,4 @@
-package org.jumpmind.util.properties;
+package org.jumpmind.properties;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;

--- a/symmetric-util/src/test/java/org/jumpmind/util/ContextTest.java
+++ b/symmetric-util/src/test/java/org/jumpmind/util/ContextTest.java
@@ -1,0 +1,111 @@
+/**
+ * Licensed to JumpMind Inc under one or more contributor
+ * license agreements.  See the NOTICE file distributed
+ * with this work for additional information regarding
+ * copyright ownership.  JumpMind Inc licenses this file
+ * to you under the GNU General Public License, version 3.0 (GPLv3)
+ * (the "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3.0 (GPLv3) along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jumpmind.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ContextTest {
+
+    private Context context;
+
+    @BeforeEach
+    void setUp() {
+        context = new Context();
+    }
+
+    @Test
+    void testGet_returnsStoredValue() {
+        context.put("key", "value");
+        assertEquals("value", context.get("key"));
+    }
+
+    @Test
+    void testPut_overwritesExistingValue() {
+        context.put("key", "first");
+        context.put("key", "second");
+        assertEquals("second", context.get("key"));
+    }
+
+    @Test
+    void testGet_missingKeyReturnsNull() {
+        assertNull(context.get("absent"));
+    }
+
+    @Test
+    void testPut_storesAnyObjectType() {
+        Object value = new int[] { 1, 2, 3 };
+        context.put("array", value);
+        assertSame(value, context.get("array"));
+    }
+
+    @Test
+    void testPut_storesNullValue() {
+        // Backed by HashMap, so a null value is allowed and distinct from "absent".
+        context.put("key", null);
+        assertNull(context.get("key"));
+        assertTrue(context.keySet().contains("key"));
+    }
+
+    @Test
+    void testRemove_returnsValueAndDeletesKey() {
+        context.put("key", "value");
+        assertEquals("value", context.remove("key"));
+        assertNull(context.get("key"));
+    }
+
+    @Test
+    void testRemove_missingKeyReturnsNull() {
+        assertNull(context.remove("absent"));
+    }
+
+    @Test
+    void testKeySet_reflectsStoredKeys() {
+        context.put("a", 1);
+        context.put("b", 2);
+        assertEquals(2, context.keySet().size());
+        assertTrue(context.keySet().containsAll(java.util.List.of("a", "b")));
+    }
+
+    @Test
+    void testKeySet_emptyForNewContext() {
+        assertTrue(context.keySet().isEmpty());
+    }
+
+    @Test
+    void testGetContext_exposesAllEntries() {
+        context.put("key", "value");
+        assertEquals(1, context.getContext().size());
+        assertEquals("value", context.getContext().get("key"));
+    }
+
+    @Test
+    void testGetContext_isLiveBackingMap() {
+        // getContext() returns the internal map, so changes through it are visible via get().
+        context.getContext().put("injected", 42);
+        assertEquals(42, context.get("injected"));
+    }
+}

--- a/symmetric-util/src/test/java/org/jumpmind/util/ContextTest.java
+++ b/symmetric-util/src/test/java/org/jumpmind/util/ContextTest.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class ContextTest {
-
     private Context context;
 
     @BeforeEach

--- a/symmetric-util/src/test/java/org/jumpmind/util/LinkedCaseInsensitiveMapTest.java
+++ b/symmetric-util/src/test/java/org/jumpmind/util/LinkedCaseInsensitiveMapTest.java
@@ -34,7 +34,6 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class LinkedCaseInsensitiveMapTest {
-
     @Test
     void testGet_resolvesAnyCasing() {
         LinkedCaseInsensitiveMap<String> map = new LinkedCaseInsensitiveMap<>();

--- a/symmetric-util/src/test/java/org/jumpmind/util/LinkedCaseInsensitiveMapTest.java
+++ b/symmetric-util/src/test/java/org/jumpmind/util/LinkedCaseInsensitiveMapTest.java
@@ -1,0 +1,151 @@
+/**
+ * Licensed to JumpMind Inc under one or more contributor
+ * license agreements.  See the NOTICE file distributed
+ * with this work for additional information regarding
+ * copyright ownership.  JumpMind Inc licenses this file
+ * to you under the GNU General Public License, version 3.0 (GPLv3)
+ * (the "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3.0 (GPLv3) along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jumpmind.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+class LinkedCaseInsensitiveMapTest {
+
+    @Test
+    void testGet_resolvesAnyCasing() {
+        LinkedCaseInsensitiveMap<String> map = new LinkedCaseInsensitiveMap<>();
+        map.put("Content-Type", "application/json");
+        assertEquals("application/json", map.get("content-type"));
+        assertEquals("application/json", map.get("CONTENT-TYPE"));
+        assertEquals("application/json", map.get("Content-Type"));
+    }
+
+    @Test
+    void testContainsKey_resolvesAnyCasing() {
+        LinkedCaseInsensitiveMap<String> map = new LinkedCaseInsensitiveMap<>();
+        map.put("Accept", "*/*");
+        assertTrue(map.containsKey("accept"));
+        assertTrue(map.containsKey("ACCEPT"));
+        assertFalse(map.containsKey("missing"));
+    }
+
+    @Test
+    void testRemove_resolvesAnyCasing() {
+        LinkedCaseInsensitiveMap<String> map = new LinkedCaseInsensitiveMap<>();
+        map.put("Host", "localhost");
+        assertEquals("localhost", map.remove("HOST"));
+        assertNull(map.get("host"));
+        assertFalse(map.containsKey("host"));
+    }
+
+    @Test
+    void testPut_sameCaseOverwriteKeepsLatestValue() {
+        LinkedCaseInsensitiveMap<String> map = new LinkedCaseInsensitiveMap<>();
+        map.put("key", "first");
+        map.put("key", "second");
+        assertEquals("second", map.get("key"));
+        assertEquals(1, map.size());
+    }
+
+    @Test
+    void testKeySet_reportsOriginalCasing() {
+        LinkedCaseInsensitiveMap<String> map = new LinkedCaseInsensitiveMap<>();
+        map.put("Content-Type", "a");
+        // Stored under the original casing, not lower-cased.
+        assertTrue(map.containsKey("content-type"));
+        assertEquals(List.of("Content-Type"), new ArrayList<>(map.keySet()));
+    }
+
+    @Test
+    void testKeySet_insertionOrderPreserved() {
+        LinkedCaseInsensitiveMap<String> map = new LinkedCaseInsensitiveMap<>();
+        map.put("first", "1");
+        map.put("second", "2");
+        map.put("third", "3");
+        assertEquals(List.of("first", "second", "third"), new ArrayList<>(map.keySet()));
+    }
+
+    @Test
+    void testGet_nonStringKeyReturnsNullOrFalse() {
+        LinkedCaseInsensitiveMap<String> map = new LinkedCaseInsensitiveMap<>();
+        map.put("key", "value");
+        assertNull(map.get(Integer.valueOf(1)));
+        assertFalse(map.containsKey(Integer.valueOf(1)));
+        assertNull(map.remove(Integer.valueOf(1)));
+    }
+
+    @Test
+    void testPut_nullKeyThrows() {
+        // Null keys are explicitly unsupported (convertKey calls toLowerCase on the key).
+        LinkedCaseInsensitiveMap<String> map = new LinkedCaseInsensitiveMap<>();
+        assertThrows(NullPointerException.class, () -> map.put(null, "x"));
+    }
+
+    @Test
+    void testGet_nullKeyLookupsAreSafe() {
+        LinkedCaseInsensitiveMap<String> map = new LinkedCaseInsensitiveMap<>();
+        assertNull(map.get(null));
+        assertFalse(map.containsKey(null));
+        assertNull(map.remove(null));
+    }
+
+    @Test
+    void testConstructor_mapCopiesEntriesCaseInsensitively() {
+        Map<String, String> source = new LinkedHashMap<>();
+        source.put("Foo", "1");
+        source.put("Bar", "2");
+        LinkedCaseInsensitiveMap<String> map = new LinkedCaseInsensitiveMap<>(source);
+        assertEquals("1", map.get("foo"));
+        assertEquals("2", map.get("BAR"));
+        assertEquals(2, map.size());
+    }
+
+    @Test
+    void testClear_emptiesBothBackingMaps() {
+        LinkedCaseInsensitiveMap<String> map = new LinkedCaseInsensitiveMap<>();
+        map.put("Key", "value");
+        map.clear();
+        assertEquals(0, map.size());
+        assertNull(map.get("key"));
+        assertFalse(map.containsKey("key"));
+        // Re-use after clear still works (case-insensitive index was cleared too).
+        map.put("Key", "again");
+        assertEquals("again", map.get("KEY"));
+    }
+
+    @Test
+    void testPut_differentCaseInflatesSize() {
+        // get/containsKey stay case-insensitive, but this version leaves the prior
+        // original-cased entry in the backing LinkedHashMap, so size() over-counts.
+        // Documents current behavior; would flag a future fix to the production class.
+        LinkedCaseInsensitiveMap<String> map = new LinkedCaseInsensitiveMap<>();
+        map.put("Name", "a");
+        map.put("NAME", "b");
+        assertEquals("b", map.get("name"));
+        assertEquals(2, map.size());
+    }
+}

--- a/symmetric-util/src/test/java/org/jumpmind/util/RandomTimeSlotTest.java
+++ b/symmetric-util/src/test/java/org/jumpmind/util/RandomTimeSlotTest.java
@@ -27,7 +27,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 
 class RandomTimeSlotTest {
-
     @Test
     void testGetRandomValueSeededByExternalId_alwaysWithinBounds() {
         // nextInt(maxValue) is in [0, maxValue), and 0 is remapped to 1,

--- a/symmetric-util/src/test/java/org/jumpmind/util/RandomTimeSlotTest.java
+++ b/symmetric-util/src/test/java/org/jumpmind/util/RandomTimeSlotTest.java
@@ -1,0 +1,69 @@
+/**
+ * Licensed to JumpMind Inc under one or more contributor
+ * license agreements.  See the NOTICE file distributed
+ * with this work for additional information regarding
+ * copyright ownership.  JumpMind Inc licenses this file
+ * to you under the GNU General Public License, version 3.0 (GPLv3)
+ * (the "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3.0 (GPLv3) along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jumpmind.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class RandomTimeSlotTest {
+
+    @Test
+    void testGetRandomValueSeededByExternalId_alwaysWithinBounds() {
+        // nextInt(maxValue) is in [0, maxValue), and 0 is remapped to 1,
+        // so every result is >= 1 and < maxValue. True for any RNG provider.
+        RandomTimeSlot slot = new RandomTimeSlot("node-001", 100);
+        for (int i = 0; i < 1000; i++) {
+            int value = slot.getRandomValueSeededByExternalId();
+            assertTrue(value >= 1 && value < 100, "out of range: " + value);
+        }
+    }
+
+    @Test
+    void testGetRandomValueSeededByExternalId_maxValueOfOneReturnsOne() {
+        // nextInt(1) is always 0, which is remapped to 1.
+        RandomTimeSlot slot = new RandomTimeSlot("node-001", 1);
+        assertEquals(1, slot.getRandomValueSeededByExternalId());
+    }
+
+    @Test
+    void testGetRandomValueSeededByExternalId_maxValueOfTwoReturnsOne() {
+        // nextInt(2) is 0 or 1; both collapse to 1 (0 -> 1, 1 stays 1).
+        RandomTimeSlot slot = new RandomTimeSlot("node-001", 2);
+        assertEquals(1, slot.getRandomValueSeededByExternalId());
+    }
+
+    @Test
+    void testGetRandomValueSeededByExternalId_noArgConstructorThrows() {
+        // The no-arg constructor never sets maxValue (stays -1), so nextInt(-1) throws.
+        RandomTimeSlot slot = new RandomTimeSlot();
+        assertThrows(IllegalArgumentException.class, slot::getRandomValueSeededByExternalId);
+    }
+
+    @Test
+    void testGetRandomValueSeededByExternalId_nullExternalIdThrows() {
+        // A null externalId skips RNG creation, so the method dereferences a null SecureRandom.
+        RandomTimeSlot slot = new RandomTimeSlot(null, 100);
+        assertThrows(NullPointerException.class, slot::getRandomValueSeededByExternalId);
+    }
+}

--- a/symmetric-util/src/test/java/org/jumpmind/util/StatisticsTest.java
+++ b/symmetric-util/src/test/java/org/jumpmind/util/StatisticsTest.java
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class StatisticsTest {
-
     private Statistics stats;
 
     @BeforeEach

--- a/symmetric-util/src/test/java/org/jumpmind/util/StatisticsTest.java
+++ b/symmetric-util/src/test/java/org/jumpmind/util/StatisticsTest.java
@@ -1,0 +1,133 @@
+/**
+ * Licensed to JumpMind Inc under one or more contributor
+ * license agreements.  See the NOTICE file distributed
+ * with this work for additional information regarding
+ * copyright ownership.  JumpMind Inc licenses this file
+ * to you under the GNU General Public License, version 3.0 (GPLv3)
+ * (the "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3.0 (GPLv3) along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jumpmind.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class StatisticsTest {
+
+    private Statistics stats;
+
+    @BeforeEach
+    void setUp() {
+        stats = new Statistics();
+    }
+
+    @Test
+    void testGet_absentCategoryReturnsZero() {
+        assertEquals(0, stats.get("missing"));
+    }
+
+    @Test
+    void testIncrement_byOneAccumulates() {
+        stats.increment("rows");
+        stats.increment("rows");
+        stats.increment("rows");
+        assertEquals(3, stats.get("rows"));
+    }
+
+    @Test
+    void testIncrement_byAmountAccumulates() {
+        stats.increment("rows", 5);
+        stats.increment("rows", 3);
+        assertEquals(8, stats.get("rows"));
+    }
+
+    @Test
+    void testSet_overwritesValue() {
+        stats.set("rows", 100);
+        assertEquals(100, stats.get("rows"));
+        stats.set("rows", 7);
+        assertEquals(7, stats.get("rows"));
+    }
+
+    @Test
+    void testContains_reflectsPresence() {
+        assertFalse(stats.contains("rows"));
+        stats.increment("rows");
+        assertTrue(stats.contains("rows"));
+    }
+
+    @Test
+    void testGetTableStats_emptyInitially() {
+        assertTrue(stats.getTableStats().isEmpty());
+    }
+
+    @Test
+    void testIncrementTableStats_accumulatesPerTablePerDmlType() {
+        stats.incrementTableStats("sym_data", "I", 5);
+        stats.incrementTableStats("sym_data", "I", 3);
+        stats.incrementTableStats("sym_data", "U", 2);
+        Map<String, Long> dataStats = stats.getTableStats().get("sym_data");
+        assertEquals(2, dataStats.size());
+        assertEquals(8L, dataStats.get("I").longValue());
+        assertEquals(2L, dataStats.get("U").longValue());
+    }
+
+    @Test
+    void testIncrementTableStats_separatesDistinctTables() {
+        stats.incrementTableStats("table_a", "I", 1);
+        stats.incrementTableStats("table_b", "I", 2);
+        assertEquals(2, stats.getTableStats().size());
+        assertEquals(1L, stats.getTableStats().get("table_a").get("I").longValue());
+        assertEquals(2L, stats.getTableStats().get("table_b").get("I").longValue());
+    }
+
+    @Test
+    void testStopTimer_returnsNonNegativeElapsedAndRecordsStat() {
+        stats.startTimer("load");
+        long elapsed = stats.stopTimer("load");
+        // Wall-clock dependent, so assert the invariant rather than an exact duration.
+        assertTrue(elapsed >= 0);
+        // stopTimer increments the stat of the same name by the elapsed time.
+        assertEquals(elapsed, stats.get("load"));
+        assertTrue(stats.contains("load"));
+    }
+
+    @Test
+    void testStopTimer_withoutStartReturnsZeroAndRecordsNothing() {
+        long elapsed = stats.stopTimer("load");
+        assertEquals(0, elapsed);
+        assertFalse(stats.contains("load"));
+        assertEquals(0, stats.get("load"));
+    }
+
+    @Test
+    void testStopTimer_consumesTimer() {
+        stats.startTimer("load");
+        stats.stopTimer("load");
+        // Timer was removed, so a second stop has nothing to measure.
+        assertEquals(0, stats.stopTimer("load"));
+    }
+
+    @Test
+    void testToString_reflectsStats() {
+        stats.set("loaded", 5);
+        assertEquals("{loaded=5}", stats.toString());
+    }
+}

--- a/symmetric-util/src/test/java/org/jumpmind/util/VersionUtilTest.java
+++ b/symmetric-util/src/test/java/org/jumpmind/util/VersionUtilTest.java
@@ -20,6 +20,118 @@
  */
 package org.jumpmind.util;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
 class VersionUtilTest {
 
+    @Test
+    void testParseVersion_fullMajorMinorPatch() {
+        assertArrayEquals(new int[] { 3, 18, 5 }, VersionUtil.parseVersion("3.18.5"));
+    }
+
+    @Test
+    void testParseVersion_stripsNonNumericCharacters() {
+        assertArrayEquals(new int[] { 3, 18, 5 }, VersionUtil.parseVersion("3.18.5-SNAPSHOT"));
+        assertArrayEquals(new int[] { 3, 18, 5 }, VersionUtil.parseVersion("v3.18.5"));
+    }
+
+    @Test
+    void testParseVersion_defaultsMissingComponentsToZero() {
+        assertArrayEquals(new int[] { 3, 18, 0 }, VersionUtil.parseVersion("3.18"));
+        assertArrayEquals(new int[] { 3, 0, 0 }, VersionUtil.parseVersion("3"));
+    }
+
+    @Test
+    void testParseVersion_zerosForEmptyOrNonNumeric() {
+        assertArrayEquals(new int[] { 0, 0, 0 }, VersionUtil.parseVersion(""));
+        assertArrayEquals(new int[] { 0, 0, 0 }, VersionUtil.parseVersion("abc"));
+    }
+
+    @Test
+    void testParseVersion_ignoresComponentsBeyondPatch() {
+        // Only major/minor/patch are read; a fourth segment is dropped.
+        assertArrayEquals(new int[] { 3, 18, 5 }, VersionUtil.parseVersion("3.18.5.2"));
+    }
+
+    @Test
+    void testIsOlderThanVersion_olderByMajorMinorOrPatch() {
+        assertTrue(VersionUtil.isOlderThanVersion("2.0.0", "3.0.0"));
+        assertTrue(VersionUtil.isOlderThanVersion("3.17.0", "3.18.0"));
+        assertTrue(VersionUtil.isOlderThanVersion("3.18.4", "3.18.5"));
+    }
+
+    @Test
+    void testIsOlderThanVersion_equalOrNewerIsFalse() {
+        assertFalse(VersionUtil.isOlderThanVersion("3.18.0", "3.18.0"));
+        assertFalse(VersionUtil.isOlderThanVersion("3.18.0", "3.17.0"));
+        assertFalse(VersionUtil.isOlderThanVersion("3.18.5", "3.18.4"));
+    }
+
+    @Test
+    void testIsOlderThanVersion_blankDevelopmentOrSnapshotTargetIsOlder() {
+        assertTrue(VersionUtil.isOlderThanVersion("3.18.0", ""));
+        assertTrue(VersionUtil.isOlderThanVersion("3.18.0", "development"));
+        assertTrue(VersionUtil.isOlderThanVersion("3.18.0", "3.19.0-SNAPSHOT"));
+    }
+
+    @Test
+    void testIsOlderThanVersion_noVersionCheckAgainstRealTargetIsNotOlder() {
+        assertFalse(VersionUtil.isOlderThanVersion("", "3.18.0"));
+        assertFalse(VersionUtil.isOlderThanVersion("development", "3.18.0"));
+    }
+
+    @Test
+    void testIsOlderThanVersion_noVersionTargetTakesPrecedence() {
+        // Target is evaluated first, so a blank target wins even when check is also a no-version.
+        assertTrue(VersionUtil.isOlderThanVersion("development", ""));
+    }
+
+    @Test
+    void testIsOlderThanVersion_arrayComparesMajorThenMinorThenPatch() {
+        assertTrue(VersionUtil.isOlderThanVersion(new int[] { 3, 17, 0 }, new int[] { 3, 18, 0 }));
+        assertTrue(VersionUtil.isOlderThanVersion(new int[] { 3, 18, 4 }, new int[] { 3, 18, 5 }));
+        assertFalse(VersionUtil.isOlderThanVersion(new int[] { 3, 18, 5 }, new int[] { 3, 18, 5 }));
+        assertFalse(VersionUtil.isOlderThanVersion(new int[] { 4, 0, 0 }, new int[] { 3, 18, 0 }));
+    }
+
+    @Test
+    void testIsOlderThanVersion_arrayNullArgumentIsFalse() {
+        assertFalse(VersionUtil.isOlderThanVersion(null, new int[] { 3, 18, 0 }));
+        assertFalse(VersionUtil.isOlderThanVersion(new int[] { 3, 18, 0 }, null));
+    }
+
+    @Test
+    void testIsOlderMinorVersion_olderByMajorOrMinor() {
+        assertTrue(VersionUtil.isOlderMinorVersion("3.17.9", "3.18.0"));
+        assertTrue(VersionUtil.isOlderMinorVersion("2.99.0", "3.0.0"));
+    }
+
+    @Test
+    void testIsOlderMinorVersion_patchDifferencesIgnored() {
+        // Same major/minor is not "older" regardless of patch, in either direction.
+        assertFalse(VersionUtil.isOlderMinorVersion("3.18.0", "3.18.5"));
+        assertFalse(VersionUtil.isOlderMinorVersion("3.18.9", "3.18.0"));
+    }
+
+    @Test
+    void testIsOlderMinorVersion_newerMinorIsFalse() {
+        assertFalse(VersionUtil.isOlderMinorVersion("4.0.0", "3.18.0"));
+    }
+
+    @Test
+    void testIsOlderMinorVersion_anyNoVersionIsFalse() {
+        // Unlike isOlderThanVersion, a blank target (or check) yields false here, not true.
+        assertFalse(VersionUtil.isOlderMinorVersion("3.18.0", ""));
+        assertFalse(VersionUtil.isOlderMinorVersion("", "3.18.0"));
+    }
+
+    @Test
+    void testIsOlderMinorVersion_arrayComparesMajorAndMinorOnly() {
+        assertTrue(VersionUtil.isOlderMinorVersion(new int[] { 3, 17, 9 }, new int[] { 3, 18, 0 }));
+        assertFalse(VersionUtil.isOlderMinorVersion(new int[] { 3, 18, 9 }, new int[] { 3, 18, 0 }));
+    }
 }

--- a/symmetric-util/src/test/java/org/jumpmind/util/VersionUtilTest.java
+++ b/symmetric-util/src/test/java/org/jumpmind/util/VersionUtilTest.java
@@ -27,7 +27,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 
 class VersionUtilTest {
-
     @Test
     void testParseVersion_fullMajorMinorPatch() {
         assertArrayEquals(new int[] { 3, 18, 5 }, VersionUtil.parseVersion("3.18.5"));

--- a/symmetric-util/src/test/java/org/jumpmind/util/VersionUtilTest.java
+++ b/symmetric-util/src/test/java/org/jumpmind/util/VersionUtilTest.java
@@ -1,0 +1,25 @@
+/**
+ * Licensed to JumpMind Inc under one or more contributor
+ * license agreements.  See the NOTICE file distributed
+ * with this work for additional information regarding
+ * copyright ownership.  JumpMind Inc licenses this file
+ * to you under the GNU General Public License, version 3.0 (GPLv3)
+ * (the "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3.0 (GPLv3) along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jumpmind.util;
+
+class VersionUtilTest {
+
+}


### PR DESCRIPTION
As part of the 3.18 testing focus, several pure-logic utility classes in the symmetric-util module have no unit-test coverage. These classes have deterministic, side-effect-free behavior (no database, network, file I/O, or external services), which makes them low-risk, high-value targets for backfilling coverage and exercising the SonarQube quality gate without touching production code.

This ticket covers the six classes: 

VersionUtil (org.jumpmind.util) — static version parsing/comparison; delegates to AbstractVersion. Cover parseVersion (non-numeric stripping, missing major/minor/patch defaulting to 0), isOlderThanVersion (major→minor→patch precedence, equality), isOlderMinorVersion (ignores patch), and blank/development/SNAPSHOT handling. Exercises AbstractVersion's comparison logic as a side effect.

Context (org.jumpmind.util) — Map wrapper. Cover put/get/remove/keySet/getContext, including missing-key behavior.

SortedProperties (org.jumpmind.properties) — verify keys() returns keys in sorted order. (Note: different package from the others, same module.)

RandomTimeSlot (org.jumpmind.util) — getRandomValueSeededByExternalId() is seeded by externalId, so it's deterministic: same externalId/maxValue yields the same value, and the result stays within the expected bound.

LinkedCaseInsensitiveMap (org.jumpmind.util) — case-insensitive key semantics: put/get/containsKey/remove across mixed-case keys resolve to the same entry.

Statistics (org.jumpmind.util) — counters (increment/get/set/contains, increment(category, n)), table stats (incrementTableStats/getTableStats), and timers (startTimer/stopTimer use System.currentTimeMillis(), so assert elapsed ≥ 0 rather than an exact value).

