### PR TITLE
SYM-7704: Update change-log.txt link to 3.18 release notes

### DIFF
--- a/symmetric-server/src/main/deploy/change-log.txt
+++ b/symmetric-server/src/main/deploy/change-log.txt
@@ -1,1 +1,1 @@
-See http://www.symmetricds.org/issues/changelog_page.php
+See https://downloads.jumpmind.com/symmetricds/doc/3.18/html/release-notes.html


### PR DESCRIPTION
The link pointed to the retired Mantis tracker (symmetricds.org/issues/changelog_page.php), which now redirects to a
non-public Jira instance. This points it to the public release-notes doc:
downloads.jumpmind.com/symmetricds/doc/3.18/html/release-notes.html

This page currently shows a 404 error until the 3.18 release document is published.