### PR TITLE
SYM-7790: Fixed NullPointerException in DBCompare when a transform is configured

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/io/DbCompare.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/io/DbCompare.java
@@ -583,7 +583,7 @@ public class DbCompare {
             if (!CollectionUtils.isEmpty(targetTableNames)) {
                 targetTableName = targetTableNames.get(i);
             }
-            Table targetTable = loadTargetTable(tables, targetTableName);
+            Table targetTable = loadTargetTable(tables, targetTableName, tableNameParts.get("catalog"), tableNameParts.get("schema"));
             if (targetTable == null) {
                 log.warn("No target table found for name {}", tableName);
                 continue;
@@ -633,10 +633,10 @@ public class DbCompare {
         return true;
     }
 
-    protected Table loadTargetTable(DbCompareTables tables, String targetTableName) {
+    protected Table loadTargetTable(DbCompareTables tables, String targetTableName, String configuredCatalog, String configuredSchema) {
         Table targetTable = null;
         if (config.isUseSymmetricConfig()) {
-            TransformTableNodeGroupLink transform = getTransformFor(tables.getSourceTable());
+            TransformTableNodeGroupLink transform = getTransformFor(tables.getSourceTable(), configuredCatalog, configuredSchema);
             if (transform != null) {
                 targetTable = loadTargetTableUsingTransform(transform);
                 tables.setTransform(transform);
@@ -669,7 +669,9 @@ public class DbCompare {
                 }
             }
         }
-        // could put a check here before copying table
+        if (targetTable == null) {
+            return null;
+        }
         long targetTableCopyTime = System.currentTimeMillis();
         Table targetTableCopy = targetTable.copy();
         targetTableCopyTime = System.currentTimeMillis() - targetTableCopyTime;
@@ -692,7 +694,7 @@ public class DbCompare {
         return null;
     }
 
-    protected TransformTableNodeGroupLink getTransformFor(Table sourceTable) {
+    protected TransformTableNodeGroupLink getTransformFor(Table sourceTable, String configuredCatalog, String configuredSchema) {
         String sourceNodeGroupId = null;
         if (sourceEngine.getNodeService().findIdentity() != null) {
             sourceNodeGroupId = sourceEngine.getNodeService().findIdentity().getNodeGroupId();
@@ -701,9 +703,14 @@ public class DbCompare {
         if (targetEngine.getNodeService().findIdentity() != null) {
             targetNodeGroupId = targetEngine.getNodeService().findIdentity().getNodeGroupId();
         }
-        List<TransformTableNodeGroupLink> transforms = sourceEngine.getTransformService().findTransformsFor(
-                sourceNodeGroupId, targetNodeGroupId, sourceTable.getName(),
-                sourceTable.getSchema(), sourceTable.getCatalog());
+        List<TransformTableNodeGroupLink> transforms = findTransforms(sourceNodeGroupId, targetNodeGroupId,
+                sourceTable.getName(), sourceTable.getSchema(), sourceTable.getCatalog());
+        if (CollectionUtils.isEmpty(transforms)
+                && (!Strings.CI.equals(configuredCatalog, sourceTable.getCatalog())
+                        || !Strings.CI.equals(configuredSchema, sourceTable.getSchema()))) {
+            transforms = findTransforms(sourceNodeGroupId, targetNodeGroupId, sourceTable.getName(),
+                    configuredSchema, configuredCatalog);
+        }
         if (!CollectionUtils.isEmpty(transforms)) {
             TransformTableNodeGroupLink transform = transforms.get(0); // Only can operate on a single table transform for now.
             if (!StringUtils.isEmpty(transform.getFullyQualifiedTargetTableName())) {
@@ -711,6 +718,12 @@ public class DbCompare {
             }
         }
         return null;
+    }
+
+    private List<TransformTableNodeGroupLink> findTransforms(String sourceNodeGroupId, String targetNodeGroupId,
+            String tableName, String schema, String catalog) {
+        return sourceEngine.getTransformService().findTransformsFor(sourceNodeGroupId, targetNodeGroupId,
+                tableName, schema, catalog);
     }
 
     protected Table loadTargetTableUsingTransform(TransformTableNodeGroupLink transform) {


### PR DESCRIPTION
Because DBCompare isn't frequently used and will soon be end of life (see SYM-7780), I didn't implement the full proposed fix from the ticket description. Instead, I just added a `null` check to prevent the NPE and changed `getTransformFor()` to fall back to using the configured catalog/schema rather than the catalog/schema from the database metadata. I sent a patch to the customer experiencing the NPE and they confirmed that this change resolves it and DBCompare is able to find their target tables.