### PR TITLE
SYM-7791: Fixed classloading deadlock during concurrent multi-engine startup with self-registering JDBC drivers

### DIFF
--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/util/DataSourceFactory.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/util/DataSourceFactory.java
@@ -42,12 +42,12 @@ public class DataSourceFactory {
     }
 
     public static void prepareDriver(String clazzName) throws Exception {
-        Class<?> clazz = Class.forName(clazzName);
-        if (!Driver.class.isAssignableFrom(clazz)) {
-            throw new NotJdbcDriverException(clazzName + " is not a JDBC driver");
-        }
-        Driver driver = (Driver) clazz.getDeclaredConstructor().newInstance();
         synchronized (DriverManager.class) {
+            Class<?> clazz = Class.forName(clazzName);
+            if (!Driver.class.isAssignableFrom(clazz)) {
+                throw new NotJdbcDriverException(clazzName + " is not a JDBC driver");
+            }
+            Driver driver = (Driver) clazz.getDeclaredConstructor().newInstance();
             Enumeration<Driver> drivers = DriverManager.getDrivers();
             while (drivers.hasMoreElements()) {
                 Driver driver2 = drivers.nextElement();


### PR DESCRIPTION
I sent a patch containing this change to the customer experiencing this deadlock and they confirmed that it resolved the issue. See [SYM-7791](https://jumpmind.atlassian.net/browse/SYM-7791) for a complete description of the bug.

[SYM-7791]: https://jumpmind.atlassian.net/browse/SYM-7791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ