### PR TITLE
SYM-7787: Resolve sonar warnings for KafkaWriter and add unit tests

### DIFF
--- a/symmetric-io/src/main/java/org/jumpmind/symmetric/io/data/writer/KafkaWriter.java
+++ b/symmetric-io/src/main/java/org/jumpmind/symmetric/io/data/writer/KafkaWriter.java
@@ -768,13 +768,9 @@ public class KafkaWriter extends DynamicDefaultDatabaseWriter {
                                         } catch (Exception e) {
                                             log.debug(rowData[i] + " was not a recognized date format so treating it as a long.");
                                         }
-                                        if (allowedProperties.contains(colName)) {
-                                            BeanUtils.setProperty(pojo, colName, date != null ? date.getTime() : rowData[i]);
-                                        }
+                                        BeanUtils.setProperty(pojo, colName, date != null ? date.getTime() : rowData[i]);
                                     } else {
-                                        if (allowedProperties.contains(colName)) {
-                                            BeanUtils.setProperty(pojo, colName, rowData[i]);
-                                        }
+                                        BeanUtils.setProperty(pojo, colName, rowData[i]);
                                     }
                                 }
                             }

--- a/symmetric-io/src/main/java/org/jumpmind/symmetric/io/data/writer/KafkaWriter.java
+++ b/symmetric-io/src/main/java/org/jumpmind/symmetric/io/data/writer/KafkaWriter.java
@@ -30,8 +30,10 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
@@ -275,6 +277,12 @@ public class KafkaWriter extends DynamicDefaultDatabaseWriter {
                     if (curClass != null) {
                         Constructor<?> defaultConstructor = curClass.getConstructor();
                         Object pojo = defaultConstructor.newInstance();
+                        Set<String> allowedProperties = new HashSet<>();
+                        for (PropertyDescriptor pd : PropertyUtils.getPropertyDescriptors(pojo)) {
+                            if (pd.getWriteMethod() != null) {
+                                allowedProperties.add(pd.getName());
+                            }
+                        }
                         for (int i = 0; i < table.getColumnNames().length; i++) {
                             String colName = getColumnName(table.getName(), table.getColumnNames()[i], pojo);
                             if (colName != null) {
@@ -288,9 +296,13 @@ public class KafkaWriter extends DynamicDefaultDatabaseWriter {
                                     } catch (Exception e) {
                                         log.debug(rowData[i] + " was not a recognized date format so treating it as a long.");
                                     }
-                                    BeanUtils.setProperty(pojo, colName, date != null ? date.getTime() : rowData[i]);
+                                    if (allowedProperties.contains(colName)) {
+                                        BeanUtils.setProperty(pojo, colName, date != null ? date.getTime() : rowData[i]);
+                                    }
                                 } else {
-                                    BeanUtils.setProperty(pojo, colName, rowData[i]);
+                                    if (allowedProperties.contains(colName)) {
+                                        BeanUtils.setProperty(pojo, colName, rowData[i]);
+                                    }
                                 }
                             }
                         }
@@ -736,6 +748,12 @@ public class KafkaWriter extends DynamicDefaultDatabaseWriter {
                     if (curClass != null) {
                         Constructor<?> defaultConstructor = curClass.getConstructor();
                         Object pojo = defaultConstructor.newInstance();
+                        Set<String> allowedProperties = new HashSet<>();
+                        for (PropertyDescriptor pd : PropertyUtils.getPropertyDescriptors(pojo)) {
+                            if (pd.getWriteMethod() != null) {
+                                allowedProperties.add(pd.getName());
+                            }
+                        }
                         if (oldData != null) {
                             for (int i = 0; i < table.getColumnNames().length; i++) {
                                 String colName = getColumnName(table.getName(), table.getColumnNames()[i], pojo);
@@ -750,9 +768,13 @@ public class KafkaWriter extends DynamicDefaultDatabaseWriter {
                                         } catch (Exception e) {
                                             log.debug(rowData[i] + " was not a recognized date format so treating it as a long.");
                                         }
-                                        BeanUtils.setProperty(pojo, colName, date != null ? date.getTime() : rowData[i]);
+                                        if (allowedProperties.contains(colName)) {
+                                            BeanUtils.setProperty(pojo, colName, date != null ? date.getTime() : rowData[i]);
+                                        }
                                     } else {
-                                        BeanUtils.setProperty(pojo, colName, rowData[i]);
+                                        if (allowedProperties.contains(colName)) {
+                                            BeanUtils.setProperty(pojo, colName, rowData[i]);
+                                        }
                                     }
                                 }
                             }
@@ -770,9 +792,13 @@ public class KafkaWriter extends DynamicDefaultDatabaseWriter {
                                         } catch (Exception e) {
                                             log.debug(rowData[i] + " was not a recognized date format so treating it as a long.");
                                         }
-                                        BeanUtils.setProperty(pojo, colName, date != null ? date.getTime() : rowData[i]);
+                                        if (allowedProperties.contains(colName)) {
+                                            BeanUtils.setProperty(pojo, colName, date != null ? date.getTime() : rowData[i]);
+                                        }
                                     } else {
-                                        BeanUtils.setProperty(pojo, colName, rowData[i]);
+                                        if (allowedProperties.contains(colName)) {
+                                            BeanUtils.setProperty(pojo, colName, rowData[i]);
+                                        }
                                     }
                                 }
                             }

--- a/symmetric-io/src/main/java/org/jumpmind/symmetric/io/data/writer/KafkaWriter.java
+++ b/symmetric-io/src/main/java/org/jumpmind/symmetric/io/data/writer/KafkaWriter.java
@@ -277,12 +277,7 @@ public class KafkaWriter extends DynamicDefaultDatabaseWriter {
                     if (curClass != null) {
                         Constructor<?> defaultConstructor = curClass.getConstructor();
                         Object pojo = defaultConstructor.newInstance();
-                        Set<String> allowedProperties = new HashSet<>();
-                        for (PropertyDescriptor pd : PropertyUtils.getPropertyDescriptors(pojo)) {
-                            if (pd.getWriteMethod() != null) {
-                                allowedProperties.add(pd.getName());
-                            }
-                        }
+                        Set<String> allowedProperties = getAllowedProperties(pojo);
                         for (int i = 0; i < table.getColumnNames().length; i++) {
                             String colName = getColumnName(table.getName(), table.getColumnNames()[i], pojo);
                             if (colName != null) {
@@ -582,6 +577,16 @@ public class KafkaWriter extends DynamicDefaultDatabaseWriter {
         return null;
     }
 
+    public Set<String> getAllowedProperties(Object pojo) {
+        Set<String> allowedProperties = new HashSet<>();
+        for (PropertyDescriptor pd : PropertyUtils.getPropertyDescriptors(pojo)) {
+            if (pd.getWriteMethod() != null) {
+                allowedProperties.add(pd.getName());
+            }
+        }
+        return allowedProperties;
+    }
+
     public void sendKafkaMessage(ProducerRecord<String, Object> record) {
         log.debug("Sending message (topic={}) (key={}) {}", record.topic(), record.key(), record.value());
         kafkaProducer.send(record);
@@ -748,12 +753,7 @@ public class KafkaWriter extends DynamicDefaultDatabaseWriter {
                     if (curClass != null) {
                         Constructor<?> defaultConstructor = curClass.getConstructor();
                         Object pojo = defaultConstructor.newInstance();
-                        Set<String> allowedProperties = new HashSet<>();
-                        for (PropertyDescriptor pd : PropertyUtils.getPropertyDescriptors(pojo)) {
-                            if (pd.getWriteMethod() != null) {
-                                allowedProperties.add(pd.getName());
-                            }
-                        }
+                        Set<String> allowedProperties = getAllowedProperties(pojo);
                         if (oldData != null) {
                             for (int i = 0; i < table.getColumnNames().length; i++) {
                                 String colName = getColumnName(table.getName(), table.getColumnNames()[i], pojo);

--- a/symmetric-io/src/main/java/org/jumpmind/symmetric/io/data/writer/KafkaWriter.java
+++ b/symmetric-io/src/main/java/org/jumpmind/symmetric/io/data/writer/KafkaWriter.java
@@ -768,9 +768,13 @@ public class KafkaWriter extends DynamicDefaultDatabaseWriter {
                                         } catch (Exception e) {
                                             log.debug(rowData[i] + " was not a recognized date format so treating it as a long.");
                                         }
-                                        BeanUtils.setProperty(pojo, colName, date != null ? date.getTime() : rowData[i]);
+                                        if (allowedProperties.contains(colName)) {
+                                            BeanUtils.setProperty(pojo, colName, date != null ? date.getTime() : rowData[i]);
+                                        }
                                     } else {
-                                        BeanUtils.setProperty(pojo, colName, rowData[i]);
+                                        if (allowedProperties.contains(colName)) {
+                                            BeanUtils.setProperty(pojo, colName, rowData[i]);
+                                        }
                                     }
                                 }
                             }

--- a/symmetric-io/src/test/java/org/jumpmind/symmetric/io/data/writer/KafkaWriterTest.java
+++ b/symmetric-io/src/test/java/org/jumpmind/symmetric/io/data/writer/KafkaWriterTest.java
@@ -36,6 +36,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.Future;
 
 import org.apache.kafka.clients.producer.KafkaProducer;
@@ -168,6 +169,34 @@ public class KafkaWriterTest {
     }
 
     @Test
+    public void testExecute_jsonFormat() {
+        KafkaWriter writer = createKafkaWriter(KafkaWriter.KAFKA_FORMAT_JSON,
+                KafkaWriter.KAFKA_TOPIC_BY_TABLE, KafkaWriter.KAFKA_MESSAGE_BY_ROW);
+        writer.kafkaProducer = mockKafkaProducer;
+        // Set up the context and table without calling open()
+        writer.context = testContext;
+        writer.batch = testBatch;
+        writer.sourceTable = testBusinessTable;
+        writer.targetTable = testBusinessTable;
+        // Create test data with old data (required for writeKafka)
+        String[] rowData = { "1", "test_name", "test_value" };
+        CsvData csvData = new CsvData(DataEventType.INSERT);
+        csvData.putParsedData(CsvData.ROW_DATA, rowData);
+        int result = writer.execute(csvData, rowData);
+        assertEquals(1, result);
+        assertFalse(writer.kafkaDataMap.isEmpty());
+        List<ProducerRecord<String, Object>> records = writer.kafkaDataMap.get(testBusinessTableName);
+        assertNotNull(records);
+        assertEquals(1, records.size());
+        String recordValue = (String) records.get(0).value();
+        assertTrue(recordValue.contains("\"test_table\""));
+        assertTrue(recordValue.contains("\"eventType\": \"INSERT\""));
+        assertTrue(recordValue.contains("\"id\""));
+        assertTrue(recordValue.contains("\"name\""));
+        assertTrue(recordValue.contains("\"test_name\""));
+    }
+
+    @Test
     public void testWriteKafkaCsvFormat() {
         KafkaWriter writer = createKafkaWriter(KafkaWriter.KAFKA_FORMAT_CSV,
                 KafkaWriter.KAFKA_TOPIC_BY_TABLE, KafkaWriter.KAFKA_MESSAGE_BY_ROW);
@@ -193,6 +222,29 @@ public class KafkaWriterTest {
     }
 
     @Test
+    public void testExecute_csvFormat() {
+        KafkaWriter writer = createKafkaWriter(KafkaWriter.KAFKA_FORMAT_CSV,
+                KafkaWriter.KAFKA_TOPIC_BY_TABLE, KafkaWriter.KAFKA_MESSAGE_BY_ROW);
+        writer.kafkaProducer = mockKafkaProducer;
+        writer.context = testContext;
+        writer.batch = testBatch;
+        writer.sourceTable = testBusinessTable;
+        writer.targetTable = testBusinessTable;
+        String[] rowData = { "1", "test_name", "test_value" };
+        CsvData csvData = new CsvData(DataEventType.UPDATE);
+        csvData.putParsedData(CsvData.ROW_DATA, rowData);
+        int result = writer.execute(csvData, rowData);
+        assertEquals(1, result);
+        List<ProducerRecord<String, Object>> records = writer.kafkaDataMap.get(testBusinessTableName);
+        assertNotNull(records);
+        String recordValue = (String) records.get(0).value();
+        assertTrue(recordValue.contains("\"TABLE\""));
+        assertTrue(recordValue.contains("\"test_table\""));
+        assertTrue(recordValue.contains("\"EVENT\""));
+        assertTrue(recordValue.contains("UPDATE"));
+    }
+
+    @Test
     public void testWriteKafkaXmlFormat() {
         KafkaWriter writer = createKafkaWriter(KafkaWriter.KAFKA_FORMAT_XML,
                 KafkaWriter.KAFKA_TOPIC_BY_TABLE, KafkaWriter.KAFKA_MESSAGE_BY_ROW);
@@ -207,6 +259,29 @@ public class KafkaWriterTest {
         csvData.putParsedData(CsvData.ROW_DATA, rowData);
         csvData.putParsedData(CsvData.OLD_DATA, oldData);
         int result = writer.writeKafka(csvData, testBusinessTable);
+        assertEquals(1, result);
+        List<ProducerRecord<String, Object>> records = writer.kafkaDataMap.get(testBusinessTableName);
+        assertNotNull(records);
+        String recordValue = (String) records.get(0).value();
+        assertTrue(recordValue.contains("<row entity=\"test_table\""));
+        assertTrue(recordValue.contains("dml=\"INSERT\""));
+        assertTrue(recordValue.contains("<data key=\"id\">1</data>"));
+        assertTrue(recordValue.contains("<data key=\"name\">test_name</data>"));
+    }
+
+    @Test
+    public void testExecute_xmlFormat() {
+        KafkaWriter writer = createKafkaWriter(KafkaWriter.KAFKA_FORMAT_XML,
+                KafkaWriter.KAFKA_TOPIC_BY_TABLE, KafkaWriter.KAFKA_MESSAGE_BY_ROW);
+        writer.kafkaProducer = mockKafkaProducer;
+        writer.context = testContext;
+        writer.batch = testBatch;
+        writer.sourceTable = testBusinessTable;
+        writer.targetTable = testBusinessTable;
+        String[] rowData = { "1", "test_name", "test_value" };
+        CsvData csvData = new CsvData(DataEventType.INSERT);
+        csvData.putParsedData(CsvData.ROW_DATA, rowData);
+        int result = writer.execute(csvData, rowData);
         assertEquals(1, result);
         List<ProducerRecord<String, Object>> records = writer.kafkaDataMap.get(testBusinessTableName);
         assertNotNull(records);
@@ -499,12 +574,34 @@ public class KafkaWriterTest {
     }
 
     @Test
-    public void testGetColumnNameReturnsNullForUnmatchedColumn() {
+    public void testGetColumnName_returnsNullForUnmatchedColumn() {
         KafkaWriter writer = createKafkaWriter(KafkaWriter.KAFKA_FORMAT_AVRO,
                 KafkaWriter.KAFKA_TOPIC_BY_TABLE, KafkaWriter.KAFKA_MESSAGE_BY_ROW);
         PojoTestBean bean = new PojoTestBean();
         String columnName = writer.getColumnName("test_table", "not_a_real_column", bean);
         assertEquals(null, columnName);
+    }
+
+    @Test
+    public void testGetAllowedProperties_includesWritableProperties() {
+        KafkaWriter writer = createKafkaWriter(KafkaWriter.KAFKA_FORMAT_AVRO,
+                KafkaWriter.KAFKA_TOPIC_BY_TABLE, KafkaWriter.KAFKA_MESSAGE_BY_ROW);
+        PojoTestBean bean = new PojoTestBean();
+        Set<String> allowed = writer.getAllowedProperties(bean);
+        assertTrue(allowed.contains("id"));
+        assertTrue(allowed.contains("name"));
+        assertTrue(allowed.contains("amount"));
+        assertTrue(allowed.contains("count"));
+        assertEquals(4, allowed.size());
+    }
+
+    @Test
+    public void testGetAllowedProperties_excludesReadOnlyProperties() {
+        KafkaWriter writer = createKafkaWriter(KafkaWriter.KAFKA_FORMAT_AVRO,
+                KafkaWriter.KAFKA_TOPIC_BY_TABLE, KafkaWriter.KAFKA_MESSAGE_BY_ROW);
+        PojoTestBean bean = new PojoTestBean();
+        Set<String> allowed = writer.getAllowedProperties(bean);
+        assertFalse(allowed.contains("class"));
     }
 
     @Test
@@ -562,6 +659,29 @@ public class KafkaWriterTest {
     }
 
     @Test
+    public void testExecute_avroFormatWithoutConfluent() throws Exception {
+        KafkaWriter writer = createKafkaWriter(KafkaWriter.KAFKA_FORMAT_AVRO,
+                KafkaWriter.KAFKA_TOPIC_BY_TABLE, KafkaWriter.KAFKA_MESSAGE_BY_ROW);
+        writer.kafkaProducer = mockKafkaProducer;
+        writer.context = testContext;
+        writer.batch = testBatch;
+        writer.sourceTable = testBusinessTable;
+        writer.targetTable = testBusinessTable;
+        String[] rowData = { "1", "test_name", "test_value" };
+        CsvData csvData = new CsvData(DataEventType.INSERT);
+        csvData.putParsedData(CsvData.ROW_DATA, rowData);
+        int result = writer.execute(csvData, rowData);
+        assertEquals(1, result);
+        List<ProducerRecord<String, Object>> records = writer.kafkaDataMap.get("test_table");
+        assertNotNull(records);
+        assertEquals(1, records.size());
+        // The value should be a byte array for AVRO without Confluent
+        Object recordValue = records.get(0).value();
+        assertTrue(recordValue instanceof byte[]);
+        assertTrue(((byte[]) recordValue).length > 0);
+    }
+
+    @Test
     public void testWriteKafka_avroFormatWithConfluent() {
         KafkaWriter writer = createConfluentKafkaWriter(KafkaWriter.KAFKA_FORMAT_AVRO,
                 KafkaWriter.KAFKA_TOPIC_BY_TABLE, KafkaWriter.KAFKA_MESSAGE_BY_ROW);
@@ -571,7 +691,6 @@ public class KafkaWriterTest {
         Table pojoTable = createPojoTable("kafka_pojo");
         writer.sourceTable = pojoTable;
         writer.targetTable = pojoTable;
-        // Seed the class cache so getClassByTableName resolves our nested bean without scanning the classpath
         writer.tableClassCache.put(writer.getTableName(pojoTable.getName()), PojoTestBean.class);
         String[] rowData = { "1", "test_name", "500", "5" };
         String[] oldData = { "1", "old_name", "0", "0" };
@@ -580,7 +699,6 @@ public class KafkaWriterTest {
         csvData.putParsedData(CsvData.OLD_DATA, oldData);
         int result = writer.writeKafka(csvData, pojoTable);
         assertEquals(1, result);
-        // The Confluent branch sends the populated POJO immediately via the producer
         @SuppressWarnings("unchecked")
         ArgumentCaptor<ProducerRecord<String, Object>> captor = ArgumentCaptor.forClass(ProducerRecord.class);
         verify(mockKafkaProducer).send(captor.capture());
@@ -594,7 +712,7 @@ public class KafkaWriterTest {
     }
 
     @Test
-    public void testWriteKafkaAvroFormatWithConfluentDeletePrimaryKeyOnly() {
+    public void testWriteKafka_avroFormatWithConfluentDeletePrimaryKeyOnly() {
         KafkaWriter writer = createConfluentKafkaWriter(KafkaWriter.KAFKA_FORMAT_AVRO,
                 KafkaWriter.KAFKA_TOPIC_BY_TABLE, KafkaWriter.KAFKA_MESSAGE_BY_ROW);
         writer.kafkaProducer = mockKafkaProducer;
@@ -604,8 +722,6 @@ public class KafkaWriterTest {
         writer.sourceTable = pojoTable;
         writer.targetTable = pojoTable;
         writer.tableClassCache.put(writer.getTableName(pojoTable.getName()), PojoTestBean.class);
-        // A DELETE that carries only primary-key data (no old data) drives the primary-key
-        // population loop. PK column order is id, amount, count.
         String[] pkData = { "1", "500", "5" };
         CsvData csvData = new CsvData(DataEventType.DELETE);
         csvData.putParsedData(CsvData.PK_DATA, pkData);
@@ -617,10 +733,10 @@ public class KafkaWriterTest {
         Object value = captor.getValue().value();
         assertTrue(value instanceof PojoTestBean);
         PojoTestBean pojo = (PojoTestBean) value;
-        assertEquals("1", pojo.getId()); // String -> CharSequence branch
-        assertEquals(Long.valueOf(500L), pojo.getAmount()); // non-date String -> Long branch
-        assertEquals(Integer.valueOf(5), pojo.getCount()); // Integer -> generic else branch
-        assertEquals(null, pojo.getName()); // non-PK column not populated
+        assertEquals("1", pojo.getId());
+        assertEquals(Long.valueOf(500L), pojo.getAmount());
+        assertEquals(Integer.valueOf(5), pojo.getCount());
+        assertEquals(null, pojo.getName());
     }
 
     @Test

--- a/symmetric-io/src/test/java/org/jumpmind/symmetric/io/data/writer/KafkaWriterTest.java
+++ b/symmetric-io/src/test/java/org/jumpmind/symmetric/io/data/writer/KafkaWriterTest.java
@@ -504,7 +504,7 @@ public class KafkaWriterTest {
                 KafkaWriter.KAFKA_TOPIC_BY_TABLE, KafkaWriter.KAFKA_MESSAGE_BY_ROW);
         PojoTestBean bean = new PojoTestBean();
         String columnName = writer.getColumnName("test_table", "not_a_real_column", bean);
-        assertNull(columnName);
+        assertEquals(null, columnName);
     }
 
     @Test
@@ -620,7 +620,7 @@ public class KafkaWriterTest {
         assertEquals("1", pojo.getId()); // String -> CharSequence branch
         assertEquals(Long.valueOf(500L), pojo.getAmount()); // non-date String -> Long branch
         assertEquals(Integer.valueOf(5), pojo.getCount()); // Integer -> generic else branch
-        assertNull(pojo.getName()); // non-PK column not populated
+        assertEquals(null, pojo.getName()); // non-PK column not populated
     }
 
     @Test

--- a/symmetric-io/src/test/java/org/jumpmind/symmetric/io/data/writer/KafkaWriterTest.java
+++ b/symmetric-io/src/test/java/org/jumpmind/symmetric/io/data/writer/KafkaWriterTest.java
@@ -499,6 +499,15 @@ public class KafkaWriterTest {
     }
 
     @Test
+    public void testGetColumnNameReturnsNullForUnmatchedColumn() {
+        KafkaWriter writer = createKafkaWriter(KafkaWriter.KAFKA_FORMAT_AVRO,
+                KafkaWriter.KAFKA_TOPIC_BY_TABLE, KafkaWriter.KAFKA_MESSAGE_BY_ROW);
+        PojoTestBean bean = new PojoTestBean();
+        String columnName = writer.getColumnName("test_table", "not_a_real_column", bean);
+        assertNull(columnName);
+    }
+
+    @Test
     public void testDatumToByteArray() throws Exception {
         org.apache.avro.Schema.Parser parser = new org.apache.avro.Schema.Parser();
         org.apache.avro.Schema schema = parser.parse(KafkaWriter.AVRO_CDC_SCHEMA);
@@ -553,6 +562,96 @@ public class KafkaWriterTest {
     }
 
     @Test
+    public void testWriteKafka_avroFormatWithConfluent() throws Exception {
+        KafkaWriter writer = createConfluentKafkaWriter(KafkaWriter.KAFKA_FORMAT_AVRO,
+                KafkaWriter.KAFKA_TOPIC_BY_TABLE, KafkaWriter.KAFKA_MESSAGE_BY_ROW);
+        writer.kafkaProducer = mockKafkaProducer;
+        writer.context = testContext;
+        writer.batch = testBatch;
+        Table pojoTable = createPojoTable("kafka_pojo");
+        writer.sourceTable = pojoTable;
+        writer.targetTable = pojoTable;
+        // Seed the class cache so getClassByTableName resolves our nested bean without scanning the classpath
+        writer.tableClassCache.put(writer.getTableName(pojoTable.getName()), PojoTestBean.class);
+        String[] rowData = { "1", "test_name", "500", "5" };
+        String[] oldData = { "1", "old_name", "0", "0" };
+        CsvData csvData = new CsvData(DataEventType.INSERT);
+        csvData.putParsedData(CsvData.ROW_DATA, rowData);
+        csvData.putParsedData(CsvData.OLD_DATA, oldData);
+        int result = writer.writeKafka(csvData, pojoTable);
+        assertEquals(1, result);
+        // The Confluent branch sends the populated POJO immediately via the producer
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<ProducerRecord<String, Object>> captor = ArgumentCaptor.forClass(ProducerRecord.class);
+        verify(mockKafkaProducer).send(captor.capture());
+        Object value = captor.getValue().value();
+        assertTrue(value instanceof PojoTestBean);
+        PojoTestBean pojo = (PojoTestBean) value;
+        assertEquals("1", pojo.getId());
+        assertEquals("test_name", pojo.getName());
+        assertEquals(Long.valueOf(500L), pojo.getAmount());
+        assertEquals(Integer.valueOf(5), pojo.getCount());
+    }
+
+    @Test
+    public void testWriteKafkaAvroFormatWithConfluentDeletePrimaryKeyOnly() throws Exception {
+        KafkaWriter writer = createConfluentKafkaWriter(KafkaWriter.KAFKA_FORMAT_AVRO,
+                KafkaWriter.KAFKA_TOPIC_BY_TABLE, KafkaWriter.KAFKA_MESSAGE_BY_ROW);
+        writer.kafkaProducer = mockKafkaProducer;
+        writer.context = testContext;
+        writer.batch = testBatch;
+        Table pojoTable = createPojoCompositePkTable("kafka_pojo");
+        writer.sourceTable = pojoTable;
+        writer.targetTable = pojoTable;
+        writer.tableClassCache.put(writer.getTableName(pojoTable.getName()), PojoTestBean.class);
+        // A DELETE that carries only primary-key data (no old data) drives the primary-key
+        // population loop. PK column order is id, amount, count.
+        String[] pkData = { "1", "500", "5" };
+        CsvData csvData = new CsvData(DataEventType.DELETE);
+        csvData.putParsedData(CsvData.PK_DATA, pkData);
+        int result = writer.writeKafka(csvData, pojoTable);
+        assertEquals(1, result);
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<ProducerRecord<String, Object>> captor = ArgumentCaptor.forClass(ProducerRecord.class);
+        verify(mockKafkaProducer).send(captor.capture());
+        Object value = captor.getValue().value();
+        assertTrue(value instanceof PojoTestBean);
+        PojoTestBean pojo = (PojoTestBean) value;
+        assertEquals("1", pojo.getId()); // String -> CharSequence branch
+        assertEquals(Long.valueOf(500L), pojo.getAmount()); // non-date String -> Long branch
+        assertEquals(Integer.valueOf(5), pojo.getCount()); // Integer -> generic else branch
+        assertNull(pojo.getName()); // non-PK column not populated
+    }
+
+    @Test
+    public void testExecute_avroFormatWithConfluent() throws Exception {
+        KafkaWriter writer = createConfluentKafkaWriter(KafkaWriter.KAFKA_FORMAT_AVRO,
+                KafkaWriter.KAFKA_TOPIC_BY_TABLE, KafkaWriter.KAFKA_MESSAGE_BY_ROW);
+        writer.kafkaProducer = mockKafkaProducer;
+        writer.context = testContext;
+        writer.batch = testBatch;
+        Table pojoTable = createPojoTable("kafka_pojo");
+        writer.sourceTable = pojoTable;
+        writer.targetTable = pojoTable;
+        writer.tableClassCache.put(writer.getTableName(pojoTable.getName()), PojoTestBean.class);
+        String[] rowData = { "1", "test_name", "500", "5" };
+        CsvData csvData = new CsvData(DataEventType.INSERT);
+        csvData.putParsedData(CsvData.ROW_DATA, rowData);
+        int result = writer.execute(csvData, rowData);
+        assertEquals(1, result);
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<ProducerRecord<String, Object>> captor = ArgumentCaptor.forClass(ProducerRecord.class);
+        verify(mockKafkaProducer).send(captor.capture());
+        Object value = captor.getValue().value();
+        assertTrue(value instanceof PojoTestBean);
+        PojoTestBean pojo = (PojoTestBean) value;
+        assertEquals("1", pojo.getId());
+        assertEquals("test_name", pojo.getName());
+        assertEquals(Long.valueOf(500L), pojo.getAmount());
+        assertEquals(Integer.valueOf(5), pojo.getCount());
+    }
+
+    @Test
     public void testKafkaConstants() {
         assertEquals("JSON", KafkaWriter.KAFKA_FORMAT_JSON);
         assertEquals("XML", KafkaWriter.KAFKA_FORMAT_XML);
@@ -574,6 +673,46 @@ public class KafkaWriterTest {
         return writer;
     }
 
+    private KafkaWriter createConfluentKafkaWriter(String outputFormat, String topicBy, String messageBy) {
+        KafkaWriter writer = new KafkaWriter(
+                mockPlatform, mockPlatform, "sym_",
+                null, new DatabaseWriterSettings(),
+                "test-producer", outputFormat,
+                topicBy, messageBy,
+                "http://localhost:8081", null, "test-node", "localhost:9092", "kafka.", props, "reload");
+        return writer;
+    }
+
+    Table createPojoTable(String tableName) {
+        Table table = new Table(tableName);
+        Column idColumn = new Column("id", true);
+        idColumn.setPrimaryKey(true);
+        Column nameColumn = new Column("name");
+        Column amountColumn = new Column("amount");
+        Column countColumn = new Column("count");
+        table.addColumn(idColumn);
+        table.addColumn(nameColumn);
+        table.addColumn(amountColumn);
+        table.addColumn(countColumn);
+        return table;
+    }
+
+    Table createPojoCompositePkTable(String tableName) {
+        Table table = new Table(tableName);
+        Column idColumn = new Column("id", true);
+        idColumn.setPrimaryKey(true);
+        Column nameColumn = new Column("name");
+        Column amountColumn = new Column("amount");
+        amountColumn.setPrimaryKey(true);
+        Column countColumn = new Column("count");
+        countColumn.setPrimaryKey(true);
+        table.addColumn(idColumn);
+        table.addColumn(nameColumn);
+        table.addColumn(amountColumn);
+        table.addColumn(countColumn);
+        return table;
+    }
+
     // Simple test bean for getColumnName test
     public static class TestBean {
         private String myField;
@@ -584,6 +723,48 @@ public class KafkaWriterTest {
 
         public void setMyField(String myField) {
             this.myField = myField;
+        }
+    }
+
+    // Bean used to exercise the Confluent/Avro branch of writeKafka where a POJO is
+    // instantiated and populated from row data. Property types cover each population branch:
+    // String (CharSequence branch), Long (date/long branch), and Integer (generic else branch).
+    public static class PojoTestBean {
+        private String id;
+        private String name;
+        private Long amount;
+        private Integer count;
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public Long getAmount() {
+            return amount;
+        }
+
+        public void setAmount(Long amount) {
+            this.amount = amount;
+        }
+
+        public Integer getCount() {
+            return count;
+        }
+
+        public void setCount(Integer count) {
+            this.count = count;
         }
     }
 }

--- a/symmetric-io/src/test/java/org/jumpmind/symmetric/io/data/writer/KafkaWriterTest.java
+++ b/symmetric-io/src/test/java/org/jumpmind/symmetric/io/data/writer/KafkaWriterTest.java
@@ -562,7 +562,7 @@ public class KafkaWriterTest {
     }
 
     @Test
-    public void testWriteKafka_avroFormatWithConfluent() throws Exception {
+    public void testWriteKafka_avroFormatWithConfluent() {
         KafkaWriter writer = createConfluentKafkaWriter(KafkaWriter.KAFKA_FORMAT_AVRO,
                 KafkaWriter.KAFKA_TOPIC_BY_TABLE, KafkaWriter.KAFKA_MESSAGE_BY_ROW);
         writer.kafkaProducer = mockKafkaProducer;
@@ -594,7 +594,7 @@ public class KafkaWriterTest {
     }
 
     @Test
-    public void testWriteKafkaAvroFormatWithConfluentDeletePrimaryKeyOnly() throws Exception {
+    public void testWriteKafkaAvroFormatWithConfluentDeletePrimaryKeyOnly() {
         KafkaWriter writer = createConfluentKafkaWriter(KafkaWriter.KAFKA_FORMAT_AVRO,
                 KafkaWriter.KAFKA_TOPIC_BY_TABLE, KafkaWriter.KAFKA_MESSAGE_BY_ROW);
         writer.kafkaProducer = mockKafkaProducer;
@@ -624,7 +624,7 @@ public class KafkaWriterTest {
     }
 
     @Test
-    public void testExecute_avroFormatWithConfluent() throws Exception {
+    public void testExecute_avroFormatWithConfluent() {
         KafkaWriter writer = createConfluentKafkaWriter(KafkaWriter.KAFKA_FORMAT_AVRO,
                 KafkaWriter.KAFKA_TOPIC_BY_TABLE, KafkaWriter.KAFKA_MESSAGE_BY_ROW);
         writer.kafkaProducer = mockKafkaProducer;
@@ -674,13 +674,12 @@ public class KafkaWriterTest {
     }
 
     private KafkaWriter createConfluentKafkaWriter(String outputFormat, String topicBy, String messageBy) {
-        KafkaWriter writer = new KafkaWriter(
+        return new KafkaWriter(
                 mockPlatform, mockPlatform, "sym_",
                 null, new DatabaseWriterSettings(),
                 "test-producer", outputFormat,
                 topicBy, messageBy,
                 "http://localhost:8081", null, "test-node", "localhost:9092", "kafka.", props, "reload");
-        return writer;
     }
 
     Table createPojoTable(String tableName) {

--- a/symmetric-io/src/test/java/org/jumpmind/symmetric/io/data/writer/KafkaWriterTest.java
+++ b/symmetric-io/src/test/java/org/jumpmind/symmetric/io/data/writer/KafkaWriterTest.java
@@ -659,7 +659,7 @@ public class KafkaWriterTest {
     }
 
     @Test
-    public void testExecute_avroFormatWithoutConfluent() throws Exception {
+    public void testExecute_avroFormatWithoutConfluent() {
         KafkaWriter writer = createKafkaWriter(KafkaWriter.KAFKA_FORMAT_AVRO,
                 KafkaWriter.KAFKA_TOPIC_BY_TABLE, KafkaWriter.KAFKA_MESSAGE_BY_ROW);
         writer.kafkaProducer = mockKafkaProducer;

--- a/symmetric-io/src/test/java/org/jumpmind/symmetric/io/data/writer/KafkaWriterTest.java
+++ b/symmetric-io/src/test/java/org/jumpmind/symmetric/io/data/writer/KafkaWriterTest.java
@@ -169,7 +169,7 @@ public class KafkaWriterTest {
     }
 
     @Test
-    public void testExecute_jsonFormat() {
+    void testExecute_jsonFormat() {
         KafkaWriter writer = createKafkaWriter(KafkaWriter.KAFKA_FORMAT_JSON,
                 KafkaWriter.KAFKA_TOPIC_BY_TABLE, KafkaWriter.KAFKA_MESSAGE_BY_ROW);
         writer.kafkaProducer = mockKafkaProducer;
@@ -222,7 +222,7 @@ public class KafkaWriterTest {
     }
 
     @Test
-    public void testExecute_csvFormat() {
+    void testExecute_csvFormat() {
         KafkaWriter writer = createKafkaWriter(KafkaWriter.KAFKA_FORMAT_CSV,
                 KafkaWriter.KAFKA_TOPIC_BY_TABLE, KafkaWriter.KAFKA_MESSAGE_BY_ROW);
         writer.kafkaProducer = mockKafkaProducer;
@@ -270,7 +270,7 @@ public class KafkaWriterTest {
     }
 
     @Test
-    public void testExecute_xmlFormat() {
+    void testExecute_xmlFormat() {
         KafkaWriter writer = createKafkaWriter(KafkaWriter.KAFKA_FORMAT_XML,
                 KafkaWriter.KAFKA_TOPIC_BY_TABLE, KafkaWriter.KAFKA_MESSAGE_BY_ROW);
         writer.kafkaProducer = mockKafkaProducer;
@@ -574,7 +574,7 @@ public class KafkaWriterTest {
     }
 
     @Test
-    public void testGetColumnName_returnsNullForUnmatchedColumn() {
+    void testGetColumnName_returnsNullForUnmatchedColumn() {
         KafkaWriter writer = createKafkaWriter(KafkaWriter.KAFKA_FORMAT_AVRO,
                 KafkaWriter.KAFKA_TOPIC_BY_TABLE, KafkaWriter.KAFKA_MESSAGE_BY_ROW);
         PojoTestBean bean = new PojoTestBean();
@@ -583,7 +583,7 @@ public class KafkaWriterTest {
     }
 
     @Test
-    public void testGetAllowedProperties_includesWritableProperties() {
+    void testGetAllowedProperties_includesWritableProperties() {
         KafkaWriter writer = createKafkaWriter(KafkaWriter.KAFKA_FORMAT_AVRO,
                 KafkaWriter.KAFKA_TOPIC_BY_TABLE, KafkaWriter.KAFKA_MESSAGE_BY_ROW);
         PojoTestBean bean = new PojoTestBean();
@@ -596,7 +596,7 @@ public class KafkaWriterTest {
     }
 
     @Test
-    public void testGetAllowedProperties_excludesReadOnlyProperties() {
+    void testGetAllowedProperties_excludesReadOnlyProperties() {
         KafkaWriter writer = createKafkaWriter(KafkaWriter.KAFKA_FORMAT_AVRO,
                 KafkaWriter.KAFKA_TOPIC_BY_TABLE, KafkaWriter.KAFKA_MESSAGE_BY_ROW);
         PojoTestBean bean = new PojoTestBean();
@@ -659,7 +659,7 @@ public class KafkaWriterTest {
     }
 
     @Test
-    public void testExecute_avroFormatWithoutConfluent() {
+    void testExecute_avroFormatWithoutConfluent() {
         KafkaWriter writer = createKafkaWriter(KafkaWriter.KAFKA_FORMAT_AVRO,
                 KafkaWriter.KAFKA_TOPIC_BY_TABLE, KafkaWriter.KAFKA_MESSAGE_BY_ROW);
         writer.kafkaProducer = mockKafkaProducer;
@@ -682,7 +682,7 @@ public class KafkaWriterTest {
     }
 
     @Test
-    public void testWriteKafka_avroFormatWithConfluent() {
+    void testWriteKafka_avroFormatWithConfluent() {
         KafkaWriter writer = createConfluentKafkaWriter(KafkaWriter.KAFKA_FORMAT_AVRO,
                 KafkaWriter.KAFKA_TOPIC_BY_TABLE, KafkaWriter.KAFKA_MESSAGE_BY_ROW);
         writer.kafkaProducer = mockKafkaProducer;
@@ -712,7 +712,7 @@ public class KafkaWriterTest {
     }
 
     @Test
-    public void testWriteKafka_avroFormatWithConfluentDeletePrimaryKeyOnly() {
+    void testWriteKafka_avroFormatWithConfluentDeletePrimaryKeyOnly() {
         KafkaWriter writer = createConfluentKafkaWriter(KafkaWriter.KAFKA_FORMAT_AVRO,
                 KafkaWriter.KAFKA_TOPIC_BY_TABLE, KafkaWriter.KAFKA_MESSAGE_BY_ROW);
         writer.kafkaProducer = mockKafkaProducer;
@@ -740,7 +740,7 @@ public class KafkaWriterTest {
     }
 
     @Test
-    public void testExecute_avroFormatWithConfluent() {
+    void testExecute_avroFormatWithConfluent() {
         KafkaWriter writer = createConfluentKafkaWriter(KafkaWriter.KAFKA_FORMAT_AVRO,
                 KafkaWriter.KAFKA_TOPIC_BY_TABLE, KafkaWriter.KAFKA_MESSAGE_BY_ROW);
         writer.kafkaProducer = mockKafkaProducer;


### PR DESCRIPTION
Sonar flagged S4512 (security hotspot) on the BeanUtils.setProperty calls used to populate a POJO for Confluent/Avro Kafka messages, since it can't statically verify that the property name being set is constrained.

getColumnName() already implicitly guards this — it only ever returns a property name that matches an actual PropertyDescriptor on the target bean, so unrecognized columns are silently skipped before reaching BeanUtils. This change adds an explicit, local allowlist check (derived from the bean's own writable properties) right at each BeanUtils.setProperty call site, so the constraint is visible to the scanner and to future readers, rather than relying on the implicit behavior of a different method. No behavior change is expected, since the existing guard already prevents any non-bean property from reaching this code.

Applied to both writeKafka() and execute(), including the primary-key-only path.

Also added test coverage for the previously-untested Confluent/Avro POJO branches in both methods, and for getColumnName().