### PR TITLE
SYM-7786: Resolved sonar warning with compliant solution in AppUtils and added unit tests

### DIFF
--- a/symmetric-util/src/main/java/org/jumpmind/util/AppUtils.java
+++ b/symmetric-util/src/main/java/org/jumpmind/util/AppUtils.java
@@ -361,15 +361,14 @@ public class AppUtils {
         if (SystemUtils.IS_OS_UNIX) {
             FileAttribute<Set<PosixFilePermission>> attr = PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rw-------"));
             return Files.createTempFile(prefix, suffix, attr).toFile();
-        } else {
-            File file = Files.createTempFile(prefix, suffix).toFile();
-            file.setReadable(false, false);
-            file.setReadable(true, true);
-            file.setWritable(false, false);
-            file.setWritable(true, true);
-            return file;
         }
-    }
+        File file = File.createTempFile(prefix, suffix);
+        file.setReadable(false, false);
+        file.setReadable(true, true);
+        file.setWritable(false, false);
+        file.setWritable(true, true);
+        return file;
+        }
 
     public static String formatStackTrace(StackTraceElement[] stackTrace) {
         return formatStackTrace(stackTrace, 0, true);

--- a/symmetric-util/src/main/java/org/jumpmind/util/AppUtils.java
+++ b/symmetric-util/src/main/java/org/jumpmind/util/AppUtils.java
@@ -368,7 +368,7 @@ public class AppUtils {
         file.setWritable(false, false);
         file.setWritable(true, true);
         return file;
-        }
+    }
 
     public static String formatStackTrace(StackTraceElement[] stackTrace) {
         return formatStackTrace(stackTrace, 0, true);

--- a/symmetric-util/src/main/java/org/jumpmind/util/AppUtils.java
+++ b/symmetric-util/src/main/java/org/jumpmind/util/AppUtils.java
@@ -34,9 +34,13 @@ import java.net.UnknownHostException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Date;
 import java.util.Enumeration;
 import java.util.Properties;
+import java.util.Set;
 import java.util.TimeZone;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
@@ -44,6 +48,7 @@ import java.util.zip.ZipInputStream;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
+import org.apache.commons.lang3.SystemUtils;
 import org.apache.commons.lang3.time.FastDateFormat;
 import org.jumpmind.exception.IoException;
 import org.slf4j.Logger;
@@ -353,12 +358,17 @@ public class AppUtils {
     }
 
     public static File createTempFile(String prefix, String suffix) throws IOException {
-        File file = File.createTempFile(prefix, suffix);
-        file.setReadable(false, false);
-        file.setReadable(true, true);
-        file.setWritable(false, false);
-        file.setWritable(true, true);
-        return file;
+        if (SystemUtils.IS_OS_UNIX) {
+            FileAttribute<Set<PosixFilePermission>> attr = PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rw-------"));
+            return Files.createTempFile(prefix, suffix, attr).toFile();
+        } else {
+            File file = Files.createTempFile(prefix, suffix).toFile();
+            file.setReadable(false, false);
+            file.setReadable(true, true);
+            file.setWritable(false, false);
+            file.setWritable(true, true);
+            return file;
+        }
     }
 
     public static String formatStackTrace(StackTraceElement[] stackTrace) {

--- a/symmetric-util/src/test/java/org/jumpmind/util/AppUtilsTest.java
+++ b/symmetric-util/src/test/java/org/jumpmind/util/AppUtilsTest.java
@@ -22,15 +22,20 @@ package org.jumpmind.util;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
 import java.util.Date;
+import java.util.Set;
 import java.util.zip.ZipEntry;
 
 import org.apache.commons.lang3.time.DateUtils;
-import static org.junit.Assert.*;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class AppUtilsTest {
     @TempDir
@@ -104,13 +109,46 @@ class AppUtilsTest {
     }
 
     @Test
+    void testCreateTempFile_usesPrefixSuffixAndSystemTempDir() throws IOException {
+        File file = AppUtils.createTempFile("myprefix", ".mysuffix");
+        try {
+            assertTrue(file.exists());
+            assertTrue(file.getName().startsWith("myprefix"));
+            assertTrue(file.getName().endsWith(".mysuffix"));
+            assertEquals(new File(System.getProperty("java.io.tmpdir")).getCanonicalPath(),
+                    file.getParentFile().getCanonicalPath());
+            assertTrue(file.canRead());
+            assertTrue(file.canWrite());
+        } finally {
+            file.delete();
+        }
+    }
+
+    @Test
+    void testCreateTempFile_restrictsPermissionsToOwnerOnly() throws IOException {
+        File file = AppUtils.createTempFile("apputils-test", ".tmp");
+        try {
+            assertTrue(file.exists());
+            if (file.toPath().getFileSystem().supportedFileAttributeViews().contains("posix")) {
+                Set<PosixFilePermission> perms = Files.getPosixFilePermissions(file.toPath());
+                assertEquals(Set.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE), perms);
+            } else {
+                assertTrue(file.canRead());
+                assertTrue(file.canWrite());
+            }
+        } finally {
+            file.delete();
+        }
+    }
+
+    @Test
     void testGetLocalDateForOffset() {
         Date gmt = AppUtils.getLocalDateForOffset("+00:00");
         Date plusFour = AppUtils.getLocalDateForOffset("+04:00");
         Date minusFour = AppUtils.getLocalDateForOffset("-04:00");
         long nearZero = plusFour.getTime() - gmt.getTime() - DateUtils.MILLIS_PER_HOUR * 4;
-        assertTrue(nearZero + " was the left over ms", Math.abs(nearZero) < 1000);
+        assertTrue(Math.abs(nearZero) < 1000, nearZero + " was the left over ms");
         nearZero = plusFour.getTime() - minusFour.getTime() - DateUtils.MILLIS_PER_HOUR * 8;
-        assertTrue(nearZero + " was the left over ms", Math.abs(nearZero) < 1000);
+        assertTrue(Math.abs(nearZero) < 1000, nearZero + " was the left over ms");
     }
 }


### PR DESCRIPTION
Resolves the Sonar Security Hotspot S5443 ("Make sure publicly writable directories are used safely") on AppUtils.createTempFile.

Previously the method created the temp file with default permissions and then tightened them via setReadable/setWritable, leaving a brief window where the file was more permissive than intended. This change adopts Sonar's documented compliant solution:

- Unix (POSIX): create the file with PosixFilePermissions rw------- passed as a FileAttribute, so owner-only permissions are applied atomically at creation — no window.
- Non-Unix (Windows): POSIX attributes aren't supported, so fall back to creating the file and applying setReadable/setWritable (owner-only). The per-user temp directory's inherited ACLs already restrict access on Windows.

Final permissions are unchanged (rw------- / owner-only); the fix is about applying them atomically on the platform where it matters. Added unit tests to AppUtilsTest verifying owner-only permissions.

New tests use JUnit 5 assertions (org.junit.jupiter.api.Assertions), so I switched the file's static import from JUnit 4's org.junit.Assert.* to org.junit.jupiter.api.Assertions.* for consistency. This required updating testGetLocalDateForOffset to JUnit 5's argument order (message moves to the last parameter). The other existing tests use assertTrue(condition)/assertEquals(expected, actual) forms that are identical across both APIs, so they compile unchanged under the new import.