### PR TITLE
SYM-7702: Prevented a warning message from being logged whenever a node starts up with a platform that lacks a dedicated dialect

### DIFF
--- a/symmetric-client/src/main/java/org/jumpmind/symmetric/db/JdbcSymmetricDialectFactory.java
+++ b/symmetric-client/src/main/java/org/jumpmind/symmetric/db/JdbcSymmetricDialectFactory.java
@@ -153,10 +153,6 @@ public class JdbcSymmetricDialectFactory implements ISymmetricDialectFactory {
         } else if (platform instanceof IngresDatabasePlatform) {
             dialect = new IngresSymmetricDialect(parameterService, platform);
         } else {
-            log.warn("No dedicated SymmetricDS dialect found for platform '{}'. "
-                    + "Falling back to GenericSymmetricDialect, which has limited functionality. "
-                    + "For more information contact the SymmetricDS sales team.",
-                    platform.getClass().getSimpleName());
             dialect = new GenericSymmetricDialect(parameterService, platform);
         }
         return dialect;


### PR DESCRIPTION
I'm proposing that we remove this log message. Here's my reasoning:

1. There are some platforms that don't need a dedicated dialect, like Kafka and RabbitMQ. This message gets logged for platforms like these (in both open-source and Pro), even though no functionality is missing.
2. We added this message specifically for SQL Server and Oracle. We already have an `AbstractSymmetricEngine.checkForProOnlyDatabase()` method that throws an exception for these databases and prevents the engine from starting up. This exception's message makes the `JdbcSymmetricDialectFactory` warning logging redundant. Also, pointing out that the `GenericSymmetricDialect` has limited functionality doesn't make much sense when the engine isn't going to start anyway.