### PR TITLE
SYM-7815: Log error messages and skip routing for unsupported Column Segment router

### DIFF
--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/common/ConfigurationChangedHelper.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/common/ConfigurationChangedHelper.java
@@ -45,6 +45,7 @@ import org.jumpmind.symmetric.model.OutgoingBatch;
 import org.jumpmind.symmetric.model.Trigger;
 import org.jumpmind.symmetric.service.ClusterConstants;
 import org.jumpmind.symmetric.service.ITriggerRouterService;
+import org.jumpmind.symmetric.service.impl.RouterService;
 import org.jumpmind.util.AppUtils;
 import org.jumpmind.util.Context;
 import org.slf4j.Logger;
@@ -101,6 +102,10 @@ public class ConfigurationChangedHelper {
                 CTX_KEY_RESYNC_NEEDED);
         updateContext(TableConstants.SYM_PARAMETER, table, context, CTX_KEY_FLUSH_PARAMETERS_NEEDED);
         updateContext(TableConstants.SYM_ROUTER, table, context, CTX_KEY_RESYNC_NEEDED, CTX_KEY_FLUSH_ROUTERS_NEEDED);
+        if (matchesTable(table, TableConstants.SYM_ROUTER) && (data.getDataEventType().equals(DataEventType.INSERT)
+                || data.getDataEventType().equals(DataEventType.UPDATE))) {
+            logIfUnsupportedColumnSegmentRouter(table, data);
+        }
         updateContext(TableConstants.SYM_TRANSFORM_TABLE, table, context, CTX_KEY_FLUSH_TRANSFORMS_NEEDED);
         updateContext(TableConstants.SYM_TRANSFORM_COLUMN, table, context, CTX_KEY_FLUSH_TRANSFORMS_NEEDED);
         updateContext(TableConstants.SYM_TRIGGER_ROUTER_GROUPLET, table, context, CTX_KEY_FLUSH_GROUPLETS_NEEDED, CTX_KEY_RESYNC_NEEDED);
@@ -325,6 +330,16 @@ public class ConfigurationChangedHelper {
         String nodeGroupId = engine.getParameterService().getNodeGroupId();
         String columnValue = getColumnValue(table, data, columnName);
         return columnValue == null || nodeGroupId.equals(columnValue) || columnValue.equals(ParameterConstants.ALL);
+    }
+
+    private void logIfUnsupportedColumnSegmentRouter(Table table, CsvData data) {
+        String routerType = getColumnValue(table, data, "router_type");
+        String sourceNodeGroupId = getColumnValue(table, data, "source_node_group_id");
+        if (RouterService.COLUMN_SEGMENT_ROUTER_TYPE.equals(routerType) && engine.getParameterService().getNodeGroupId().equals(sourceNodeGroupId)) {
+            String routerId = getColumnValue(table, data, "router_id");
+            log.error("Router type 'segment' configured on router '{}' is not supported in this version of SymmetricDS. "
+                    + "Upgrade to version 3.18.0 or later (PRO edition) to use the Column Segment Router.", routerId);
+        }
     }
 
     private void updateContext(String tableSuffix, Table table, Context context, String... constants) {

--- a/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/RouterService.java
+++ b/symmetric-core/src/main/java/org/jumpmind/symmetric/service/impl/RouterService.java
@@ -26,6 +26,7 @@ import static org.jumpmind.symmetric.common.Constants.LOG_PROCESS_SUMMARY_THRESH
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -76,6 +77,7 @@ import org.jumpmind.symmetric.model.Trigger;
 import org.jumpmind.symmetric.model.TriggerHistory;
 import org.jumpmind.symmetric.model.TriggerReBuildReason;
 import org.jumpmind.symmetric.model.TriggerRouter;
+import org.jumpmind.symmetric.route.AbstractDataRouter;
 import org.jumpmind.symmetric.route.AbstractFileParsingRouter;
 import org.jumpmind.symmetric.route.AuditTableDataRouter;
 import org.jumpmind.symmetric.route.BshDataRouter;
@@ -116,10 +118,13 @@ import org.jumpmind.util.FormatUtils;
  * @see IRouterService
  */
 public class RouterService extends AbstractService implements IRouterService, INodeCommunicationExecutor {
+    public static final String COLUMN_SEGMENT_ROUTER_TYPE = "segment";
     final int MAX_LOGGING_LENGTH = 512;
     protected Map<Integer, CounterStat> missingTriggerRouter = new ConcurrentHashMap<Integer, CounterStat>();
     protected Map<String, CounterStat> invalidRouterType = new ConcurrentHashMap<String, CounterStat>();
+    protected Map<String, CounterStat> unsupportedColumnSegmentRouterType = new ConcurrentHashMap<String, CounterStat>();
     protected Map<Integer, CounterStat> missingColumns = new ConcurrentHashMap<Integer, CounterStat>();
+    protected final IDataRouter skipRoutingDataRouter = new SkipRoutingDataRouter();
     protected long triggerRouterCacheTime = 0;
     protected Map<String, Boolean> commonBatchesLastKnownState = new ConcurrentHashMap<String, Boolean>();
     protected long commonBatchesCacheTime;
@@ -250,6 +255,12 @@ public class RouterService extends AbstractService implements IRouterService, IN
                                 router.getRouterType(), router.getRouterId());
                     }
                     invalidRouterType.clear();
+                    for (CounterStat counterStat : unsupportedColumnSegmentRouterType.values()) {
+                        Router router = (Router) counterStat.getObject();
+                        log.error("Router type 'segment' configured on router '{}' is not supported in this version of SymmetricDS. "
+                                + "Upgrade to version 3.18.0 or later (PRO edition) to use the Column Segment Router.", router.getRouterId());
+                    }
+                    unsupportedColumnSegmentRouterType.clear();
                     for (CounterStat counterStat : missingTriggerRouter.values()) {
                         Data data = (Data) counterStat.getObject();
                         log.warn("Ignoring data captured for table '{}' because there is no trigger router configured for it.  "
@@ -1157,12 +1168,10 @@ public class RouterService extends AbstractService implements IRouterService, IN
         if (!StringUtils.isBlank(router.getRouterType())) {
             dataRouter = routers.get(router.getRouterType());
             if (dataRouter == null) {
-                CounterStat counterStat = invalidRouterType.get(router.getRouterId());
-                if (counterStat == null) {
-                    counterStat = new CounterStat(router);
-                    invalidRouterType.put(router.getRouterId(), counterStat);
+                trackUnsupportedRouterType(router);
+                if (COLUMN_SEGMENT_ROUTER_TYPE.equals(router.getRouterType())) {
+                    return skipRoutingDataRouter;
                 }
-                counterStat.incrementCount();
             } else if (dataRouter.isDmlOnly() && !dataMetaData.getData().getDataEventType().isDml() && dataMetaData.getData()
                     .getDataEventType() != DataEventType.RELOAD) {
                 dataRouter = null;
@@ -1172,6 +1181,18 @@ public class RouterService extends AbstractService implements IRouterService, IN
             return getRouters().get("default");
         }
         return dataRouter;
+    }
+
+    protected void trackUnsupportedRouterType(Router router) {
+        Map<String, CounterStat> counterMap = COLUMN_SEGMENT_ROUTER_TYPE.equals(router.getRouterType())
+                ? unsupportedColumnSegmentRouterType
+                : invalidRouterType;
+        CounterStat counterStat = counterMap.get(router.getRouterId());
+        if (counterStat == null) {
+            counterStat = new CounterStat(router);
+            counterMap.put(router.getRouterId(), counterStat);
+        }
+        counterStat.incrementCount();
     }
 
     protected List<TriggerRouter> getTriggerRoutersForData(Data data, ChannelRouterContext context) {
@@ -1280,5 +1301,17 @@ public class RouterService extends AbstractService implements IRouterService, IN
             }
         }
         return true;
+    }
+
+    /**
+     * Routes to no nodes. Used in place of the default router for router types that this version of SymmetricDS doesn't support, so that unroutable data isn't
+     * broadcast to every node as the default router would otherwise do.
+     */
+    protected static class SkipRoutingDataRouter extends AbstractDataRouter {
+        @Override
+        public Set<String> routeToNodes(SimpleRouterContext context, DataMetaData dataMetaData, Set<Node> nodes,
+                boolean initialLoad, boolean initialLoadSelectUsed, TriggerRouter triggerRouter) {
+            return Collections.emptySet();
+        }
     }
 }

--- a/symmetric-core/src/test/java/org/jumpmind/symmetric/common/ConfigurationChangedHelperTest.java
+++ b/symmetric-core/src/test/java/org/jumpmind/symmetric/common/ConfigurationChangedHelperTest.java
@@ -1,22 +1,111 @@
+/**
+ * Licensed to JumpMind Inc under one or more contributor
+ * license agreements.  See the NOTICE file distributed
+ * with this work for additional information regarding
+ * copyright ownership.  JumpMind Inc licenses this file
+ * to you under the GNU General Public License, version 3.0 (GPLv3)
+ * (the "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3.0 (GPLv3) along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.jumpmind.symmetric.common;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.List;
 
+import org.jumpmind.db.model.Column;
+import org.jumpmind.db.model.Table;
 import org.jumpmind.symmetric.ISymmetricEngine;
+import org.jumpmind.symmetric.io.data.CsvData;
+import org.jumpmind.symmetric.io.data.DataEventType;
+import org.jumpmind.symmetric.service.IParameterService;
+import org.jumpmind.symmetric.service.impl.RouterService;
+import org.jumpmind.util.Context;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class ConfigurationChangedHelperTest {
+    private static final String[] ROUTER_COLUMN_NAMES = { "router_id", "router_type", "source_node_group_id" };
+    private static final String CURRENT_NODE_GROUP_ID = "store";
     private ConfigurationChangedHelper helper;
     private ISymmetricEngine engine;
+    private IParameterService parameterService;
 
     @BeforeEach
     void setUp() {
         engine = mock(ISymmetricEngine.class);
+        parameterService = mock(IParameterService.class);
+        when(engine.getTablePrefix()).thenReturn("sym");
+        when(engine.getParameterService()).thenReturn(parameterService);
+        when(parameterService.getNodeGroupId()).thenReturn(CURRENT_NODE_GROUP_ID);
         helper = new ConfigurationChangedHelper(engine);
+    }
+
+    private Table buildRouterTable() {
+        Table table = new Table(TableConstants.getTableName("sym", TableConstants.SYM_ROUTER));
+        for (String columnName : ROUTER_COLUMN_NAMES) {
+            table.addColumn(new Column(columnName));
+        }
+        return table;
+    }
+
+    @Test
+    void testHandleChangeChecksNodeGroupForColumnSegmentRouterOnInsert() {
+        Table table = buildRouterTable();
+        CsvData data = new CsvData(DataEventType.INSERT,
+                new String[] { "router1", RouterService.COLUMN_SEGMENT_ROUTER_TYPE, CURRENT_NODE_GROUP_ID });
+        helper.handleChange(new Context(), table, data);
+        verify(parameterService).getNodeGroupId();
+    }
+
+    @Test
+    void testHandleChangeChecksNodeGroupForColumnSegmentRouterOnUpdate() {
+        Table table = buildRouterTable();
+        CsvData data = new CsvData(DataEventType.UPDATE,
+                new String[] { "router1", RouterService.COLUMN_SEGMENT_ROUTER_TYPE, CURRENT_NODE_GROUP_ID });
+        helper.handleChange(new Context(), table, data);
+        verify(parameterService).getNodeGroupId();
+    }
+
+    @Test
+    void testHandleChangeChecksNodeGroupForColumnSegmentRouterInDifferentNodeGroup() {
+        Table table = buildRouterTable();
+        CsvData data = new CsvData(DataEventType.INSERT,
+                new String[] { "router1", RouterService.COLUMN_SEGMENT_ROUTER_TYPE, "warehouse" });
+        helper.handleChange(new Context(), table, data);
+        verify(parameterService).getNodeGroupId();
+    }
+
+    @Test
+    void testHandleChangeSkipsCheckForNonColumnSegmentRouterType() {
+        Table table = buildRouterTable();
+        CsvData data = new CsvData(DataEventType.INSERT, new String[] { "router1", "default", CURRENT_NODE_GROUP_ID });
+        helper.handleChange(new Context(), table, data);
+        verify(parameterService, never()).getNodeGroupId();
+    }
+
+    @Test
+    void testHandleChangeSkipsCheckOnDelete() {
+        Table table = buildRouterTable();
+        CsvData data = new CsvData(DataEventType.DELETE,
+                new String[] { "router1", RouterService.COLUMN_SEGMENT_ROUTER_TYPE, CURRENT_NODE_GROUP_ID });
+        helper.handleChange(new Context(), table, data);
+        verify(parameterService, never()).getNodeGroupId();
     }
 
     @Test

--- a/symmetric-core/src/test/java/org/jumpmind/symmetric/service/impl/RouterServiceTest.java
+++ b/symmetric-core/src/test/java/org/jumpmind/symmetric/service/impl/RouterServiceTest.java
@@ -21,20 +21,29 @@
 package org.jumpmind.symmetric.service.impl;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.jumpmind.db.platform.DatabaseInfo;
 import org.jumpmind.db.platform.IDatabasePlatform;
 import org.jumpmind.symmetric.ISymmetricEngine;
 import org.jumpmind.symmetric.db.ISymmetricDialect;
 import org.jumpmind.symmetric.model.Channel;
+import org.jumpmind.symmetric.model.Node;
 import org.jumpmind.symmetric.model.Router;
 import org.jumpmind.symmetric.model.Trigger;
 import org.jumpmind.symmetric.model.TriggerRouter;
+import org.jumpmind.symmetric.route.IDataRouter;
 import org.jumpmind.symmetric.service.IExtensionService;
 import org.jumpmind.symmetric.service.IParameterService;
 import org.junit.jupiter.api.BeforeEach;
@@ -45,6 +54,7 @@ public class RouterServiceTest {
     final static String SOURCE_NODE_GROUP = "source";
     final static String TARGET_NODE_GROUP = "target";
     RouterService routerService;
+    IExtensionService extensionService;
 
     @BeforeEach
     public void setup() {
@@ -52,7 +62,7 @@ public class RouterServiceTest {
         IParameterService parameterService = mock(IParameterService.class);
         ISymmetricDialect symmetricDialect = mock(ISymmetricDialect.class);
         IDatabasePlatform databasePlatform = mock(IDatabasePlatform.class);
-        IExtensionService extensionService = mock(IExtensionService.class);
+        extensionService = mock(IExtensionService.class);
         when(databasePlatform.getDatabaseInfo()).thenReturn(new DatabaseInfo());
         when(symmetricDialect.getPlatform()).thenReturn(databasePlatform);
         when(engine.getDatabasePlatform()).thenReturn(databasePlatform);
@@ -133,5 +143,47 @@ public class RouterServiceTest {
         triggerRouters.add(new TriggerRouter(tableTrigger2, new Router("test", TARGET_NODE_GROUP, SOURCE_NODE_GROUP, "default")));
         triggerRouters.add(new TriggerRouter(tableTrigger3, new Router("test", TARGET_NODE_GROUP, SOURCE_NODE_GROUP, "default")));
         assertTrue(routerService.producesCommonBatches(CHANNEL_2_TEST, SOURCE_NODE_GROUP, triggerRouters));
+    }
+
+    @Test
+    public void testGetDataRouterSkipsRoutingForUnsupportedColumnSegmentRouterType() {
+        IDataRouter defaultRouter = mock(IDataRouter.class);
+        Map<String, IDataRouter> routers = new HashMap<String, IDataRouter>();
+        routers.put("default", defaultRouter);
+        when(extensionService.getExtensionPointMap(IDataRouter.class)).thenReturn(routers);
+        Router router = new Router("segmentRouter", SOURCE_NODE_GROUP, TARGET_NODE_GROUP, RouterService.COLUMN_SEGMENT_ROUTER_TYPE);
+        IDataRouter result = routerService.getDataRouter(router, null);
+        assertNotEquals(defaultRouter, result);
+        Set<Node> nodes = new HashSet<Node>();
+        nodes.add(new Node("node1", SOURCE_NODE_GROUP));
+        assertTrue(result.routeToNodes(null, null, nodes, false, false, null).isEmpty());
+        assertEquals(1, routerService.unsupportedColumnSegmentRouterType.get("segmentRouter").getCount());
+        assertFalse(routerService.invalidRouterType.containsKey("segmentRouter"));
+    }
+
+    @Test
+    public void testGetDataRouterFallsBackToDefaultForOtherInvalidRouterType() {
+        IDataRouter defaultRouter = mock(IDataRouter.class);
+        Map<String, IDataRouter> routers = new HashMap<String, IDataRouter>();
+        routers.put("default", defaultRouter);
+        when(extensionService.getExtensionPointMap(IDataRouter.class)).thenReturn(routers);
+        Router router = new Router("bogusRouter", SOURCE_NODE_GROUP, TARGET_NODE_GROUP, "bogus");
+        IDataRouter result = routerService.getDataRouter(router, null);
+        assertEquals(defaultRouter, result);
+        assertEquals(1, routerService.invalidRouterType.get("bogusRouter").getCount());
+        assertFalse(routerService.unsupportedColumnSegmentRouterType.containsKey("bogusRouter"));
+    }
+
+    @Test
+    public void testGetDataRouterUsesRegisteredRouterForKnownType() {
+        IDataRouter defaultRouter = mock(IDataRouter.class);
+        Map<String, IDataRouter> routers = new HashMap<String, IDataRouter>();
+        routers.put("default", defaultRouter);
+        when(extensionService.getExtensionPointMap(IDataRouter.class)).thenReturn(routers);
+        Router router = new Router("defaultRouter", SOURCE_NODE_GROUP, TARGET_NODE_GROUP, "default");
+        IDataRouter result = routerService.getDataRouter(router, null);
+        assertEquals(defaultRouter, result);
+        assertTrue(routerService.invalidRouterType.isEmpty());
+        assertTrue(routerService.unsupportedColumnSegmentRouterType.isEmpty());
     }
 }

--- a/symmetric-core/src/test/java/org/jumpmind/symmetric/service/impl/RouterServiceTest.java
+++ b/symmetric-core/src/test/java/org/jumpmind/symmetric/service/impl/RouterServiceTest.java
@@ -20,10 +20,10 @@
  */
 package org.jumpmind.symmetric.service.impl;
 
-import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 


### PR DESCRIPTION
The changes in this PR fulfill REQ-4 from the [ticket](https://jumpmind.atlassian.net/browse/SYM-7815) description. It wouldn't make sense to add 3.16 and 3.17 to the fix versions on the PR, so I'll manually cherry pick these changes and create another PR for 3.17 once this PR is merged.