### PR TITLE
SYM-7833: Updated log class name for all descendants of AbstractDatabasePlatform

### DIFF
--- a/symmetric-db/build.gradle
+++ b/symmetric-db/build.gradle
@@ -19,4 +19,10 @@ apply from: symAssembleDir + '/common.gradle'
         }
 
         testImplementation project(path: ':symmetric-util', configuration: 'testArtifacts')
+        testImplementation ("com.datastax.cassandra:cassandra-driver-core:3.11.5") {
+            exclude group: 'org.slf4j'
+            exclude group: 'com.google.guava'
+            exclude group: 'io.netty'
+            exclude group: 'com.fasterxml.jackson.core'
+        }
     }

--- a/symmetric-db/src/main/java/org/jumpmind/db/platform/AbstractDatabasePlatform.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/platform/AbstractDatabasePlatform.java
@@ -111,7 +111,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class AbstractDatabasePlatform implements IDatabasePlatform {
     /* The log for this platform. */
-    protected final Logger log = LoggerFactory.getLogger(getClass());
+    protected final Logger log = LoggerFactory.getLogger(getClassName());
     public static final String REQUIRED_FIELD_NULL_SUBSTITUTE = " ";
     public static final String ZERO_DATE_STRING = "0000-00-00 00:00:00";
     /*

--- a/symmetric-db/src/main/java/org/jumpmind/db/platform/IDatabasePlatform.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/platform/IDatabasePlatform.java
@@ -70,6 +70,14 @@ public interface IDatabasePlatform {
     public String getName();
 
     /**
+     * Returns the fully-qualified class name of this platform implementation. Used to name the platform's logger accurately, since some implementations have
+     * obfuscated class names at runtime.
+     *
+     * @return the fully-qualified class name
+     */
+    public String getClassName();
+
+    /**
      * Returns information about this platform.
      *
      * @return The info object

--- a/symmetric-db/src/main/java/org/jumpmind/db/platform/cassandra/CassandraPlatform.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/platform/cassandra/CassandraPlatform.java
@@ -61,6 +61,11 @@ public class CassandraPlatform extends AbstractDatabasePlatform {
     }
 
     @Override
+    public String getClassName() {
+        return CassandraPlatform.class.getName();
+    }
+
+    @Override
     public String getDefaultSchema() {
         return null;
     }

--- a/symmetric-db/src/main/java/org/jumpmind/db/platform/kafka/KafkaPlatform.java
+++ b/symmetric-db/src/main/java/org/jumpmind/db/platform/kafka/KafkaPlatform.java
@@ -39,6 +39,11 @@ public class KafkaPlatform extends AbstractDatabasePlatform {
     }
 
     @Override
+    public String getClassName() {
+        return KafkaPlatform.class.getName();
+    }
+
+    @Override
     public String getDefaultSchema() {
         return null;
     }

--- a/symmetric-db/src/test/java/org/jumpmind/db/platform/AbstractDatabasePlatformTest.java
+++ b/symmetric-db/src/test/java/org/jumpmind/db/platform/AbstractDatabasePlatformTest.java
@@ -97,6 +97,11 @@ public class AbstractDatabasePlatformTest {
         }
 
         @Override
+        public String getClassName() {
+            return "Test";
+        }
+
+        @Override
         public String getDefaultSchema() {
             return "default Schema.";
         }

--- a/symmetric-db/src/test/java/org/jumpmind/db/platform/cassandra/CassandraPlatformTest.java
+++ b/symmetric-db/src/test/java/org/jumpmind/db/platform/cassandra/CassandraPlatformTest.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to JumpMind Inc under one or more contributor
+ * license agreements.  See the NOTICE file distributed
+ * with this work for additional information regarding
+ * copyright ownership.  JumpMind Inc licenses this file
+ * to you under the GNU General Public License, version 3.0 (GPLv3)
+ * (the "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3.0 (GPLv3) along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jumpmind.db.platform.cassandra;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+
+class CassandraPlatformTest {
+    @Test
+    void testGetClassName() {
+        CassandraPlatform platform = mock(CassandraPlatform.class, CALLS_REAL_METHODS);
+        assertEquals(CassandraPlatform.class.getName(), platform.getClassName());
+    }
+}

--- a/symmetric-db/src/test/java/org/jumpmind/db/platform/kafka/KafkaPlatformTest.java
+++ b/symmetric-db/src/test/java/org/jumpmind/db/platform/kafka/KafkaPlatformTest.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to JumpMind Inc under one or more contributor
+ * license agreements.  See the NOTICE file distributed
+ * with this work for additional information regarding
+ * copyright ownership.  JumpMind Inc licenses this file
+ * to you under the GNU General Public License, version 3.0 (GPLv3)
+ * (the "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3.0 (GPLv3) along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jumpmind.db.platform.kafka;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+
+class KafkaPlatformTest {
+    @Test
+    void testGetClassName() {
+        KafkaPlatform platform = mock(KafkaPlatform.class, CALLS_REAL_METHODS);
+        assertEquals(KafkaPlatform.class.getName(), platform.getClassName());
+    }
+}

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/ase/AseDatabasePlatform.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/ase/AseDatabasePlatform.java
@@ -118,6 +118,11 @@ public class AseDatabasePlatform extends AbstractJdbcDatabasePlatform {
     }
 
     @Override
+    public String getClassName() {
+        return AseDatabasePlatform.class.getName();
+    }
+
+    @Override
     public String getDefaultCatalog() {
         if (StringUtils.isBlank(defaultCatalog)) {
             defaultCatalog = getSqlTemplate().queryForObject("select DB_NAME()", String.class);

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/db2/Db2DatabasePlatform.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/db2/Db2DatabasePlatform.java
@@ -100,6 +100,11 @@ public class Db2DatabasePlatform extends AbstractJdbcDatabasePlatform {
         return DatabaseNamesConstants.DB2;
     }
 
+    @Override
+    public String getClassName() {
+        return Db2DatabasePlatform.class.getName();
+    }
+
     public String getDefaultSchema() {
         if (StringUtils.isBlank(defaultSchema)) {
             defaultSchema = (String) getSqlTemplate().queryForObject("select CURRENT SCHEMA from sysibm.sysdummy1", String.class);

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/derby/DerbyDatabasePlatform.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/derby/DerbyDatabasePlatform.java
@@ -98,6 +98,11 @@ public class DerbyDatabasePlatform extends AbstractJdbcDatabasePlatform {
     }
 
     @Override
+    public String getClassName() {
+        return DerbyDatabasePlatform.class.getName();
+    }
+
+    @Override
     public String getDefaultSchema() {
         if (StringUtils.isBlank(defaultSchema)) {
             defaultSchema = getSqlTemplate().queryForObject("values CURRENT SCHEMA", String.class);

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/firebird/FirebirdDatabasePlatform.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/firebird/FirebirdDatabasePlatform.java
@@ -93,6 +93,11 @@ public class FirebirdDatabasePlatform extends AbstractJdbcDatabasePlatform {
         return DatabaseNamesConstants.FIREBIRD;
     }
 
+    @Override
+    public String getClassName() {
+        return FirebirdDatabasePlatform.class.getName();
+    }
+
     public String getDefaultCatalog() {
         return null;
     }

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/firebird/FirebirdDialect1DatabasePlatform.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/firebird/FirebirdDialect1DatabasePlatform.java
@@ -63,4 +63,9 @@ public class FirebirdDialect1DatabasePlatform extends FirebirdDatabasePlatform {
     public String getName() {
         return DatabaseNamesConstants.FIREBIRD_DIALECT1;
     }
+
+    @Override
+    public String getClassName() {
+        return FirebirdDialect1DatabasePlatform.class.getName();
+    }
 }

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/generic/GenericJdbcDatabasePlatform.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/generic/GenericJdbcDatabasePlatform.java
@@ -52,6 +52,11 @@ public class GenericJdbcDatabasePlatform extends AbstractJdbcDatabasePlatform {
     }
 
     @Override
+    public String getClassName() {
+        return GenericJdbcDatabasePlatform.class.getName();
+    }
+
+    @Override
     public boolean isDedicatedPlatform() {
         return false;
     }

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/greenplum/GreenplumPlatform.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/greenplum/GreenplumPlatform.java
@@ -57,4 +57,9 @@ public class GreenplumPlatform extends PostgreSqlDatabasePlatform {
     public String getName() {
         return DatabaseNamesConstants.GREENPLUM;
     }
+
+    @Override
+    public String getClassName() {
+        return GreenplumPlatform.class.getName();
+    }
 }

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/h2/H2DatabasePlatform.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/h2/H2DatabasePlatform.java
@@ -88,6 +88,11 @@ public class H2DatabasePlatform extends AbstractJdbcDatabasePlatform implements 
     }
 
     @Override
+    public String getClassName() {
+        return H2DatabasePlatform.class.getName();
+    }
+
+    @Override
     public String getDefaultSchema() {
         if (StringUtils.isBlank(defaultSchema)) {
             defaultSchema = getSqlTemplate().queryForObject("select SCHEMA()", String.class);

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/hana/HanaDatabasePlatform.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/hana/HanaDatabasePlatform.java
@@ -56,6 +56,11 @@ public class HanaDatabasePlatform extends AbstractJdbcDatabasePlatform {
     }
 
     @Override
+    public String getClassName() {
+        return HanaDatabasePlatform.class.getName();
+    }
+
+    @Override
     public String getDefaultSchema() {
         return null;
     }

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/hbase/HbasePlatform.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/hbase/HbasePlatform.java
@@ -41,6 +41,11 @@ public class HbasePlatform extends GenericJdbcDatabasePlatform {
     }
 
     @Override
+    public String getClassName() {
+        return HbasePlatform.class.getName();
+    }
+
+    @Override
     protected IDdlBuilder createDdlBuilder() {
         return new HbaseDdlBuilder();
     }

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/hsqldb/HsqlDbDatabasePlatform.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/hsqldb/HsqlDbDatabasePlatform.java
@@ -84,6 +84,11 @@ public class HsqlDbDatabasePlatform extends AbstractJdbcDatabasePlatform {
         return DatabaseNamesConstants.HSQLDB;
     }
 
+    @Override
+    public String getClassName() {
+        return HsqlDbDatabasePlatform.class.getName();
+    }
+
     public String getDefaultCatalog() {
         return null;
     }

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/hsqldb2/HsqlDb2DatabasePlatform.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/hsqldb2/HsqlDb2DatabasePlatform.java
@@ -84,6 +84,11 @@ public class HsqlDb2DatabasePlatform extends AbstractJdbcDatabasePlatform {
         return DatabaseNamesConstants.HSQLDB2;
     }
 
+    @Override
+    public String getClassName() {
+        return HsqlDb2DatabasePlatform.class.getName();
+    }
+
     public String getDefaultSchema() {
         return getDefaultCatalog();
     }

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/informix/InformixDatabasePlatform.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/informix/InformixDatabasePlatform.java
@@ -80,6 +80,11 @@ public class InformixDatabasePlatform extends AbstractJdbcDatabasePlatform imple
     }
 
     @Override
+    public String getClassName() {
+        return InformixDatabasePlatform.class.getName();
+    }
+
+    @Override
     public String getDefaultCatalog() {
         return defaultCatalog;
     }

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/ingres/IngresDatabasePlatform.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/ingres/IngresDatabasePlatform.java
@@ -52,6 +52,11 @@ public class IngresDatabasePlatform extends AbstractJdbcDatabasePlatform {
     }
 
     @Override
+    public String getClassName() {
+        return IngresDatabasePlatform.class.getName();
+    }
+
+    @Override
     public String getDefaultSchema() {
         if (StringUtils.isBlank(defaultSchema)) {
             defaultSchema = (String) getSqlTemplate().queryForObject("SELECT DBMSINFO('SESSION_SCHEMA')", String.class);

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/interbase/InterbaseDatabasePlatform.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/interbase/InterbaseDatabasePlatform.java
@@ -85,6 +85,11 @@ public class InterbaseDatabasePlatform extends AbstractJdbcDatabasePlatform {
         return DatabaseNamesConstants.INTERBASE;
     }
 
+    @Override
+    public String getClassName() {
+        return InterbaseDatabasePlatform.class.getName();
+    }
+
     public String getDefaultCatalog() {
         return null;
     }

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/mariadb/MariaDBDatabasePlatform.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/mariadb/MariaDBDatabasePlatform.java
@@ -48,6 +48,11 @@ public class MariaDBDatabasePlatform extends MySqlDatabasePlatform {
     }
 
     @Override
+    public String getClassName() {
+        return MariaDBDatabasePlatform.class.getName();
+    }
+
+    @Override
     public PermissionResult getLogMinePermission() {
         final PermissionResult result = new PermissionResult(PermissionType.LOG_MINE, "Use LogMiner");
         StringBuilder solution = new StringBuilder();

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/mysql/MySqlDatabasePlatform.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/mysql/MySqlDatabasePlatform.java
@@ -126,6 +126,11 @@ public class MySqlDatabasePlatform extends AbstractJdbcDatabasePlatform {
         return DatabaseNamesConstants.MYSQL;
     }
 
+    @Override
+    public String getClassName() {
+        return MySqlDatabasePlatform.class.getName();
+    }
+
     public String getDefaultSchema() {
         return null;
     }

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/nuodb/NuoDbDatabasePlatform.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/nuodb/NuoDbDatabasePlatform.java
@@ -72,6 +72,11 @@ public class NuoDbDatabasePlatform extends AbstractJdbcDatabasePlatform {
         return DatabaseNamesConstants.NUODB;
     }
 
+    @Override
+    public String getClassName() {
+        return NuoDbDatabasePlatform.class.getName();
+    }
+
     public String getDefaultSchema() {
         if (StringUtils.isBlank(defaultSchema)) {
             defaultSchema = getSqlTemplate().queryForObject("select current_schema from system.dual", String.class);

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/postgresql/PostgreSql95DatabasePlatform.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/postgresql/PostgreSql95DatabasePlatform.java
@@ -56,4 +56,9 @@ public class PostgreSql95DatabasePlatform extends PostgreSqlDatabasePlatform {
     public String getName() {
         return DatabaseNamesConstants.POSTGRESQL95;
     }
+
+    @Override
+    public String getClassName() {
+        return PostgreSql95DatabasePlatform.class.getName();
+    }
 }

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/postgresql/PostgreSqlDatabasePlatform.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/postgresql/PostgreSqlDatabasePlatform.java
@@ -147,6 +147,11 @@ public class PostgreSqlDatabasePlatform extends AbstractJdbcDatabasePlatform {
     }
 
     @Override
+    public String getClassName() {
+        return PostgreSqlDatabasePlatform.class.getName();
+    }
+
+    @Override
     public String getDefaultSchema() {
         if (StringUtils.isBlank(defaultSchema)) {
             defaultSchema = getSqlTemplate().queryForObject("select current_schema()", String.class);

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/raima/RaimaDatabasePlatform.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/raima/RaimaDatabasePlatform.java
@@ -65,6 +65,11 @@ public class RaimaDatabasePlatform extends AbstractJdbcDatabasePlatform {
         return DatabaseNamesConstants.RAIMA;
     }
 
+    @Override
+    public String getClassName() {
+        return RaimaDatabasePlatform.class.getName();
+    }
+
     public String getDefaultSchema() {
         return null;
     }

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/redshift/RedshiftDatabasePlatform.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/redshift/RedshiftDatabasePlatform.java
@@ -84,6 +84,11 @@ public class RedshiftDatabasePlatform extends AbstractJdbcDatabasePlatform {
         return DatabaseNamesConstants.REDSHIFT;
     }
 
+    @Override
+    public String getClassName() {
+        return RedshiftDatabasePlatform.class.getName();
+    }
+
     public String getDefaultCatalog() {
         return null;
     }

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/sqlanywhere/SqlAnywhere12DatabasePlatform.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/sqlanywhere/SqlAnywhere12DatabasePlatform.java
@@ -8,4 +8,9 @@ public class SqlAnywhere12DatabasePlatform extends SqlAnywhereDatabasePlatform {
     public SqlAnywhere12DatabasePlatform(DataSource dataSource, SqlTemplateSettings settings) {
         super(dataSource, settings);
     }
+
+    @Override
+    public String getClassName() {
+        return SqlAnywhere12DatabasePlatform.class.getName();
+    }
 }

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/sqlanywhere/SqlAnywhereDatabasePlatform.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/sqlanywhere/SqlAnywhereDatabasePlatform.java
@@ -97,6 +97,11 @@ public class SqlAnywhereDatabasePlatform extends AbstractJdbcDatabasePlatform {
         return DatabaseNamesConstants.SQLANYWHERE;
     }
 
+    @Override
+    public String getClassName() {
+        return SqlAnywhereDatabasePlatform.class.getName();
+    }
+
     public String getDefaultCatalog() {
         if (StringUtils.isBlank(defaultCatalog)) {
             defaultCatalog = getSqlTemplate().queryForObject("select DB_NAME()", String.class);

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/sqlite/SqliteDatabasePlatform.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/sqlite/SqliteDatabasePlatform.java
@@ -69,6 +69,11 @@ public class SqliteDatabasePlatform extends AbstractJdbcDatabasePlatform impleme
         return DatabaseNamesConstants.SQLITE;
     }
 
+    @Override
+    public String getClassName() {
+        return SqliteDatabasePlatform.class.getName();
+    }
+
     public String getDefaultSchema() {
         return null;
     }

--- a/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/voltdb/VoltDbDatabasePlatform.java
+++ b/symmetric-jdbc/src/main/java/org/jumpmind/db/platform/voltdb/VoltDbDatabasePlatform.java
@@ -61,6 +61,11 @@ public class VoltDbDatabasePlatform extends AbstractJdbcDatabasePlatform {
     }
 
     @Override
+    public String getClassName() {
+        return VoltDbDatabasePlatform.class.getName();
+    }
+
+    @Override
     public Database readDatabaseFromXml(InputStream is, boolean alterCaseToMatchDatabaseDefaultCase) {
         Database database = super.readDatabaseFromXml(is, alterCaseToMatchDatabaseDefaultCase);
         for (Table table : database.getTables()) {

--- a/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/ase/AseDatabasePlatformTest.java
+++ b/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/ase/AseDatabasePlatformTest.java
@@ -53,6 +53,11 @@ public class AseDatabasePlatformTest {
     }
 
     @Test
+    void testGetClassName() {
+        assertEquals(AseDatabasePlatform.class.getName(), platform.getClassName());
+    }
+
+    @Test
     void testCanColumnBeUsedInWhereClause_withUnitext_shouldBeLob() {
         Column column = new Column();
         column.setJdbcTypeCode(Types.LONGVARBINARY);

--- a/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/db2/Db2DatabasePlatformTest.java
+++ b/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/db2/Db2DatabasePlatformTest.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to JumpMind Inc under one or more contributor
+ * license agreements.  See the NOTICE file distributed
+ * with this work for additional information regarding
+ * copyright ownership.  JumpMind Inc licenses this file
+ * to you under the GNU General Public License, version 3.0 (GPLv3)
+ * (the "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3.0 (GPLv3) along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jumpmind.db.platform.db2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+
+class Db2DatabasePlatformTest {
+    @Test
+    void testGetClassName() {
+        Db2DatabasePlatform platform = mock(Db2DatabasePlatform.class, CALLS_REAL_METHODS);
+        assertEquals(Db2DatabasePlatform.class.getName(), platform.getClassName());
+    }
+}

--- a/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/derby/DerbyDatabasePlatformTest.java
+++ b/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/derby/DerbyDatabasePlatformTest.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to JumpMind Inc under one or more contributor
+ * license agreements.  See the NOTICE file distributed
+ * with this work for additional information regarding
+ * copyright ownership.  JumpMind Inc licenses this file
+ * to you under the GNU General Public License, version 3.0 (GPLv3)
+ * (the "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3.0 (GPLv3) along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jumpmind.db.platform.derby;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+
+class DerbyDatabasePlatformTest {
+    @Test
+    void testGetClassName() {
+        DerbyDatabasePlatform platform = mock(DerbyDatabasePlatform.class, CALLS_REAL_METHODS);
+        assertEquals(DerbyDatabasePlatform.class.getName(), platform.getClassName());
+    }
+}

--- a/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/firebird/FirebirdDatabasePlatformTest.java
+++ b/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/firebird/FirebirdDatabasePlatformTest.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to JumpMind Inc under one or more contributor
+ * license agreements.  See the NOTICE file distributed
+ * with this work for additional information regarding
+ * copyright ownership.  JumpMind Inc licenses this file
+ * to you under the GNU General Public License, version 3.0 (GPLv3)
+ * (the "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3.0 (GPLv3) along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jumpmind.db.platform.firebird;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+
+class FirebirdDatabasePlatformTest {
+    @Test
+    void testGetClassName() {
+        FirebirdDatabasePlatform platform = mock(FirebirdDatabasePlatform.class, CALLS_REAL_METHODS);
+        assertEquals(FirebirdDatabasePlatform.class.getName(), platform.getClassName());
+    }
+}

--- a/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/firebird/FirebirdDialect1DatabasePlatformTest.java
+++ b/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/firebird/FirebirdDialect1DatabasePlatformTest.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to JumpMind Inc under one or more contributor
+ * license agreements.  See the NOTICE file distributed
+ * with this work for additional information regarding
+ * copyright ownership.  JumpMind Inc licenses this file
+ * to you under the GNU General Public License, version 3.0 (GPLv3)
+ * (the "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3.0 (GPLv3) along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jumpmind.db.platform.firebird;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+
+class FirebirdDialect1DatabasePlatformTest {
+    @Test
+    void testGetClassName() {
+        FirebirdDialect1DatabasePlatform platform = mock(FirebirdDialect1DatabasePlatform.class, CALLS_REAL_METHODS);
+        assertEquals(FirebirdDialect1DatabasePlatform.class.getName(), platform.getClassName());
+    }
+}

--- a/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/generic/GenericJdbcDatabasePlatformTest.java
+++ b/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/generic/GenericJdbcDatabasePlatformTest.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to JumpMind Inc under one or more contributor
+ * license agreements.  See the NOTICE file distributed
+ * with this work for additional information regarding
+ * copyright ownership.  JumpMind Inc licenses this file
+ * to you under the GNU General Public License, version 3.0 (GPLv3)
+ * (the "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3.0 (GPLv3) along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jumpmind.db.platform.generic;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+
+class GenericJdbcDatabasePlatformTest {
+    @Test
+    void testGetClassName() {
+        GenericJdbcDatabasePlatform platform = mock(GenericJdbcDatabasePlatform.class, CALLS_REAL_METHODS);
+        assertEquals(GenericJdbcDatabasePlatform.class.getName(), platform.getClassName());
+    }
+}

--- a/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/greenplum/GreenplumPlatformTest.java
+++ b/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/greenplum/GreenplumPlatformTest.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to JumpMind Inc under one or more contributor
+ * license agreements.  See the NOTICE file distributed
+ * with this work for additional information regarding
+ * copyright ownership.  JumpMind Inc licenses this file
+ * to you under the GNU General Public License, version 3.0 (GPLv3)
+ * (the "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3.0 (GPLv3) along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jumpmind.db.platform.greenplum;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+
+class GreenplumPlatformTest {
+    @Test
+    void testGetClassName() {
+        GreenplumPlatform platform = mock(GreenplumPlatform.class, CALLS_REAL_METHODS);
+        assertEquals(GreenplumPlatform.class.getName(), platform.getClassName());
+    }
+}

--- a/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/h2/H2DatabasePlatformTest.java
+++ b/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/h2/H2DatabasePlatformTest.java
@@ -48,6 +48,11 @@ public class H2DatabasePlatformTest {
     }
 
     @Test
+    void testGetClassName() {
+        assertEquals(H2DatabasePlatform.class.getName(), platform.getClassName());
+    }
+
+    @Test
     void testShutdown() {
         when(sqlTemplate.update("SHUTDOWN COMPACT")).thenReturn(0);
         platform.shutdown();

--- a/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/hana/HanaDatabasePlatformTest.java
+++ b/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/hana/HanaDatabasePlatformTest.java
@@ -38,6 +38,11 @@ class HanaDatabasePlatformTest {
     }
 
     @Test
+    void testGetClassName() {
+        assertEquals(HanaDatabasePlatform.class.getName(), platform.getClassName());
+    }
+
+    @Test
     void testGetDefaultSchema() {
         assertNull(platform.getDefaultSchema());
     }

--- a/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/hbase/HbasePlatformTest.java
+++ b/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/hbase/HbasePlatformTest.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to JumpMind Inc under one or more contributor
+ * license agreements.  See the NOTICE file distributed
+ * with this work for additional information regarding
+ * copyright ownership.  JumpMind Inc licenses this file
+ * to you under the GNU General Public License, version 3.0 (GPLv3)
+ * (the "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3.0 (GPLv3) along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jumpmind.db.platform.hbase;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+
+class HbasePlatformTest {
+    @Test
+    void testGetClassName() {
+        HbasePlatform platform = mock(HbasePlatform.class, CALLS_REAL_METHODS);
+        assertEquals(HbasePlatform.class.getName(), platform.getClassName());
+    }
+}

--- a/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/hsqldb/HsqlDbDatabasePlatformTest.java
+++ b/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/hsqldb/HsqlDbDatabasePlatformTest.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to JumpMind Inc under one or more contributor
+ * license agreements.  See the NOTICE file distributed
+ * with this work for additional information regarding
+ * copyright ownership.  JumpMind Inc licenses this file
+ * to you under the GNU General Public License, version 3.0 (GPLv3)
+ * (the "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3.0 (GPLv3) along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jumpmind.db.platform.hsqldb;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+
+class HsqlDbDatabasePlatformTest {
+    @Test
+    void testGetClassName() {
+        HsqlDbDatabasePlatform platform = mock(HsqlDbDatabasePlatform.class, CALLS_REAL_METHODS);
+        assertEquals(HsqlDbDatabasePlatform.class.getName(), platform.getClassName());
+    }
+}

--- a/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/hsqldb2/HsqlDb2DatabasePlatformTest.java
+++ b/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/hsqldb2/HsqlDb2DatabasePlatformTest.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to JumpMind Inc under one or more contributor
+ * license agreements.  See the NOTICE file distributed
+ * with this work for additional information regarding
+ * copyright ownership.  JumpMind Inc licenses this file
+ * to you under the GNU General Public License, version 3.0 (GPLv3)
+ * (the "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3.0 (GPLv3) along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jumpmind.db.platform.hsqldb2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+
+class HsqlDb2DatabasePlatformTest {
+    @Test
+    void testGetClassName() {
+        HsqlDb2DatabasePlatform platform = mock(HsqlDb2DatabasePlatform.class, CALLS_REAL_METHODS);
+        assertEquals(HsqlDb2DatabasePlatform.class.getName(), platform.getClassName());
+    }
+}

--- a/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/informix/InformixDatabasePlatformTest.java
+++ b/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/informix/InformixDatabasePlatformTest.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to JumpMind Inc under one or more contributor
+ * license agreements.  See the NOTICE file distributed
+ * with this work for additional information regarding
+ * copyright ownership.  JumpMind Inc licenses this file
+ * to you under the GNU General Public License, version 3.0 (GPLv3)
+ * (the "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3.0 (GPLv3) along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jumpmind.db.platform.informix;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+
+class InformixDatabasePlatformTest {
+    @Test
+    void testGetClassName() {
+        InformixDatabasePlatform platform = mock(InformixDatabasePlatform.class, CALLS_REAL_METHODS);
+        assertEquals(InformixDatabasePlatform.class.getName(), platform.getClassName());
+    }
+}

--- a/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/ingres/IngresDatabasePlatformTest.java
+++ b/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/ingres/IngresDatabasePlatformTest.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to JumpMind Inc under one or more contributor
+ * license agreements.  See the NOTICE file distributed
+ * with this work for additional information regarding
+ * copyright ownership.  JumpMind Inc licenses this file
+ * to you under the GNU General Public License, version 3.0 (GPLv3)
+ * (the "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3.0 (GPLv3) along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jumpmind.db.platform.ingres;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+
+class IngresDatabasePlatformTest {
+    @Test
+    void testGetClassName() {
+        IngresDatabasePlatform platform = mock(IngresDatabasePlatform.class, CALLS_REAL_METHODS);
+        assertEquals(IngresDatabasePlatform.class.getName(), platform.getClassName());
+    }
+}

--- a/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/interbase/InterbaseDatabasePlatformTest.java
+++ b/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/interbase/InterbaseDatabasePlatformTest.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to JumpMind Inc under one or more contributor
+ * license agreements.  See the NOTICE file distributed
+ * with this work for additional information regarding
+ * copyright ownership.  JumpMind Inc licenses this file
+ * to you under the GNU General Public License, version 3.0 (GPLv3)
+ * (the "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3.0 (GPLv3) along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jumpmind.db.platform.interbase;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+
+class InterbaseDatabasePlatformTest {
+    @Test
+    void testGetClassName() {
+        InterbaseDatabasePlatform platform = mock(InterbaseDatabasePlatform.class, CALLS_REAL_METHODS);
+        assertEquals(InterbaseDatabasePlatform.class.getName(), platform.getClassName());
+    }
+}

--- a/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/mariadb/MariaDBDatabasePlatformTest.java
+++ b/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/mariadb/MariaDBDatabasePlatformTest.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to JumpMind Inc under one or more contributor
+ * license agreements.  See the NOTICE file distributed
+ * with this work for additional information regarding
+ * copyright ownership.  JumpMind Inc licenses this file
+ * to you under the GNU General Public License, version 3.0 (GPLv3)
+ * (the "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3.0 (GPLv3) along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jumpmind.db.platform.mariadb;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+
+class MariaDBDatabasePlatformTest {
+    @Test
+    void testGetClassName() {
+        MariaDBDatabasePlatform platform = mock(MariaDBDatabasePlatform.class, CALLS_REAL_METHODS);
+        assertEquals(MariaDBDatabasePlatform.class.getName(), platform.getClassName());
+    }
+}

--- a/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/mysql/MySqlDatabasePlatformTest.java
+++ b/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/mysql/MySqlDatabasePlatformTest.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to JumpMind Inc under one or more contributor
+ * license agreements.  See the NOTICE file distributed
+ * with this work for additional information regarding
+ * copyright ownership.  JumpMind Inc licenses this file
+ * to you under the GNU General Public License, version 3.0 (GPLv3)
+ * (the "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3.0 (GPLv3) along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jumpmind.db.platform.mysql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+
+class MySqlDatabasePlatformTest {
+    @Test
+    void testGetClassName() {
+        MySqlDatabasePlatform platform = mock(MySqlDatabasePlatform.class, CALLS_REAL_METHODS);
+        assertEquals(MySqlDatabasePlatform.class.getName(), platform.getClassName());
+    }
+}

--- a/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/nuodb/NuoDbDatabasePlatformTest.java
+++ b/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/nuodb/NuoDbDatabasePlatformTest.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to JumpMind Inc under one or more contributor
+ * license agreements.  See the NOTICE file distributed
+ * with this work for additional information regarding
+ * copyright ownership.  JumpMind Inc licenses this file
+ * to you under the GNU General Public License, version 3.0 (GPLv3)
+ * (the "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3.0 (GPLv3) along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jumpmind.db.platform.nuodb;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+
+class NuoDbDatabasePlatformTest {
+    @Test
+    void testGetClassName() {
+        NuoDbDatabasePlatform platform = mock(NuoDbDatabasePlatform.class, CALLS_REAL_METHODS);
+        assertEquals(NuoDbDatabasePlatform.class.getName(), platform.getClassName());
+    }
+}

--- a/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/postgresql/PostgreSql95DatabasePlatformTest.java
+++ b/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/postgresql/PostgreSql95DatabasePlatformTest.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to JumpMind Inc under one or more contributor
+ * license agreements.  See the NOTICE file distributed
+ * with this work for additional information regarding
+ * copyright ownership.  JumpMind Inc licenses this file
+ * to you under the GNU General Public License, version 3.0 (GPLv3)
+ * (the "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3.0 (GPLv3) along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jumpmind.db.platform.postgresql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+
+class PostgreSql95DatabasePlatformTest {
+    @Test
+    void testGetClassName() {
+        PostgreSql95DatabasePlatform platform = mock(PostgreSql95DatabasePlatform.class, CALLS_REAL_METHODS);
+        assertEquals(PostgreSql95DatabasePlatform.class.getName(), platform.getClassName());
+    }
+}

--- a/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/postgresql/PostgreSqlDatabasePlatformTest.java
+++ b/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/postgresql/PostgreSqlDatabasePlatformTest.java
@@ -40,6 +40,11 @@ class PostgreSqlDatabasePlatformTest {
     private final PostgreSqlDatabasePlatform platform = mock(PostgreSqlDatabasePlatform.class, CALLS_REAL_METHODS);
 
     @Test
+    void testGetClassName() {
+        assertEquals(PostgreSqlDatabasePlatform.class.getName(), platform.getClassName());
+    }
+
+    @Test
     void testIsMissingCitextExtensionError_citextDirectMessage() {
         assertTrue(platform.isMissingCitextExtensionError(
                 new SqlException("ERROR: type \"citext\" does not exist")));

--- a/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/raima/RaimaDatabasePlatformTest.java
+++ b/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/raima/RaimaDatabasePlatformTest.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to JumpMind Inc under one or more contributor
+ * license agreements.  See the NOTICE file distributed
+ * with this work for additional information regarding
+ * copyright ownership.  JumpMind Inc licenses this file
+ * to you under the GNU General Public License, version 3.0 (GPLv3)
+ * (the "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3.0 (GPLv3) along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jumpmind.db.platform.raima;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+
+class RaimaDatabasePlatformTest {
+    @Test
+    void testGetClassName() {
+        RaimaDatabasePlatform platform = mock(RaimaDatabasePlatform.class, CALLS_REAL_METHODS);
+        assertEquals(RaimaDatabasePlatform.class.getName(), platform.getClassName());
+    }
+}

--- a/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/redshift/RedshiftDatabasePlatformTest.java
+++ b/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/redshift/RedshiftDatabasePlatformTest.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to JumpMind Inc under one or more contributor
+ * license agreements.  See the NOTICE file distributed
+ * with this work for additional information regarding
+ * copyright ownership.  JumpMind Inc licenses this file
+ * to you under the GNU General Public License, version 3.0 (GPLv3)
+ * (the "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3.0 (GPLv3) along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jumpmind.db.platform.redshift;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+
+class RedshiftDatabasePlatformTest {
+    @Test
+    void testGetClassName() {
+        RedshiftDatabasePlatform platform = mock(RedshiftDatabasePlatform.class, CALLS_REAL_METHODS);
+        assertEquals(RedshiftDatabasePlatform.class.getName(), platform.getClassName());
+    }
+}

--- a/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/sqlanywhere/SqlAnywhere12DatabasePlatformTest.java
+++ b/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/sqlanywhere/SqlAnywhere12DatabasePlatformTest.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to JumpMind Inc under one or more contributor
+ * license agreements.  See the NOTICE file distributed
+ * with this work for additional information regarding
+ * copyright ownership.  JumpMind Inc licenses this file
+ * to you under the GNU General Public License, version 3.0 (GPLv3)
+ * (the "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3.0 (GPLv3) along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jumpmind.db.platform.sqlanywhere;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+
+class SqlAnywhere12DatabasePlatformTest {
+    @Test
+    void testGetClassName() {
+        SqlAnywhere12DatabasePlatform platform = mock(SqlAnywhere12DatabasePlatform.class, CALLS_REAL_METHODS);
+        assertEquals(SqlAnywhere12DatabasePlatform.class.getName(), platform.getClassName());
+    }
+}

--- a/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/sqlanywhere/SqlAnywhereDatabasePlatformTest.java
+++ b/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/sqlanywhere/SqlAnywhereDatabasePlatformTest.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to JumpMind Inc under one or more contributor
+ * license agreements.  See the NOTICE file distributed
+ * with this work for additional information regarding
+ * copyright ownership.  JumpMind Inc licenses this file
+ * to you under the GNU General Public License, version 3.0 (GPLv3)
+ * (the "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3.0 (GPLv3) along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jumpmind.db.platform.sqlanywhere;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+
+class SqlAnywhereDatabasePlatformTest {
+    @Test
+    void testGetClassName() {
+        SqlAnywhereDatabasePlatform platform = mock(SqlAnywhereDatabasePlatform.class, CALLS_REAL_METHODS);
+        assertEquals(SqlAnywhereDatabasePlatform.class.getName(), platform.getClassName());
+    }
+}

--- a/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/sqlite/SqliteDatabasePlatformTest.java
+++ b/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/sqlite/SqliteDatabasePlatformTest.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to JumpMind Inc under one or more contributor
+ * license agreements.  See the NOTICE file distributed
+ * with this work for additional information regarding
+ * copyright ownership.  JumpMind Inc licenses this file
+ * to you under the GNU General Public License, version 3.0 (GPLv3)
+ * (the "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3.0 (GPLv3) along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jumpmind.db.platform.sqlite;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+
+class SqliteDatabasePlatformTest {
+    @Test
+    void testGetClassName() {
+        SqliteDatabasePlatform platform = mock(SqliteDatabasePlatform.class, CALLS_REAL_METHODS);
+        assertEquals(SqliteDatabasePlatform.class.getName(), platform.getClassName());
+    }
+}

--- a/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/voltdb/VoltDbDatabasePlatformTest.java
+++ b/symmetric-jdbc/src/test/java/org/jumpmind/db/platform/voltdb/VoltDbDatabasePlatformTest.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to JumpMind Inc under one or more contributor
+ * license agreements.  See the NOTICE file distributed
+ * with this work for additional information regarding
+ * copyright ownership.  JumpMind Inc licenses this file
+ * to you under the GNU General Public License, version 3.0 (GPLv3)
+ * (the "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3.0 (GPLv3) along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jumpmind.db.platform.voltdb;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+
+class VoltDbDatabasePlatformTest {
+    @Test
+    void testGetClassName() {
+        VoltDbDatabasePlatform platform = mock(VoltDbDatabasePlatform.class, CALLS_REAL_METHODS);
+        assertEquals(VoltDbDatabasePlatform.class.getName(), platform.getClassName());
+    }
+}


### PR DESCRIPTION
I could have avoided adding `getClassName()` to every open-source platform by having `AbstractDatabasePlatform` implement it and call `getClass().getName()`. However, I think it's better to force each concrete platform to have its own implementation of `getClassName()` so that when someone adds a new Pro platform, they don't forget to implement this method and handle obfuscation. Let me know if this needs changed.