### PR TITLE
SYM-7840: Changed variable type from 'integer' to 'numeric(18,0)' in Interbase trigger template

### DIFF
--- a/symmetric-client/src/main/java/org/jumpmind/symmetric/db/interbase/InterbaseTriggerTemplate.java
+++ b/symmetric-client/src/main/java/org/jumpmind/symmetric/db/interbase/InterbaseTriggerTemplate.java
@@ -44,7 +44,7 @@ public class InterbaseTriggerTemplate extends AbstractTriggerTemplate {
         sqlTemplates.put("insertTriggerTemplate",
                 "create trigger $(triggerName) for $(schemaName)$(tableName) after insert as                                                                                                                            "
                         +
-                        "                                declare variable name integer;                                                                                                                                           "
+                        "                                declare variable name numeric(18,0);                                                                                                                                           "
                         +
                         "                                declare variable sync_triggers_disabled varchar(30);                                                                                                                   "
                         +
@@ -99,7 +99,7 @@ public class InterbaseTriggerTemplate extends AbstractTriggerTemplate {
         sqlTemplates.put("insertReloadTriggerTemplate",
                 "create trigger $(triggerName) for $(schemaName)$(tableName) after insert as                                                                                                                            "
                         +
-                        "                                declare variable name integer;                                                                                                                                           "
+                        "                                declare variable name numeric(18,0);                                                                                                                                           "
                         +
                         "                                declare variable sync_triggers_disabled varchar(30);                                                                                                                   "
                         +
@@ -154,7 +154,7 @@ public class InterbaseTriggerTemplate extends AbstractTriggerTemplate {
         sqlTemplates.put("updateTriggerTemplate",
                 "create trigger $(triggerName) for $(schemaName)$(tableName) after update as                                                                                                                            "
                         +
-                        "                                declare variable name integer;                                                                                                                                           "
+                        "                                declare variable name numeric(18,0);                                                                                                                                           "
                         +
                         "                                declare variable sync_triggers_disabled varchar(30);                                                                                                                   "
                         +
@@ -213,7 +213,7 @@ public class InterbaseTriggerTemplate extends AbstractTriggerTemplate {
         sqlTemplates.put("updateReloadTriggerTemplate",
                 "create trigger $(triggerName) for $(schemaName)$(tableName) after update as                                                                                                                            "
                         +
-                        "                                declare variable name integer;                                                                                                                                           "
+                        "                                declare variable name numeric(18,0);                                                                                                                                           "
                         +
                         "                                declare variable sync_triggers_disabled varchar(30);                                                                                                                   "
                         +
@@ -268,7 +268,7 @@ public class InterbaseTriggerTemplate extends AbstractTriggerTemplate {
         sqlTemplates.put("deleteTriggerTemplate",
                 "create trigger  $(triggerName) for $(schemaName)$(tableName) after delete as                                                                                                                           "
                         +
-                        "                                declare variable name integer;                                                                                                                                           "
+                        "                                declare variable name numeric(18,0);                                                                                                                                           "
                         +
                         "                                declare variable sync_triggers_disabled varchar(30);                                                                                                                   "
                         +


### PR DESCRIPTION
Changed variable type from 'integer' to 'numeric(18,0)' in InterbaseTriggerTemplate.java to support larger generator values and prevent arithmetic overflow exceptions during trigger execution.