### PR TITLE
SYM-7842: Change Jaybird test implementation driver version for Firebird integration tests

### DIFF
--- a/symmetric-jdbc/build.gradle
+++ b/symmetric-jdbc/build.gradle
@@ -27,7 +27,7 @@ apply from: symAssembleDir + '/common.gradle'
         testImplementation "org.jumpmind.symmetric.module:db2jcc:9.7"
         // Pinned to Jaybird 5.0.4 - v6 deadlocks the Firebird integration tests (background
 		// cleanup helper holds the connection lock, hanging the connection health check).
-        testImplementation "org.firebirdsql.jdbc:jaybird:5.0.4.java11"
+        testImplementation "org.firebirdsql.jdbc:jaybird:5.0.12.java11"
         testImplementation "jakarta.resource:jakarta.resource-api:2.1.0"
         testImplementation "org.jumpmind.symmetric.module:ifxjdbc:1.0"
         testImplementation "org.jumpmind.symmetric.module:ifxlang:1.0"

--- a/symmetric-jdbc/build.gradle
+++ b/symmetric-jdbc/build.gradle
@@ -25,7 +25,7 @@ apply from: symAssembleDir + '/common.gradle'
         testImplementation "org.hsqldb:hsqldb:$hsqldbVersion"
         testImplementation "org.xerial:sqlite-jdbc:$sqliteVersion"
         testImplementation "org.jumpmind.symmetric.module:db2jcc:9.7"
-        // Pinned to Jaybird 5.0.4 - v6 deadlocks the Firebird integration tests (background
+        // Pinned to Jaybird 5.0.12 - v6 deadlocks the Firebird integration tests (background
 		// cleanup helper holds the connection lock, hanging the connection health check).
         testImplementation "org.firebirdsql.jdbc:jaybird:5.0.12.java11"
         testImplementation "jakarta.resource:jakarta.resource-api:2.1.0"

--- a/symmetric-jdbc/build.gradle
+++ b/symmetric-jdbc/build.gradle
@@ -25,7 +25,9 @@ apply from: symAssembleDir + '/common.gradle'
         testImplementation "org.hsqldb:hsqldb:$hsqldbVersion"
         testImplementation "org.xerial:sqlite-jdbc:$sqliteVersion"
         testImplementation "org.jumpmind.symmetric.module:db2jcc:9.7"
-        testImplementation "org.firebirdsql.jdbc:jaybird:6.0.1"
+        // Pinned to Jaybird 5.0.4 - v6 deadlocks the Firebird integration tests (background
+		// cleanup helper holds the connection lock, hanging the connection health check).
+        testImplementation "org.firebirdsql.jdbc:jaybird:5.0.4.java11"
         testImplementation "jakarta.resource:jakarta.resource-api:2.1.0"
         testImplementation "org.jumpmind.symmetric.module:ifxjdbc:1.0"
         testImplementation "org.jumpmind.symmetric.module:ifxlang:1.0"


### PR DESCRIPTION
Firebird integration tests hang indefinitely or fail inconsistently due to a deadlock in the Jaybird 6.0.1 JDBC driver. This blocks adding Firebird to the GitHub integration test matrix because of inconsistent behavior.

Cause:
Jaybird 6 runs statement cleanup on a background thread. That thread acquires the connection lock and then makes a blocking network call that never returns. The connection pool does a health check on every connection borrow, and that check needs the same lock which causes the pool blocks forever, and every test behind it blocks too.
It only triggers when garbage collection runs at the wrong moment, which is why failures appeared random and moved between tests.

Fix:
Change the testImplementation driver for Jaybird to the last committed version, 5.0.4.
Jaybird 5 does not use that background cleanup mechanism, so the deadlock cannot occur. 5.0.4 also happens to be the version listed in symmetric-modules.properties, so this brings tests in line with what is actually run for customers using Firebird in symmetricDS.